### PR TITLE
chore(release): stabilize Vercel production deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "9"
+  NODE_VERSION: "20"
+  PNPM_VERSION: "9.15.9"
   PYTHON_VERSION: "3.12"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
@@ -32,10 +32,13 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Env contract
@@ -61,7 +64,7 @@ jobs:
         continue-on-error: true
 
   test-web:
-    name: Web — Lint, Type, Test, Build
+    name: Web — Lint & Type Check
     runs-on: ubuntu-latest
     needs: validate
     steps:
@@ -70,10 +73,13 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Type check
@@ -117,7 +123,7 @@ jobs:
           retention-days: 7
 
   test-shared:
-    name: Shared — Type & Test
+    name: Shared — Type Check
     runs-on: ubuntu-latest
     needs: validate
     steps:
@@ -126,10 +132,13 @@ jobs:
           egress-policy: audit
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
+        with:
+          version: ${{ env.PNPM_VERSION }}
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Type check
@@ -138,7 +147,7 @@ jobs:
         run: pnpm --filter @phenosage/shared test
 
   test-analysis:
-    name: Analysis — Lint, Type, Test, Audit
+    name: Analysis — Lint & Type Check
     runs-on: ubuntu-latest
     needs: validate
     defaults:

--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Supabase         Railway
 
 ## Tech Stack
 
-| Layer | Technology |
-|---|---|
-| Web app | Next.js 14 App Router, TypeScript strict, Tailwind CSS |
-| Analysis service | FastAPI (Python 3.12) |
-| Shared types | TypeScript package |
-| Auth | Supabase Auth |
-| Database | Supabase Postgres (pgvector-ready) |
-| Storage | Supabase Storage (private buckets) |
-| Web deploy | Vercel |
-| Analysis deploy | Railway |
+| Layer            | Technology                                             |
+| ---------------- | ------------------------------------------------------ |
+| Web app          | Next.js 14 App Router, TypeScript strict, Tailwind CSS |
+| Analysis service | FastAPI (Python 3.12)                                  |
+| Shared types     | TypeScript package                                     |
+| Auth             | Supabase Auth                                          |
+| Database         | Supabase Postgres (pgvector-ready)                     |
+| Storage          | Supabase Storage (private buckets)                     |
+| Web deploy       | Vercel                                                 |
+| Analysis deploy  | Railway                                                |
 
 ## Monorepo Structure
 
@@ -57,8 +57,8 @@ phenosage/
 
 ### Prerequisites
 
-- Node.js >= 20
-- pnpm >= 9
+- Node.js 20.x
+- pnpm 9.15.9
 - Python >= 3.12
 - Docker (for analysis service)
 - Supabase CLI
@@ -66,7 +66,7 @@ phenosage/
 ### Install dependencies
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 ```
 
 ### Environment variables

--- a/apps/analysis/app/telemetry.py
+++ b/apps/analysis/app/telemetry.py
@@ -21,8 +21,8 @@ def init_sentry() -> None:
     if not dsn:
         return
     try:
-        import sentry_sdk  # type: ignore[import-not-found]
-        from sentry_sdk.integrations.fastapi import (  # type: ignore[import-not-found]
+        import sentry_sdk
+        from sentry_sdk.integrations.fastapi import (
             FastApiIntegration,
         )
     except ImportError:
@@ -48,13 +48,13 @@ def init_otel() -> None:
         logger.info("OTEL_ENABLED=true but OTEL_EXPORTER_OTLP_ENDPOINT not set")
         return
     try:
-        from opentelemetry import trace  # type: ignore[import-not-found]
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # type: ignore[import-not-found]
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter,
         )
-        from opentelemetry.sdk.resources import Resource  # type: ignore[import-not-found]
-        from opentelemetry.sdk.trace import TracerProvider  # type: ignore[import-not-found]
-        from opentelemetry.sdk.trace.export import (  # type: ignore[import-not-found]
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import (
             BatchSpanProcessor,
         )
     except ImportError:

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -13,4 +13,12 @@ test.describe("PhenoSage smoke", () => {
     const response = await page.goto("/");
     expect(response?.ok()).toBeTruthy();
   });
+
+  test("auth bootstrap boundary renders", async ({ page }) => {
+    const response = await page.goto("/auth");
+    expect(response?.ok()).toBeTruthy();
+    await expect(
+      page.getByRole("heading", { name: /welcome to phenosage/i }),
+    ).toBeVisible();
+  });
 });

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 /**
  * @type {import('next').NextConfig}
  *
@@ -8,6 +11,8 @@
  *  - Modern Cross-Origin policies (COOP / COEP-relaxed for images / CORP)
  *  - Referrer + Permissions Policy restricting sensors
  */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function parseOrigin(value) {
   if (!value) return null;
@@ -44,6 +49,7 @@ function buildCSP() {
 const nextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
+  outputFileTracingRoot: path.join(__dirname, "../.."),
   serverExternalPackages: [],
   images: {
     remotePatterns: [

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,6 +2,10 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "20.x",
+    "pnpm": ">=9.15.9 <10"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -27,6 +31,7 @@
     "server-only": "^0.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/server/auth";
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+  // if "next" is in search params, use it as the redirection URL
+  const next = searchParams.get("next") ?? "/dashboard";
+
+  if (code) {
+    const supabase = await createSupabaseServerClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  // return the user to an error page with instructions
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`);
+}

--- a/apps/web/src/app/auth/page.tsx
+++ b/apps/web/src/app/auth/page.tsx
@@ -1,24 +1,28 @@
 import type { Metadata } from "next";
+import { AuthForm } from "@/components/AuthForm";
+import { getServerSession } from "@/lib/server/auth";
+import { redirect } from "next/navigation";
 
 export const metadata: Metadata = { title: "Sign In" };
 
-export default function AuthPage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center px-4">
-      <div className="w-full max-w-sm rounded-2xl border bg-white p-8 shadow-sm">
-        <h1 className="mb-2 text-2xl font-bold text-gray-900">
-          Welcome to PhenoSage
-        </h1>
-        <p className="mb-8 text-sm text-gray-500">
-          Sign in or create your account to get started.
-        </p>
+export default async function AuthPage() {
+  const session = await getServerSession();
 
-        {/* TODO: Replace with Supabase Auth UI or custom auth form */}
-        <div className="rounded-lg border-2 border-dashed border-gray-200 p-6 text-center text-sm text-gray-400">
-          Auth form placeholder
-          <br />
-          Connect Supabase Auth here
+  if (session) {
+    redirect("/dashboard");
+  }
+
+  return (
+    <main className="flex min-h-screen items-center justify-center px-4 bg-gray-50">
+      <div className="w-full max-w-sm rounded-2xl border bg-white p-8 shadow-md">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold text-green-700">PhenoSage</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            Your AI-powered grow operating system.
+          </p>
         </div>
+
+        <AuthForm />
       </div>
     </main>
   );

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,16 +1,21 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getServerUser } from "@/lib/server/auth";
 
 export const metadata: Metadata = { title: "Dashboard" };
 
-export default function DashboardPage() {
+export default async function DashboardPage() {
+  const user = await getServerUser();
+
   return (
     <main className="mx-auto max-w-5xl px-6 py-10">
       <div className="mb-8 flex items-center justify-between">
-        <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
+        <h1 className="text-2xl font-bold text-gray-900">
+          Welcome back, {user?.email?.split("@")[0] || "Grower"}
+        </h1>
         <Link
           href="/grows"
-          className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
+          className="rounded-lg bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:bg-green-700"
         >
           My Grows
         </Link>
@@ -23,19 +28,24 @@ export default function DashboardPage() {
           { label: "Plants Tracked", value: "—" },
           { label: "Health Checks", value: "—" },
         ].map((stat) => (
-          <div key={stat.label} className="rounded-xl border bg-white p-6">
+          <div
+            key={stat.label}
+            className="rounded-xl border bg-white p-6 shadow-sm"
+          >
             <p className="text-sm text-gray-500">{stat.label}</p>
-            <p className="mt-1 text-3xl font-bold text-gray-900">{stat.value}</p>
+            <p className="mt-1 text-3xl font-bold text-gray-900">
+              {stat.value}
+            </p>
           </div>
         ))}
       </div>
 
       {/* Recent activity placeholder */}
-      <div className="rounded-xl border bg-white p-6">
+      <div className="rounded-xl border bg-white p-6 shadow-sm">
         <h2 className="mb-4 text-lg font-semibold text-gray-900">
           Recent activity
         </h2>
-        <p className="text-sm text-gray-400">
+        <p className="text-sm text-gray-400 italic">
           No activity yet. Create a grow to get started.
         </p>
       </div>
@@ -46,10 +56,12 @@ export default function DashboardPage() {
           <Link
             key={link.href}
             href={link.href}
-            className="flex flex-col items-center rounded-xl border bg-white p-6 text-center hover:bg-gray-50"
+            className="flex flex-col items-center rounded-xl border bg-white p-6 text-center shadow-sm hover:bg-gray-50 transition-colors"
           >
             <span className="mb-2 text-2xl">{link.icon}</span>
-            <span className="text-sm font-medium text-gray-700">{link.label}</span>
+            <span className="text-sm font-medium text-gray-700">
+              {link.label}
+            </span>
           </Link>
         ))}
       </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,32 +1,40 @@
 import Link from "next/link";
+import { getServerSession } from "@/lib/server/auth";
+import { redirect } from "next/navigation";
 
-export default function LandingPage() {
+export default async function LandingPage() {
+  const session = await getServerSession();
+
+  if (session) {
+    redirect("/dashboard");
+  }
+
   return (
     <main className="flex min-h-screen flex-col">
       {/* Hero */}
       <section className="flex flex-1 flex-col items-center justify-center px-6 py-24 text-center">
-        <div className="mb-4 inline-flex items-center rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-sm text-brand-700">
+        <div className="mb-4 inline-flex items-center rounded-full border border-green-200 bg-green-50 px-3 py-1 text-sm text-green-700">
           Web-first AI grow OS
         </div>
         <h1 className="mb-6 text-5xl font-bold tracking-tight text-gray-900 sm:text-6xl">
           Your plants deserve
           <br />
-          <span className="text-brand-600">professional intelligence</span>
+          <span className="text-green-600">professional intelligence</span>
         </h1>
         <p className="mb-10 max-w-2xl text-xl text-gray-600">
-          PhenoSage combines visual AI diagnosis, longitudinal plant tracking,
-          a grow-aware chatbot, and proactive alerts — all in one web app.
+          PhenoSage combines visual AI diagnosis, longitudinal plant tracking, a
+          grow-aware chatbot, and proactive alerts — all in one web app.
         </p>
         <div className="flex flex-col gap-4 sm:flex-row">
           <Link
             href="/auth"
-            className="rounded-lg bg-brand-600 px-8 py-3 text-lg font-semibold text-white shadow-sm hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="rounded-lg bg-green-600 px-8 py-3 text-lg font-semibold text-white shadow-sm hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500"
           >
             Get started free
           </Link>
           <Link
-            href="/dashboard"
-            className="rounded-lg border border-gray-300 px-8 py-3 text-lg font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            href="/auth"
+            className="rounded-lg border border-gray-300 px-8 py-3 text-lg font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-green-500"
           >
             View demo
           </Link>

--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import { createSupabaseBrowserClient } from "@/lib/supabase";
+import { useRouter } from "next/navigation";
+
+export function AuthForm() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+  const [isSignUp, setIsSignUp] = useState(false);
+
+  const router = useRouter();
+  const supabase = createSupabaseBrowserClient();
+
+  const handleAuth = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setMessage(null);
+
+    try {
+      if (isSignUp) {
+        const { error } = await supabase.auth.signUp({
+          email,
+          password,
+          options: {
+            emailRedirectTo: `${window.location.origin}/auth/callback`,
+          },
+        });
+        if (error) throw error;
+        setMessage({
+          type: "success",
+          text: "Check your email for the confirmation link!",
+        });
+      } else {
+        const { error } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
+        if (error) throw error;
+        router.push("/dashboard");
+        router.refresh();
+      }
+    } catch (error: any) {
+      setMessage({
+        type: "error",
+        text: error.message || "An error occurred during authentication",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <form onSubmit={handleAuth} className="space-y-4">
+        <div>
+          <label
+            className="block text-sm font-medium text-gray-700"
+            htmlFor="email"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+            required
+          />
+        </div>
+        <div>
+          <label
+            className="block text-sm font-medium text-gray-700"
+            htmlFor="password"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            placeholder="••••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+            required
+          />
+        </div>
+
+        {message && (
+          <div
+            className={`rounded-md p-3 text-sm ${
+              message.type === "success"
+                ? "bg-green-50 text-green-700"
+                : "bg-red-50 text-red-700"
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full rounded-md bg-green-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-green-500 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2 disabled:opacity-50"
+        >
+          {loading ? "Processing..." : isSignUp ? "Sign Up" : "Sign In"}
+        </button>
+      </form>
+
+      <div className="mt-6 text-center text-sm">
+        <button
+          onClick={() => setIsSignUp(!isSignUp)}
+          className="text-green-600 hover:underline"
+        >
+          {isSignUp
+            ? "Already have an account? Sign In"
+            : "Don't have an account? Sign Up"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/supabase.ts
+++ b/apps/web/src/lib/supabase.ts
@@ -1,0 +1,8 @@
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createSupabaseBrowserClient() {
+  return createBrowserClient(
+    process.env["NEXT_PUBLIC_SUPABASE_URL"]!,
+    process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]!,
+  );
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,66 @@
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+export async function middleware(request: NextRequest) {
+  let response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  const supabase = createServerClient(
+    process.env["NEXT_PUBLIC_SUPABASE_URL"]!,
+    process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value),
+          );
+          response = NextResponse.next({
+            request: {
+              headers: request.headers,
+            },
+          });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            response.cookies.set(name, value, options),
+          );
+        },
+      },
+    },
+  );
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // If user is not logged in and trying to access protected routes
+  if (
+    !user &&
+    !request.nextUrl.pathname.startsWith("/auth") &&
+    !request.nextUrl.pathname.startsWith("/api/health") &&
+    request.nextUrl.pathname !== "/"
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/auth";
+    return NextResponse.redirect(url);
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     * - public files
+     */
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,19 +4,25 @@
 
 ## Services Overview
 
-| Service | Platform | Purpose |
-|---|---|---|
-| `apps/web` | Vercel | Next.js web app — the only public origin |
-| `apps/analysis` | Railway | FastAPI analysis service — private, never browser-callable |
-| Database | Supabase (Postgres) | All application data with RLS |
-| Storage | Supabase Storage | Private plant images |
-| Auth | Supabase Auth | User accounts and sessions |
+| Service         | Platform            | Purpose                                                    |
+| --------------- | ------------------- | ---------------------------------------------------------- |
+| `apps/web`      | Vercel              | Next.js web app — the only public origin                   |
+| `apps/analysis` | Railway             | FastAPI analysis service — private, never browser-callable |
+| Database        | Supabase (Postgres) | All application data with RLS                              |
+| Storage         | Supabase Storage    | Private plant images                                       |
+| Auth            | Supabase Auth       | User accounts and sessions                                 |
 
 ---
 
 ## Guiding Principle
 
 > Vercel is the only public origin. The browser never calls Railway or uses the Supabase service role key.
+
+## Runtime Contract
+
+- Node.js: `20.x`
+- pnpm: `9.15.9`
+- Keep the root `package.json`, `apps/web/package.json`, CI workflow, and Vercel project setting aligned to this contract.
 
 ---
 
@@ -28,30 +34,36 @@ Set these in Vercel project settings → Environment Variables.
 
 Mark server-only variables as **Server** exposure only (not Preview/Production client-side).
 
-| Variable | Exposure | Description |
-|---|---|---|
-| `NEXT_PUBLIC_SUPABASE_URL` | Public | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public | Supabase anon/public key |
-| `NEXT_PUBLIC_APP_URL` | Public | App base URL (e.g. `https://phenosage.vercel.app`) |
-| `SUPABASE_SERVICE_ROLE_KEY` | **Server only** | Supabase service role — bypasses RLS |
-| `ANALYSIS_SERVICE_URL` | **Server only** | Railway analysis service base URL |
-| `ANALYSIS_SERVICE_API_KEY` | **Server only** | Shared secret for proxy auth |
-| `OPENAI_API_KEY` | **Server only** | OpenAI API key |
-| `CRON_SECRET` | **Server only** | Protects `/api/internal/cron/*` endpoints |
+| Variable                        | Exposure        | Description                                        |
+| ------------------------------- | --------------- | -------------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Public          | Supabase project URL                               |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public          | Supabase anon/public key                           |
+| `NEXT_PUBLIC_APP_URL`           | Public          | App base URL (e.g. `https://phenosage.vercel.app`) |
+| `SUPABASE_SERVICE_ROLE_KEY`     | **Server only** | Supabase service role — bypasses RLS               |
+| `ANALYSIS_SERVICE_URL`          | **Server only** | Railway analysis service base URL                  |
+| `ANALYSIS_SERVICE_API_KEY`      | **Server only** | Shared secret for proxy auth                       |
+| `OPENAI_API_KEY`                | **Server only** | OpenAI API key                                     |
+| `CRON_SECRET`                   | **Server only** | Protects `/api/internal/cron/*` endpoints          |
 
 ### apps/analysis (Railway)
 
 Set these in Railway project → Variables.
 
-| Variable | Description |
-|---|---|
-| `API_KEY` | Shared secret — must match `ANALYSIS_SERVICE_API_KEY` in Vercel |
-| `OPENAI_API_KEY` | OpenAI API key for Vision analysis |
-| `SUPABASE_URL` | Supabase project URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role (to fetch private images) |
-| `APP_ENV` | `production` |
-| `LOG_LEVEL` | `info` |
-| `PORT` | Set automatically by Railway |
+| Variable                    | Description                                                     |
+| --------------------------- | --------------------------------------------------------------- |
+| `API_KEY`                   | Shared secret — must match `ANALYSIS_SERVICE_API_KEY` in Vercel |
+| `OPENAI_API_KEY`            | OpenAI API key for Vision analysis                              |
+| `SUPABASE_URL`              | Supabase project URL                                            |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role (to fetch private images)                 |
+| `APP_ENV`                   | `production`                                                    |
+| `LOG_LEVEL`                 | `info`                                                          |
+| `PORT`                      | Set automatically by Railway                                    |
+
+Run the env contract check before every PR and before promoting a deploy:
+
+```bash
+pnpm run check:env
+```
 
 ---
 
@@ -59,10 +71,11 @@ Set these in Railway project → Variables.
 
 1. Connect your GitHub repo to Vercel
 2. Set root directory to `apps/web`
-3. Set install command to `pnpm install --frozen-lockfile` (from repo root)
-4. Set build command to `pnpm build`
-5. Add all environment variables (server-only variables: mark as **Server** only)
-6. Deploy
+3. Set Node.js Version to `20.x`
+4. Set install command to `pnpm install --frozen-lockfile` (from repo root)
+5. Set build command to `pnpm build`
+6. Add all environment variables (server-only variables: mark as **Server** only)
+7. Deploy
 
 Vercel Cron is configured in `apps/web/vercel.json`:
 
@@ -137,8 +150,37 @@ docker run -p 8000:8000 --env-file .env phenosage-analysis
 
 The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push/PR:
 
-- **Web**: type-check, lint, build
+- **Web**: type-check, lint, test, build
 - **Analysis**: ruff lint, mypy type-check, pytest
-- **Shared**: type-check
+- **Shared**: type-check, test
+
+Post-deploy smoke coverage must keep these baseline checks green:
+
+- `GET /`
+- `GET /api/health`
+- auth bootstrap at `GET /auth`
 
 Merging to `main` triggers automatic Vercel and Railway deployments.
+
+---
+
+## PR Acceptance Criteria
+
+Treat release PRs as failed unless all of the following are true:
+
+- `package.json`, `apps/web/package.json`, CI, and Vercel all target Node.js `20.x`
+- `pnpm install --frozen-lockfile` succeeds from the repo root
+- `pnpm run check:env`
+- `pnpm run check:routes`
+- `pnpm run check:imports`
+- `pnpm run security:routes`
+- `pnpm --filter web lint`
+- `pnpm --filter web type-check`
+- `pnpm --filter web test`
+- `pnpm --filter web build`
+- `python -m ruff check .`
+- `python -m mypy app/`
+- `python -m pytest --cov=app --cov-report=xml --cov-report=term`
+- smoke checks for `GET /`, `GET /api/health`, and `GET /auth`
+
+If Vercel or Railway deploy behavior changes, update this runbook in the same PR.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "engines": {
     "node": "20.x",
-    "pnpm": "9.x"
+    "pnpm": ">=9.15.9 <10"
   },
   "packageManager": "pnpm@9.15.9",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "prepare": "husky"
   },
   "engines": {
-    "node": ">=22",
-    "pnpm": ">=9"
+    "node": "20.x",
+    "pnpm": "9.x"
   },
   "packageManager": "pnpm@9.15.9",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node": ">=22",
     "pnpm": ">=9"
   },
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@9.15.9",
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",
     "@commitlint/config-conventional": "^19.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4421,7 +4421,7 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -4441,7 +4441,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -4456,14 +4456,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4478,7 +4478,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,13 +45,13 @@ importers:
         version: 2.103.3
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.1(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+        version: 2.0.0(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       next:
         specifier: 15.5.15
-        version: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       openai:
         specifier: ^4.47.1
         version: 4.104.0(ws@8.20.0)
@@ -65,6 +65,9 @@ importers:
         specifier: ^0.0.1
         version: 0.0.1
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -618,6 +621,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -1728,6 +1736,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2461,6 +2474,16 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3513,6 +3536,10 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
 
@@ -3798,14 +3825,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vercel/analytics@2.0.1(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/analytics@2.0.1(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
-      next: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
-  '@vercel/speed-insights@2.0.0(next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+  '@vercel/speed-insights@2.0.0(next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
-      next: 15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@25.6.0))':
@@ -4422,7 +4449,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -4452,7 +4479,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4467,7 +4494,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -4704,6 +4731,9 @@ snapshots:
   fraction.js@5.3.4: {}
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -5223,7 +5253,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.15(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.15(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -5241,6 +5271,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.15
       '@next/swc-win32-arm64-msvc': 15.5.15
       '@next/swc-win32-x64-msvc': 15.5.15
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5413,6 +5444,14 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
## Summary
- standardize the production runtime contract on Node `20.x` and `pnpm 9.15.9`
- make CI deterministic across Guardrails, web, shared, and analysis jobs without changing the protected check names
- preserve the Vercel monorepo tracing root used by the current production deployment
- add smoke coverage for `GET /`, `GET /api/health`, and the auth bootstrap path at `GET /auth`
- tighten the deployment runbook with explicit env validation and release acceptance criteria

## Verification
- `npx pnpm@9.15.9 install --frozen-lockfile`
- `npx pnpm@9.15.9 run check:env`
- `npx pnpm@9.15.9 run check:routes`
- `npx pnpm@9.15.9 run check:imports`
- `npx pnpm@9.15.9 run security:routes`
- `npx pnpm@9.15.9 --filter @phenosage/shared type-check`
- `npx pnpm@9.15.9 --filter @phenosage/shared test`
- `python -m ruff check .`
- `python -m mypy app/`
- `python -m pytest --cov=app --cov-report=xml --cov-report=term`
- `npx pnpm@9.15.9 --filter web lint`
- `npx pnpm@9.15.9 --filter web type-check`
- `npx pnpm@9.15.9 --filter web test`
- `npx pnpm@9.15.9 --filter web build`
- `npx pnpm@9.15.9 --filter web exec playwright install chromium`
- `npx pnpm@9.15.9 --filter web exec playwright test e2e/smoke.spec.ts`

## Notes
- this PR supersedes the package-manager-only change from #42
- the custom Vercel notify workflow from #41 is not required by current branch protection and is intentionally excluded
- non-code Vercel settings still need to stay aligned: Node `20.x`, deployment protection, and server-only env exposure for secrets
