### PR TITLE
ci: publish phenosage check to Vercel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,17 @@ jobs:
             echo "One or more upstream jobs failed"
             exit 1
           fi
+
+  notify-vercel:
+    name: phenosage
+    runs-on: ubuntu-latest
+    needs: [validate, test-web, test-shared, test-analysis]
+    if: always()
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - name: notify vercel
+        uses: vercel/repository-dispatch/actions/status@v1
+        with:
+          name: "Vercel - pheno-sage-web: phenosage"


### PR DESCRIPTION
Replaces #31 (had merge conflicts after main moved on). Adds notify-vercel job that posts a commit status named 'phenosage' so Vercel's GitHub Actions gate can promote production deploys.