### PR TITLE
feat: end-to-end chat, image upload, and analysis pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ Supabase         Railway
 
 ## Tech Stack
 
-| Layer | Technology |
-|---|---|
-| Web app | Next.js 14 App Router, TypeScript strict, Tailwind CSS |
-| Analysis service | FastAPI (Python 3.12) |
-| Shared types | TypeScript package |
-| Auth | Supabase Auth |
-| Database | Supabase Postgres (pgvector-ready) |
-| Storage | Supabase Storage (private buckets) |
-| Web deploy | Vercel |
-| Analysis deploy | Railway |
+| Layer            | Technology                                             |
+| ---------------- | ------------------------------------------------------ |
+| Web app          | Next.js 15 App Router, TypeScript strict, Tailwind CSS |
+| Analysis service | FastAPI (Python 3.12)                                  |
+| Shared types     | TypeScript package                                     |
+| Auth             | Supabase Auth                                          |
+| Database         | Supabase Postgres (pgvector-ready)                     |
+| Storage          | Supabase Storage (private buckets)                     |
+| Web deploy       | Vercel                                                 |
+| Analysis deploy  | Railway                                                |
 
 ## Monorepo Structure
 
@@ -57,7 +57,7 @@ phenosage/
 
 ### Prerequisites
 
-- Node.js >= 20
+- Node.js >= 22
 - pnpm >= 9
 - Python >= 3.12
 - Docker (for analysis service)

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,6 +4,48 @@ Handoff log between sessions. Keep entries short. Newest at top.
 
 ---
 
+## 2026-04-19 — End-to-end vertical slice (Claude Opus 4.7)
+
+**Landed on `claude/complete-core-loop-6tDQM`**
+
+- `feat(upload)` — `POST /api/uploads/sign` issues Supabase signed upload URLs
+  scoped to `{growId}/{plantId}/…`, strict MIME allowlist, UUID validation.
+- `feat(images)` — `POST /api/plants/:id/images` verifies the uploaded object
+  exists in Storage before persisting the `plant_images` row.
+- `feat(analyze)` — real FastAPI proxy w/ snake_case wire contract and
+  camelCase response mapping; `POST /api/plants/:id/analyze` persists
+  `plant_analyses` + `plant_findings`; optional previous-image comparison.
+- `feat(analysis-service)` — OpenAI Vision (`gpt-4o`) with fallback on storage
+  or vision failure; blended score; structured access logging and correlation
+  ID middleware.
+- `feat(ui)` — `/plants/[id]` server page renders photo grid with signed URLs,
+  latest analysis card, findings list; client `PhotoUploader` drives the full
+  sign → upload → register → analyze flow.
+- `feat(chat)` — `POST /api/chat` loads grow + plants + recent findings via
+  service role, persists `chat_threads` + `chat_messages`, returns grounded
+  assistant reply; `/assistant` rendered as working client chat UI.
+- `feat(observability)` — `apps/web/instrumentation.ts` with optional Sentry
+  - stderr fallback; `correlationIdFromRequest` + `createLogger` threaded
+    through every mutating route; `x-request-id` round-tripped to FastAPI.
+- `feat(db)` — migration `002_plant_analyses.sql` adds analysis-history table
+  with member-read RLS and supporting indexes.
+- `test` — added vitest coverage for uploads/sign, plants/images, analyze,
+  timeline, analysis/latest, chat, analysis-proxy; new pytest coverage for
+  the vision + comparison services.
+- `docs(env)` — `apps/web/.env.example` now matches the root contract
+  (NEXT_PUBLIC_APP_ENV, CRON_SECRET, SENTRY_DSN, LOG_LEVEL).
+
+**Known-unblocked follow-ups**
+
+- Stream assistant replies — current `/api/chat` waits for the full completion
+  before responding; streaming would improve perceived latency.
+- Daily-summary cron (`/api/internal/cron/daily-summary`) is still a no-op
+  stub with auth + request-ID logging.
+- `/ready` remains env-only; a deeper probe (Supabase + analysis service
+  reachability) would catch credential drift earlier.
+
+---
+
 ## 2026-04-18 — Production-hardening sweep (Claude Opus 4.7)
 
 **Landed on `main`**

--- a/apps/analysis/app/main.py
+++ b/apps/analysis/app/main.py
@@ -1,12 +1,29 @@
+import logging
+import sys
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.middleware import CorrelationIdMiddleware
 from app.routers.analyze import router as analyze_router
 from app.routers.health import router as health_router
 from app.telemetry import init_all as init_telemetry
 
+
+def _configure_logging() -> None:
+    level_name = (settings.log_level or "info").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+
+_configure_logging()
 init_telemetry()
+
 
 app = FastAPI(
     title="PhenoSage Analysis Service",
@@ -26,8 +43,11 @@ app.add_middleware(
     allow_origins=settings.allowed_origins_list,
     allow_credentials=False,
     allow_methods=["GET", "POST"],
-    allow_headers=["Authorization", "Content-Type"],
+    allow_headers=["Authorization", "Content-Type", "x-request-id"],
+    expose_headers=["x-request-id"],
 )
+
+app.add_middleware(CorrelationIdMiddleware)
 
 app.include_router(health_router, tags=["health"])
 app.include_router(analyze_router, tags=["analysis"])

--- a/apps/analysis/app/middleware.py
+++ b/apps/analysis/app/middleware.py
@@ -1,0 +1,70 @@
+"""Request-scoped correlation IDs + structured access logging."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+logger = logging.getLogger("phenosage.access")
+REQUEST_ID_HEADER = "x-request-id"
+
+
+class CorrelationIdMiddleware(BaseHTTPMiddleware):
+    """Ensures every request has an ``x-request-id`` header on the response.
+
+    Honors an inbound ``x-request-id`` so the Next.js proxy can stitch traces
+    across service boundaries. Attaches the ID to ``request.state`` for handlers
+    that want to include it in structured logs.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        inbound = request.headers.get(REQUEST_ID_HEADER)
+        correlation_id = (
+            inbound
+            if inbound and 1 <= len(inbound) <= 128
+            else uuid.uuid4().hex
+        )
+        request.state.correlation_id = correlation_id
+
+        started = time.perf_counter()
+        try:
+            response = await call_next(request)
+        except Exception:
+            elapsed_ms = (time.perf_counter() - started) * 1000.0
+            _access_log(request, None, elapsed_ms, correlation_id, error=True)
+            raise
+
+        response.headers[REQUEST_ID_HEADER] = correlation_id
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        _access_log(request, response.status_code, elapsed_ms, correlation_id)
+        return response
+
+
+def _access_log(
+    request: Request,
+    status: int | None,
+    elapsed_ms: float,
+    correlation_id: str,
+    *,
+    error: bool = False,
+) -> None:
+    record = {
+        "level": "error" if error else "info",
+        "msg": "http_request",
+        "method": request.method,
+        "path": request.url.path,
+        "status": status,
+        "elapsed_ms": round(elapsed_ms, 2),
+        "request_id": correlation_id,
+    }
+    logger.info(json.dumps(record))

--- a/apps/analysis/app/services/image_analysis.py
+++ b/apps/analysis/app/services/image_analysis.py
@@ -1,18 +1,15 @@
-"""
-Image analysis pipeline service.
-
-TODO (Milestone 1 → 2):
-  - Fetch image bytes from Supabase Storage using the service role key
-  - Encode to base64 for OpenAI Vision API
-  - Build a structured prompt from GrowContext
-  - Parse GPT-4o response into AnalysisFinding list
-  - Return scored AnalyzeResponse
-"""
+"""Image analysis pipeline — OpenAI Vision + structured output + health scoring."""
 
 from __future__ import annotations
 
+import json
+import logging
 from datetime import UTC, datetime
+from typing import Any
 
+from openai import AsyncOpenAI
+
+from app.config import settings
 from app.models.analysis import (
     AnalysisFinding,
     AnalyzeRequest,
@@ -20,39 +17,225 @@ from app.models.analysis import (
     FindingCategory,
     FindingSeverity,
 )
+from app.services.image_comparison import compare_images
+from app.services.prompts import SYSTEM_PROMPT, build_analysis_prompt
+from app.services.scoring import compute_health_score
+from app.services.storage import (
+    StorageFetchError,
+    fetch_image_bytes,
+    guess_content_type,
+    image_to_data_url,
+)
 
-MODEL_VERSION = "gpt-4o-stub-0.1"
+logger = logging.getLogger(__name__)
+
+MODEL_NAME = "gpt-4o"
+MODEL_VERSION = "gpt-4o-2024-08-06"
+FALLBACK_MODEL_VERSION = "phenosage-fallback-0.1"
+
+
+class AnalysisError(RuntimeError):
+    """Raised when the analysis pipeline cannot produce a structured response."""
+
+
+_client: AsyncOpenAI | None = None
+
+
+def get_openai_client() -> AsyncOpenAI:
+    global _client
+    if _client is None:
+        if not settings.openai_api_key:
+            raise AnalysisError("OPENAI_API_KEY not configured")
+        _client = AsyncOpenAI(api_key=settings.openai_api_key)
+    return _client
 
 
 async def run_analysis(request: AnalyzeRequest) -> AnalyzeResponse:
-    """
-    Entry point for the image analysis pipeline.
+    """Fetch the image, call OpenAI Vision, parse and score, and return a response."""
+    try:
+        image_bytes = await fetch_image_bytes(request.storage_path)
+    except StorageFetchError as exc:
+        logger.warning("image fetch failed: %s", exc)
+        return _fallback_response(
+            request,
+            summary="Could not fetch the uploaded image for analysis.",
+            reason=str(exc),
+        )
 
-    Currently returns a stub response. Wire to OpenAI Vision in Milestone 1.
-    """
-    # TODO: Fetch image from Supabase Storage
-    # TODO: Optionally fetch previous image for comparison
-    # TODO: Build prompt with grow context
-    # TODO: Call OpenAI Vision API
-    # TODO: Parse structured findings from response
-    # TODO: Score overall health 0–100
+    content_type = guess_content_type(request.storage_path)
+    data_url = image_to_data_url(image_bytes, content_type)
 
-    stub_finding = AnalysisFinding(
-        category=FindingCategory.general,
-        severity=FindingSeverity.info,
-        title="Analysis not yet implemented",
-        description="This is a placeholder finding. Connect OpenAI Vision to enable real analysis.",
-        recommendation="Complete Milestone 1 implementation.",
-    )
+    user_prompt = build_analysis_prompt(request.grow_context)
+
+    try:
+        parsed = await _call_vision(data_url, user_prompt)
+    except AnalysisError as exc:
+        logger.warning("vision call failed: %s", exc)
+        return _fallback_response(
+            request,
+            summary="Automated analysis could not run; try again shortly.",
+            reason=str(exc),
+        )
+
+    findings = _parse_findings(parsed)
+    summary = str(parsed.get("summary", "")).strip() or "Analysis complete."
+    model_score = parsed.get("overall_health_score")
+    computed = compute_health_score(findings)
+    score = _blend_scores(model_score, computed)
+
+    comparison_summary: str | None = None
+    if request.previous_image_id and request.previous_storage_path:
+        try:
+            text = await compare_images(
+                request.image_id,
+                request.storage_path,
+                request.previous_image_id,
+                request.previous_storage_path,
+            )
+            comparison_summary = text or None
+        except Exception as exc:  # noqa: BLE001 - comparison is best-effort
+            logger.info("image comparison skipped: %s", exc)
+            comparison_summary = None
 
     return AnalyzeResponse(
         plant_id=request.plant_id,
         image_id=request.image_id,
-        overall_health_score=0.0,
-        summary="Stub analysis — not yet implemented.",
-        findings=[stub_finding],
+        overall_health_score=score,
+        summary=summary,
+        findings=findings,
+        compared_to_image_id=request.previous_image_id,
+        comparison_summary=comparison_summary,
+        analyzed_at=datetime.now(tz=UTC),
+        model_version=MODEL_VERSION,
+    )
+
+
+async def _call_vision(data_url: str, user_prompt: str) -> dict[str, Any]:
+    client = get_openai_client()
+    try:
+        response = await client.chat.completions.create(
+            model=MODEL_NAME,
+            response_format={"type": "json_object"},
+            temperature=0.2,
+            max_tokens=1200,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": user_prompt},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": data_url, "detail": "high"},
+                        },
+                    ],
+                },
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001 - translate to a domain error
+        raise AnalysisError(f"OpenAI request failed: {exc}") from exc
+
+    choice = response.choices[0] if response.choices else None
+    content = choice.message.content if choice and choice.message else None
+    if not content:
+        raise AnalysisError("OpenAI returned an empty response")
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise AnalysisError(f"OpenAI response was not valid JSON: {exc}") from exc
+
+    if not isinstance(parsed, dict):
+        raise AnalysisError("OpenAI response was not a JSON object")
+    return parsed
+
+
+def _parse_findings(parsed: dict[str, Any]) -> list[AnalysisFinding]:
+    raw_findings = parsed.get("findings")
+    if not isinstance(raw_findings, list):
+        return [_fallback_finding()]
+    findings: list[AnalysisFinding] = []
+    for item in raw_findings:
+        if not isinstance(item, dict):
+            continue
+        category = _coerce_category(item.get("category"))
+        severity = _coerce_severity(item.get("severity"))
+        title = _safe_str(item.get("title"), max_len=120) or "Unlabeled finding"
+        description = _safe_str(item.get("description"), max_len=2000)
+        if not description:
+            continue
+        recommendation = _safe_str(item.get("recommendation"), max_len=2000)
+        findings.append(
+            AnalysisFinding(
+                category=category,
+                severity=severity,
+                title=title,
+                description=description,
+                recommendation=recommendation or None,
+            )
+        )
+    return findings or [_fallback_finding()]
+
+
+def _coerce_category(value: Any) -> FindingCategory:
+    if isinstance(value, str):
+        try:
+            return FindingCategory(value)
+        except ValueError:
+            pass
+    return FindingCategory.general
+
+
+def _coerce_severity(value: Any) -> FindingSeverity:
+    if isinstance(value, str):
+        try:
+            return FindingSeverity(value)
+        except ValueError:
+            pass
+    return FindingSeverity.info
+
+
+def _safe_str(value: Any, max_len: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip()[:max_len]
+
+
+def _blend_scores(model_score: Any, computed: float) -> float:
+    """Prefer the model's self-reported score if it's a number in range, else use
+    the penalty-derived score."""
+    if isinstance(model_score, int | float) and 0 <= float(model_score) <= 100:
+        return round((float(model_score) + computed) / 2.0, 1)
+    return computed
+
+
+def _fallback_finding() -> AnalysisFinding:
+    return AnalysisFinding(
+        category=FindingCategory.general,
+        severity=FindingSeverity.info,
+        title="Inconclusive analysis",
+        description=(
+            "The analyzer could not produce a confident reading on this image. "
+            "Try a well-lit photo of the whole plant with fan leaves visible."
+        ),
+        recommendation=(
+            "Retake the photo in natural light with the plant centered in frame."
+        ),
+    )
+
+
+def _fallback_response(
+    request: AnalyzeRequest, *, summary: str, reason: str
+) -> AnalyzeResponse:
+    findings = [_fallback_finding()]
+    return AnalyzeResponse(
+        plant_id=request.plant_id,
+        image_id=request.image_id,
+        overall_health_score=compute_health_score(findings),
+        summary=summary,
+        findings=findings,
         compared_to_image_id=request.previous_image_id,
         comparison_summary=None,
         analyzed_at=datetime.now(tz=UTC),
-        model_version=MODEL_VERSION,
+        model_version=FALLBACK_MODEL_VERSION,
     )

--- a/apps/analysis/app/services/image_comparison.py
+++ b/apps/analysis/app/services/image_comparison.py
@@ -1,14 +1,24 @@
-"""
-Image comparison service.
-
-TODO (Milestone 2):
-  - Accept two images and their analysis results
-  - Use GPT-4o Vision to describe visible changes between images
-  - Return a structured comparison summary
-  - Identify improvement/regression trends
-"""
+"""Image comparison service — brief natural-language diff between two images."""
 
 from __future__ import annotations
+
+import logging
+
+from app.services.storage import (
+    StorageFetchError,
+    fetch_image_bytes,
+    guess_content_type,
+    image_to_data_url,
+)
+
+logger = logging.getLogger(__name__)
+
+COMPARE_SYSTEM = (
+    "You are comparing two successive photos of the same cannabis plant. "
+    "Describe, in 2-3 sentences, the visible changes between the earlier image "
+    "and the latest image: growth, color shifts, stress signs, training, or "
+    "deficiencies. Do not invent numeric measurements. Return plain text only."
+)
 
 
 async def compare_images(
@@ -17,13 +27,55 @@ async def compare_images(
     image_id_b: str,
     storage_path_b: str,
 ) -> str:
-    """
-    Compare two plant images and return a descriptive summary of changes.
-    """
-    # TODO: Fetch both images from Supabase Storage
-    # TODO: Build comparison prompt
-    # TODO: Call OpenAI Vision API
-    # TODO: Return structured comparison text
+    """Return a short comparison summary between two plant images.
 
-    _ = (image_id_a, storage_path_a, image_id_b, storage_path_b)
-    return "Image comparison not yet implemented."
+    ``image_id_a`` is the *current* image, ``image_id_b`` is the *previous* image.
+    Falls back to a neutral message if either image cannot be fetched or the
+    Vision call fails.
+    """
+    # Import lazily so the main analysis path isn't held up if this module is
+    # only used occasionally; also avoids a circular import with image_analysis.
+    from app.services.image_analysis import AnalysisError, get_openai_client
+
+    try:
+        current = await fetch_image_bytes(storage_path_a)
+        previous = await fetch_image_bytes(storage_path_b)
+    except StorageFetchError as exc:
+        logger.info("comparison skipped, storage fetch failed: %s", exc)
+        return ""
+
+    current_url = image_to_data_url(current, guess_content_type(storage_path_a))
+    previous_url = image_to_data_url(previous, guess_content_type(storage_path_b))
+
+    try:
+        client = get_openai_client()
+    except AnalysisError:
+        return ""
+
+    try:
+        response = await client.chat.completions.create(
+            model="gpt-4o",
+            temperature=0.2,
+            max_tokens=300,
+            messages=[
+                {"role": "system", "content": COMPARE_SYSTEM},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Previous image:"},
+                        {"type": "image_url", "image_url": {"url": previous_url}},
+                        {"type": "text", "text": "Current image:"},
+                        {"type": "image_url", "image_url": {"url": current_url}},
+                        {"type": "text", "text": "Summarize visible changes."},
+                    ],
+                },
+            ],
+        )
+    except Exception as exc:  # noqa: BLE001 - comparison is best-effort
+        logger.info("comparison vision call failed: %s", exc)
+        return ""
+
+    choice = response.choices[0] if response.choices else None
+    content = choice.message.content if choice and choice.message else None
+    _ = image_id_a, image_id_b
+    return (content or "").strip()

--- a/apps/analysis/app/services/storage.py
+++ b/apps/analysis/app/services/storage.py
@@ -1,0 +1,70 @@
+"""Supabase Storage fetch helpers for the analysis service.
+
+Fetches are done via the Storage REST API with the service role key so the
+service has read access to the private ``plant-images`` bucket. HTTP calls go
+through ``httpx`` (already a direct dependency) — no supabase-py needed.
+"""
+
+from __future__ import annotations
+
+import base64
+from urllib.parse import quote
+
+import httpx
+
+from app.config import settings
+
+BUCKET = "plant-images"
+
+
+class StorageFetchError(RuntimeError):
+    """Raised when fetching a private object from Supabase Storage fails."""
+
+
+async def fetch_image_bytes(storage_path: str, timeout_s: float = 20.0) -> bytes:
+    """Fetch raw image bytes from the private Supabase Storage bucket.
+
+    Raises StorageFetchError on any non-200 or network failure.
+    """
+    if not settings.supabase_url or not settings.supabase_service_role_key:
+        raise StorageFetchError("Supabase credentials not configured")
+
+    # Strip a leading bucket prefix if the caller passed one.
+    clean_path = storage_path.lstrip("/")
+    if clean_path.startswith(f"{BUCKET}/"):
+        clean_path = clean_path[len(BUCKET) + 1 :]
+
+    base = settings.supabase_url.rstrip("/")
+    url = f"{base}/storage/v1/object/{BUCKET}/{quote(clean_path, safe='/')}"
+    headers = {
+        "Authorization": f"Bearer {settings.supabase_service_role_key}",
+        "apikey": settings.supabase_service_role_key,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            response = await client.get(url, headers=headers)
+    except httpx.HTTPError as exc:
+        raise StorageFetchError(f"storage network error: {exc}") from exc
+
+    if response.status_code != 200:
+        raise StorageFetchError(
+            f"storage returned {response.status_code} for {storage_path}"
+        )
+    return response.content
+
+
+def image_to_data_url(image_bytes: bytes, content_type: str = "image/jpeg") -> str:
+    """Encode image bytes as a data URL suitable for OpenAI Vision image_url input."""
+    b64 = base64.b64encode(image_bytes).decode("ascii")
+    return f"data:{content_type};base64,{b64}"
+
+
+def guess_content_type(storage_path: str) -> str:
+    lower = storage_path.lower()
+    if lower.endswith(".png"):
+        return "image/png"
+    if lower.endswith(".webp"):
+        return "image/webp"
+    if lower.endswith(".heic"):
+        return "image/heic"
+    return "image/jpeg"

--- a/apps/analysis/app/telemetry.py
+++ b/apps/analysis/app/telemetry.py
@@ -21,10 +21,8 @@ def init_sentry() -> None:
     if not dsn:
         return
     try:
-        import sentry_sdk  # type: ignore[import-not-found]
-        from sentry_sdk.integrations.fastapi import (  # type: ignore[import-not-found]
-            FastApiIntegration,
-        )
+        import sentry_sdk
+        from sentry_sdk.integrations.fastapi import FastApiIntegration
     except ImportError:
         logger.info("sentry-sdk not installed; skipping Sentry init")
         return
@@ -48,15 +46,13 @@ def init_otel() -> None:
         logger.info("OTEL_ENABLED=true but OTEL_EXPORTER_OTLP_ENDPOINT not set")
         return
     try:
-        from opentelemetry import trace  # type: ignore[import-not-found]
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # type: ignore[import-not-found]
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
             OTLPSpanExporter,
         )
-        from opentelemetry.sdk.resources import Resource  # type: ignore[import-not-found]
-        from opentelemetry.sdk.trace import TracerProvider  # type: ignore[import-not-found]
-        from opentelemetry.sdk.trace.export import (  # type: ignore[import-not-found]
-            BatchSpanProcessor,
-        )
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
     except ImportError:
         logger.info("opentelemetry-sdk not installed; skipping OTel init")
         return

--- a/apps/analysis/requirements.txt
+++ b/apps/analysis/requirements.txt
@@ -6,6 +6,13 @@ httpx==0.28.1
 python-multipart==0.0.26
 openai==2.32.0
 
+# Observability — activated only when SENTRY_DSN or OTEL_EXPORTER_OTLP_ENDPOINT is set.
+sentry-sdk[fastapi]==2.34.1
+opentelemetry-api==1.30.0
+opentelemetry-sdk==1.30.0
+opentelemetry-instrumentation-fastapi==0.51b0
+opentelemetry-exporter-otlp-proto-http==1.30.0
+
 # Linting & type checking (dev)
 ruff==0.15.11
 mypy==1.20.1

--- a/apps/analysis/tests/test_image_analysis.py
+++ b/apps/analysis/tests/test_image_analysis.py
@@ -1,0 +1,196 @@
+"""Tests for ``app.services.image_analysis.run_analysis``.
+
+Exercises the happy path (storage → vision → parse → score) and the two
+degradation paths (storage failure, vision failure) without touching the
+network.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from app.models.analysis import (
+    AnalyzeRequest,
+    FindingCategory,
+    FindingSeverity,
+    GrowContext,
+)
+from app.services import image_analysis
+
+
+def _request() -> AnalyzeRequest:
+    return AnalyzeRequest(
+        plant_id="plant-1",
+        image_id="img-1",
+        storage_path="g/p/1.jpg",
+        grow_context=GrowContext(grow_id="grow-1", stage="vegetative"),
+    )
+
+
+class _FakeChoiceMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _FakeChoiceMessage(content)
+
+
+class _FakeCompletions:
+    def __init__(self, content: str) -> None:
+        self._content = content
+        self.calls: list[dict[str, Any]] = []
+
+    async def create(self, **kwargs: Any) -> Any:  # noqa: ANN401
+        self.calls.append(kwargs)
+        return type(
+            "Resp",
+            (),
+            {"choices": [_FakeChoice(self._content)]},
+        )
+
+
+class _FakeChat:
+    def __init__(self, content: str) -> None:
+        self.completions = _FakeCompletions(content)
+
+
+class _FakeClient:
+    def __init__(self, content: str) -> None:
+        self.chat = _FakeChat(content)
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_fetch(path: str, timeout_s: float = 20.0) -> bytes:
+        return b"\x89PNG\r\n\x1a\nfake"
+
+    monkeypatch.setattr(image_analysis, "fetch_image_bytes", fake_fetch)
+
+    fake_client = _FakeClient(
+        json.dumps(
+            {
+                "overall_health_score": 85,
+                "summary": "Healthy plant with mild yellowing on lower leaves.",
+                "findings": [
+                    {
+                        "category": "nutrient_deficiency",
+                        "severity": "low",
+                        "title": "Early nitrogen deficiency",
+                        "description": "Lower fan leaves showing mild yellowing.",
+                        "recommendation": "Increase N on next feeding.",
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr(image_analysis, "get_openai_client", lambda: fake_client)
+
+    response = await image_analysis.run_analysis(_request())
+
+    assert response.plant_id == "plant-1"
+    assert response.image_id == "img-1"
+    assert response.summary.startswith("Healthy plant")
+    assert len(response.findings) == 1
+    assert response.findings[0].category == FindingCategory.nutrient_deficiency
+    assert response.findings[0].severity == FindingSeverity.low
+    # Score blends model + computed scores. Weight penalty for one "low" finding = 5,
+    # so computed = 95; model = 85; blended average = 90.0.
+    assert response.overall_health_score == pytest.approx(90.0)
+    assert response.model_version == image_analysis.MODEL_VERSION
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_storage_failure_returns_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def failing_fetch(path: str, timeout_s: float = 20.0) -> bytes:
+        raise image_analysis.StorageFetchError("not found")
+
+    monkeypatch.setattr(image_analysis, "fetch_image_bytes", failing_fetch)
+
+    response = await image_analysis.run_analysis(_request())
+
+    assert response.model_version == image_analysis.FALLBACK_MODEL_VERSION
+    assert response.summary
+    assert len(response.findings) >= 1
+    # Does not leak error details in the user-facing summary.
+    assert "not found" not in response.summary
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_vision_failure_returns_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(path: str, timeout_s: float = 20.0) -> bytes:
+        return b"bytes"
+
+    monkeypatch.setattr(image_analysis, "fetch_image_bytes", fake_fetch)
+
+    class _BoomCompletions:
+        async def create(self, **kwargs: Any) -> Any:  # noqa: ANN401
+            raise RuntimeError("openai down")
+
+    class _BoomClient:
+        class chat:  # noqa: N801
+            completions = _BoomCompletions()
+
+    monkeypatch.setattr(image_analysis, "get_openai_client", lambda: _BoomClient())
+
+    response = await image_analysis.run_analysis(_request())
+
+    assert response.model_version == image_analysis.FALLBACK_MODEL_VERSION
+    assert response.findings
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_malformed_json_returns_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(path: str, timeout_s: float = 20.0) -> bytes:
+        return b"bytes"
+
+    monkeypatch.setattr(image_analysis, "fetch_image_bytes", fake_fetch)
+    monkeypatch.setattr(
+        image_analysis, "get_openai_client", lambda: _FakeClient("not json")
+    )
+
+    response = await image_analysis.run_analysis(_request())
+    assert response.model_version == image_analysis.FALLBACK_MODEL_VERSION
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_coerces_unknown_category(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(path: str, timeout_s: float = 20.0) -> bytes:
+        return b"bytes"
+
+    monkeypatch.setattr(image_analysis, "fetch_image_bytes", fake_fetch)
+    monkeypatch.setattr(
+        image_analysis,
+        "get_openai_client",
+        lambda: _FakeClient(
+            json.dumps(
+                {
+                    "overall_health_score": 70,
+                    "summary": "ok",
+                    "findings": [
+                        {
+                            "category": "something_invalid",
+                            "severity": "high",
+                            "title": "Oops",
+                            "description": "desc",
+                        }
+                    ],
+                }
+            )
+        ),
+    )
+
+    response = await image_analysis.run_analysis(_request())
+    assert response.findings[0].category == FindingCategory.general

--- a/apps/analysis/tests/test_image_comparison.py
+++ b/apps/analysis/tests/test_image_comparison.py
@@ -1,9 +1,8 @@
-"""
-Tests for `app.services.image_comparison`.
+"""Tests for ``app.services.image_comparison``.
 
-The implementation is currently a stub. These tests lock in the public
-signature and the placeholder behaviour so any future wiring to the OpenAI
-Vision API is a deliberate, observable change.
+The real implementation calls OpenAI Vision; these tests exercise the contract
+(coroutine, stable signature, graceful degradation when storage is not
+configured) without hitting the network.
 """
 
 from __future__ import annotations
@@ -17,7 +16,12 @@ from app.services.image_comparison import compare_images
 
 
 @pytest.mark.asyncio
-async def test_compare_images_returns_string() -> None:
+async def test_compare_images_returns_empty_string_without_storage() -> None:
+    """Without Supabase credentials the helper degrades gracefully.
+
+    Settings are pulled from env at process start; in the test harness they
+    are empty strings, so the internal storage fetch raises and we return "".
+    """
     result = await compare_images(
         image_id_a="img-a",
         storage_path_a="plants/p/img-a.jpg",
@@ -25,24 +29,11 @@ async def test_compare_images_returns_string() -> None:
         storage_path_b="plants/p/img-b.jpg",
     )
     assert isinstance(result, str)
-    assert result  # non-empty
-
-
-@pytest.mark.asyncio
-async def test_compare_images_current_stub_marker() -> None:
-    """
-    The stub returns a known sentinel string. When the real implementation
-    lands this test should be replaced — its failure is the intended signal.
-    """
-    result = await compare_images("a", "p/a", "b", "p/b")
-    assert "not yet implemented" in result.lower()
+    assert result == ""
 
 
 def test_compare_images_signature_is_stable() -> None:
-    """
-    The signature is part of the internal contract used by `image_analysis`.
-    Renames here must be coordinated with that caller.
-    """
+    """Part of the internal contract used by ``image_analysis``."""
     sig = inspect.signature(compare_images)
     assert list(sig.parameters) == [
         "image_id_a",

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,3 +21,16 @@ OPENAI_API_KEY=sk-...
 
 # ─── App ─────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_ENV=development
+
+# ─── Vercel Cron ─────────────────────────────────────────────────────────────
+# Vercel Cron sends this as `Authorization: Bearer <value>`
+CRON_SECRET=replace-with-32+-byte-random-hex
+
+# ─── Observability (optional) ────────────────────────────────────────────────
+# Leave blank to disable; structured stderr logging remains the fallback.
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# Log verbosity for apps/web/src/lib/server/logger.ts — one of debug|info|warn|error
+LOG_LEVEL=info

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,123 @@
+/**
+ * Next.js instrumentation hook.
+ *
+ * This file is imported by Next.js once per server process. Keep it side-effect
+ * free aside from telemetry bootstrapping. Every integration is gated behind an
+ * env var so local dev / CI / preview deploys stay no-op by default.
+ *
+ * Supported backends:
+ *   - Sentry (SENTRY_DSN). Optional and dynamically imported so the package is
+ *     only loaded when actually configured.
+ *
+ * `onRequestError` forwards unhandled request errors to whatever backend is
+ * configured. When nothing is configured it falls back to a structured stderr
+ * log so failures remain diagnosable.
+ */
+
+interface SentryModule {
+  init: (_opts: Record<string, unknown>) => void;
+  captureException: (_err: unknown, _ctx?: Record<string, unknown>) => void;
+}
+
+async function loadSentry(): Promise<SentryModule | null> {
+  // Resolve the specifier via a runtime variable so tsc does not try to type
+  // the module at build time. @sentry/nextjs is an optional peer.
+  const specifier = "@sentry/nextjs";
+  try {
+    const mod = (await import(/* @vite-ignore */ specifier)) as SentryModule;
+    return mod ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function register(): Promise<void> {
+  const dsn = process.env["SENTRY_DSN"];
+  if (!dsn) return;
+
+  try {
+    // Only import when DSN is configured; keeps bundle + boot cost at zero for
+    // environments that haven't opted into Sentry. The package is optional and
+    // intentionally untyped here so the project still type-checks without it.
+    const mod = (await loadSentry()) as SentryModule | null;
+    if (!mod?.init) return;
+
+    mod.init({
+      dsn,
+      environment:
+        process.env["NEXT_PUBLIC_APP_ENV"] ?? process.env["NODE_ENV"],
+      release:
+        process.env["VERCEL_GIT_COMMIT_SHA"] ??
+        process.env["GIT_COMMIT_SHA"] ??
+        undefined,
+      tracesSampleRate: Number(
+        process.env["SENTRY_TRACES_SAMPLE_RATE"] ?? "0.1",
+      ),
+    });
+  } catch (err) {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        msg: "instrumentation.register failed",
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    );
+  }
+}
+
+interface RequestContext {
+  path?: string;
+  method?: string;
+  headers?: Record<string, string | string[] | undefined> | Headers;
+}
+
+export async function onRequestError(
+  error: unknown,
+  request: RequestContext,
+  context: { routerKind?: string; routePath?: string; routeType?: string },
+): Promise<void> {
+  const dsn = process.env["SENTRY_DSN"];
+  const headers = request.headers;
+  const requestId =
+    headers instanceof Headers
+      ? headers.get("x-request-id")
+      : typeof headers === "object"
+        ? ((headers?.["x-request-id"] as string | undefined) ?? null)
+        : null;
+
+  if (dsn) {
+    try {
+      const mod = (await loadSentry()) as SentryModule | null;
+      if (mod?.captureException) {
+        mod.captureException(error, {
+          tags: {
+            request_id: requestId ?? "unknown",
+            route_kind: context.routerKind ?? "unknown",
+            route_type: context.routeType ?? "unknown",
+          },
+          extra: { routePath: context.routePath, path: request.path },
+        });
+        return;
+      }
+    } catch {
+      // fall through to stderr logging
+    }
+  }
+
+  const record = {
+    level: "error",
+    msg: "next.request_error",
+    ts: new Date().toISOString(),
+    request_id: requestId,
+    path: request.path,
+    method: request.method,
+    route_kind: context.routerKind,
+    route_type: context.routeType,
+    route_path: context.routePath,
+    error:
+      error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : String(error),
+  };
+  console.error(JSON.stringify(record));
+}

--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const { getServerUser, authorizeGrowAccess, openaiCreate, tableHandlers } =
+  vi.hoisted(() => ({
+    getServerUser: vi.fn(),
+    authorizeGrowAccess: vi.fn(),
+    openaiCreate: vi.fn(),
+    tableHandlers: {} as Record<string, () => unknown>,
+  }));
+
+vi.mock("@/lib/server/auth", () => ({
+  getServerUser,
+  getServerSession: vi.fn(),
+  createSupabaseServerClient: vi.fn(),
+}));
+vi.mock("@/lib/server/authorization", () => ({
+  authorizeGrowAccess,
+  authorizePlantAccess: vi.fn(),
+}));
+vi.mock("@/lib/server/ai-client", () => ({
+  getAIClient: () => ({
+    chat: {
+      completions: {
+        create: openaiCreate,
+      },
+    },
+  }),
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDbClient: () => ({
+    from: (name: string) => {
+      const handler = tableHandlers[name];
+      if (!handler) throw new Error(`Unmocked table: ${name}`);
+      return handler();
+    },
+  }),
+}));
+
+import { POST } from "../route";
+
+function req(body: unknown): Request {
+  return new Request("http://localhost/api/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/chat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const k of Object.keys(tableHandlers)) delete tableHandlers[k];
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getServerUser.mockResolvedValue(null);
+    const res = await POST(
+      req({ message: "hi" }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when message missing", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    const res = await POST(
+      req({ message: "" }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a thread, persists messages, and returns the assistant reply", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+
+    const threadInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: { id: "t1", grow_id: null },
+          error: null,
+        }),
+      }),
+    });
+    const threadUpdate = vi.fn().mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+    });
+
+    const userMsgInsert = vi.fn().mockResolvedValue({ error: null });
+    const assistantMsgInsert = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({
+          data: {
+            id: "m-assistant",
+            role: "assistant",
+            content: "hello there",
+            created_at: "2026-04-19T00:00:00Z",
+          },
+          error: null,
+        }),
+      }),
+    });
+
+    const historyBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+
+    let messageInsertCalls = 0;
+    tableHandlers["chat_threads"] = () => ({
+      insert: threadInsert,
+      update: threadUpdate,
+    });
+    tableHandlers["chat_messages"] = () => {
+      messageInsertCalls += 1;
+      if (messageInsertCalls === 1) {
+        return { insert: userMsgInsert };
+      }
+      if (messageInsertCalls === 2) {
+        return historyBuilder;
+      }
+      return { insert: assistantMsgInsert };
+    };
+
+    openaiCreate.mockResolvedValue({
+      model: "gpt-4o",
+      choices: [{ message: { content: "hello there" } }],
+    });
+
+    const res = await POST(
+      req({ message: "hey" }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      threadId: string;
+      message: { role: string; content: string };
+    };
+    expect(body.threadId).toBe("t1");
+    expect(body.message.content).toBe("hello there");
+    expect(threadInsert).toHaveBeenCalled();
+    expect(openaiCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-4o",
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: "system" }),
+        ]),
+      }),
+    );
+  });
+
+  it("returns 404 when threadId does not belong to the user", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+
+    const threadSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: { id: "t-other", user_id: "u2", grow_id: null },
+          error: null,
+        }),
+      }),
+    });
+    tableHandlers["chat_threads"] = () => ({ select: threadSelect });
+
+    const res = await POST(
+      req({
+        message: "hey",
+        threadId: "t-other",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 502 when the OpenAI call fails", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+
+    tableHandlers["chat_threads"] = () => ({
+      insert: vi.fn().mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: { id: "t2", grow_id: null },
+            error: null,
+          }),
+        }),
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+      }),
+    });
+
+    let call = 0;
+    tableHandlers["chat_messages"] = () => {
+      call += 1;
+      if (call === 1)
+        return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+      };
+    };
+
+    openaiCreate.mockRejectedValue(new Error("openai timeout"));
+
+    const res = await POST(
+      req({ message: "hey" }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -1,63 +1,400 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAIClient } from "@/lib/server/ai-client";
-import { getServerSession } from "@/lib/server/auth";
+import { getServerUser } from "@/lib/server/auth";
+import { getDbClient } from "@/lib/server/db";
+import { authorizeGrowAccess } from "@/lib/server/authorization";
+import { correlationIdFromRequest, createLogger } from "@/lib/server/logger";
 
-// POST /api/chat
-// Accepts a threadId + message, streams OpenAI response back.
-// Context is injected server-side from the user's grow data.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MODEL = "gpt-4o";
+const MAX_MESSAGE_LEN = 4_000;
+const MAX_HISTORY_MESSAGES = 20;
+const MAX_CONTEXT_PLANTS = 8;
+const MAX_CONTEXT_FINDINGS = 20;
+
+interface ChatBody {
+  message: unknown;
+  threadId?: unknown;
+  growId?: unknown;
+}
+
+interface GroundingContext {
+  grow: {
+    name: string;
+    stage: string;
+    medium: string;
+    lightType: string;
+    daysSinceStart: number | null;
+  } | null;
+  plants: Array<{
+    id: string;
+    name: string;
+    strain: string | null;
+    notes: string | null;
+  }>;
+  findings: Array<{
+    plantName: string;
+    category: string;
+    severity: string;
+    title: string;
+    description: string;
+    recommendation: string | null;
+    createdAt: string;
+  }>;
+}
+
+/**
+ * POST /api/chat
+ *
+ * Body: { message, threadId?, growId? }
+ * - When `threadId` is provided, loads the existing thread (auth-checked) and
+ *   appends this message as a new turn.
+ * - When absent, creates a new thread bound to the user (and optional grow).
+ * - When the thread has an associated `growId`, the route loads grow/plant/
+ *   finding context from the DB and injects it into the system prompt.
+ *
+ * Returns: { threadId, message: ChatMessage }
+ */
 export async function POST(request: NextRequest) {
-  const session = await getServerSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const requestId = correlationIdFromRequest(request);
+  const log = createLogger({ route: "api.chat", requestId });
+
+  const user = await getServerUser();
+  if (!user) return errJson("Unauthorized", 401, requestId);
+
+  let body: ChatBody;
+  try {
+    body = (await request.json()) as ChatBody;
+  } catch {
+    return errJson("Invalid JSON body", 400, requestId);
   }
 
-  const body = (await request.json()) as {
-    threadId?: string;
-    message: string;
-    growId?: string;
-  };
-
-  if (!body.message?.trim()) {
-    return NextResponse.json({ error: "message is required" }, { status: 400 });
+  const message = typeof body.message === "string" ? body.message.trim() : "";
+  if (!message) {
+    return errJson("message is required", 400, requestId);
   }
+  if (message.length > MAX_MESSAGE_LEN) {
+    return errJson("message is too long", 413, requestId);
+  }
+
+  const threadIdIn =
+    typeof body.threadId === "string" && body.threadId.length > 0
+      ? body.threadId
+      : null;
+  const growIdIn =
+    typeof body.growId === "string" && body.growId.length > 0
+      ? body.growId
+      : null;
+
+  const db = getDbClient();
+
+  let threadId: string;
+  let threadGrowId: string | null;
+
+  if (threadIdIn) {
+    const { data: thread, error } = await db
+      .from("chat_threads")
+      .select("id, user_id, grow_id")
+      .eq("id", threadIdIn)
+      .maybeSingle();
+    if (error || !thread) return errJson("Thread not found", 404, requestId);
+    if (thread.user_id !== user.id) {
+      return errJson("Thread not found", 404, requestId);
+    }
+    threadId = thread.id as string;
+    threadGrowId = (thread.grow_id as string | null) ?? null;
+  } else {
+    let boundGrowId: string | null = null;
+    if (growIdIn) {
+      const grow = await authorizeGrowAccess(user.id, growIdIn);
+      if (!grow) return errJson("Grow not found", 404, requestId);
+      boundGrowId = grow.growId;
+    }
+    const { data: created, error } = await db
+      .from("chat_threads")
+      .insert({
+        user_id: user.id,
+        grow_id: boundGrowId,
+        title: truncate(message, 60),
+      })
+      .select("id, grow_id")
+      .single();
+    if (error || !created) {
+      log.error("chat_threads insert failed", { error: error?.message });
+      return errJson("Could not create thread", 500, requestId);
+    }
+    threadId = created.id as string;
+    threadGrowId = (created.grow_id as string | null) ?? null;
+  }
+
+  const { error: userMsgErr } = await db.from("chat_messages").insert({
+    thread_id: threadId,
+    role: "user",
+    content: message,
+    metadata: { request_id: requestId },
+  });
+  if (userMsgErr) {
+    log.error("chat_messages insert (user) failed", {
+      threadId,
+      error: userMsgErr.message,
+    });
+    return errJson("Could not save message", 500, requestId);
+  }
+
+  const history = await loadThreadHistory(threadId);
+  const context = threadGrowId
+    ? await loadGrounding(threadGrowId)
+    : emptyContext();
+
+  const systemPrompt = buildSystemPrompt(context);
 
   const openai = getAIClient();
+  let completion;
+  try {
+    completion = await openai.chat.completions.create({
+      model: MODEL,
+      messages: [
+        { role: "system", content: systemPrompt },
+        ...history.map((m) => ({
+          role: m.role as "user" | "assistant" | "system",
+          content: m.content,
+        })),
+      ],
+      temperature: 0.4,
+    });
+  } catch (err) {
+    log.error("openai chat completion failed", {
+      threadId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return errJson("Assistant is unavailable", 502, requestId);
+  }
 
-  // TODO: Load grow context from DB to inject as system context
-  // TODO: Persist ChatThread + ChatMessage rows via Supabase service role
+  const assistantContent =
+    completion.choices[0]?.message?.content?.trim() ??
+    "I couldn't generate a response. Please try again.";
 
-  const stream = openai.beta.chat.completions.stream({
-    model: "gpt-4o",
-    messages: [
-      {
-        role: "system",
-        content:
-          "You are PhenoSage, a professional cannabis grow advisor. " +
-          "You have access to the user's grow data and plant history. " +
-          "Give precise, evidence-based advice. Be concise and professional.",
+  const { data: savedAssistant, error: assistantErr } = await db
+    .from("chat_messages")
+    .insert({
+      thread_id: threadId,
+      role: "assistant",
+      content: assistantContent,
+      metadata: {
+        model: completion.model,
+        request_id: requestId,
+        context: {
+          grounded: Boolean(threadGrowId),
+          plants: context.plants.length,
+          findings: context.findings.length,
+        },
       },
-      { role: "user", content: body.message },
-    ],
-    stream: true,
+    })
+    .select("id, role, content, created_at")
+    .single();
+
+  if (assistantErr || !savedAssistant) {
+    log.error("chat_messages insert (assistant) failed", {
+      threadId,
+      error: assistantErr?.message,
+    });
+    return errJson("Could not save assistant reply", 500, requestId);
+  }
+
+  await db
+    .from("chat_threads")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", threadId);
+
+  log.info("chat turn complete", {
+    threadId,
+    grounded: Boolean(threadGrowId),
+    contextPlants: context.plants.length,
+    contextFindings: context.findings.length,
   });
 
-  // Return a streaming response compatible with Vercel Edge
-  const readable = new ReadableStream({
-    async start(controller) {
-      for await (const chunk of stream) {
-        const delta = chunk.choices[0]?.delta?.content;
-        if (delta) {
-          controller.enqueue(new TextEncoder().encode(delta));
+  return NextResponse.json(
+    {
+      threadId,
+      message: {
+        id: savedAssistant.id,
+        threadId,
+        role: savedAssistant.role,
+        content: savedAssistant.content,
+        createdAt: savedAssistant.created_at,
+      },
+      requestId,
+    },
+    { status: 201, headers: { "x-request-id": requestId } },
+  );
+}
+
+async function loadThreadHistory(
+  threadId: string,
+): Promise<Array<{ role: string; content: string }>> {
+  const db = getDbClient();
+  const { data } = await db
+    .from("chat_messages")
+    .select("role, content, created_at")
+    .eq("thread_id", threadId)
+    .order("created_at", { ascending: true })
+    .limit(MAX_HISTORY_MESSAGES);
+  return (data ?? []).map((m) => ({
+    role: m.role as string,
+    content: m.content as string,
+  }));
+}
+
+async function loadGrounding(growId: string): Promise<GroundingContext> {
+  const db = getDbClient();
+
+  const [growRes, plantsRes] = await Promise.all([
+    db
+      .from("grows")
+      .select("name, stage, medium, light_type, start_date")
+      .eq("id", growId)
+      .maybeSingle(),
+    db
+      .from("plants")
+      .select("id, name, strain, notes, is_archived, created_at")
+      .eq("grow_id", growId)
+      .eq("is_archived", false)
+      .order("created_at", { ascending: false })
+      .limit(MAX_CONTEXT_PLANTS),
+  ]);
+
+  const plantRows = (plantsRes.data ?? []) as Array<{
+    id: string;
+    name: string;
+    strain: string | null;
+    notes: string | null;
+  }>;
+
+  let findings: GroundingContext["findings"] = [];
+  if (plantRows.length > 0) {
+    const plantIds = plantRows.map((p) => p.id);
+    const { data: findingData } = await db
+      .from("plant_findings")
+      .select(
+        "plant_id, category, severity, title, description, recommendation, created_at",
+      )
+      .in("plant_id", plantIds)
+      .is("resolved_at", null)
+      .order("created_at", { ascending: false })
+      .limit(MAX_CONTEXT_FINDINGS);
+
+    const nameById = new Map(plantRows.map((p) => [p.id, p.name]));
+    findings = (findingData ?? []).map((f) => ({
+      plantName: nameById.get(f.plant_id as string) ?? "Unknown plant",
+      category: f.category as string,
+      severity: f.severity as string,
+      title: f.title as string,
+      description: f.description as string,
+      recommendation: (f.recommendation as string | null) ?? null,
+      createdAt: f.created_at as string,
+    }));
+  }
+
+  const grow = growRes.data as {
+    name: string;
+    stage: string;
+    medium: string;
+    light_type: string;
+    start_date: string | null;
+  } | null;
+
+  return {
+    grow: grow
+      ? {
+          name: grow.name,
+          stage: grow.stage,
+          medium: grow.medium,
+          lightType: grow.light_type,
+          daysSinceStart: grow.start_date
+            ? Math.max(
+                0,
+                Math.floor(
+                  (Date.now() - new Date(grow.start_date).getTime()) /
+                    (24 * 60 * 60 * 1000),
+                ),
+              )
+            : null,
         }
-      }
-      controller.close();
-    },
-  });
+      : null,
+    plants: plantRows.map((p) => ({
+      id: p.id,
+      name: p.name,
+      strain: p.strain,
+      notes: p.notes,
+    })),
+    findings,
+  };
+}
 
-  return new NextResponse(readable, {
-    headers: {
-      "Content-Type": "text/plain; charset=utf-8",
-      "Transfer-Encoding": "chunked",
-    },
-  });
+function buildSystemPrompt(ctx: GroundingContext): string {
+  const header =
+    "You are PhenoSage, a professional cannabis grow advisor. " +
+    "Give precise, evidence-based, concise advice. If the grower's data does not " +
+    "contain enough detail to answer a question, say so explicitly rather than " +
+    "guessing. Never claim to see images or sensor data that were not provided.";
+
+  if (!ctx.grow && ctx.plants.length === 0) {
+    return (
+      header +
+      "\n\nThe grower has not linked a specific grow to this conversation, " +
+      "so you only have their current message as context."
+    );
+  }
+
+  const lines: string[] = [header, "", "# Grower context"];
+  if (ctx.grow) {
+    lines.push(
+      `Grow "${ctx.grow.name}" — stage: ${ctx.grow.stage}, medium: ${ctx.grow.medium}, ` +
+        `light: ${ctx.grow.lightType}` +
+        (ctx.grow.daysSinceStart !== null
+          ? `, day ${ctx.grow.daysSinceStart} since start`
+          : ""),
+    );
+  }
+  if (ctx.plants.length > 0) {
+    lines.push("", "## Plants");
+    for (const p of ctx.plants) {
+      const parts = [`- ${p.name}`];
+      if (p.strain) parts.push(`(${p.strain})`);
+      if (p.notes) parts.push(`— ${truncate(p.notes, 200)}`);
+      lines.push(parts.join(" "));
+    }
+  }
+  if (ctx.findings.length > 0) {
+    lines.push("", "## Recent unresolved findings");
+    for (const f of ctx.findings) {
+      const rec = f.recommendation
+        ? ` Rec: ${truncate(f.recommendation, 160)}`
+        : "";
+      lines.push(
+        `- [${f.severity}/${f.category}] ${f.plantName}: ${f.title} — ${truncate(
+          f.description,
+          200,
+        )}.${rec}`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+function emptyContext(): GroundingContext {
+  return { grow: null, plants: [], findings: [] };
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+function errJson(message: string, status: number, requestId: string) {
+  return NextResponse.json(
+    { error: message, requestId },
+    { status, headers: { "x-request-id": requestId } },
+  );
 }

--- a/apps/web/src/app/api/internal/cron/daily-summary/route.ts
+++ b/apps/web/src/app/api/internal/cron/daily-summary/route.ts
@@ -1,29 +1,42 @@
 import { NextRequest, NextResponse } from "next/server";
+import { correlationIdFromRequest, createLogger } from "@/lib/server/logger";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
-// GET /api/internal/cron/daily-summary
-// Vercel Cron always issues a GET request and signs it with
-// `Authorization: Bearer ${CRON_SECRET}` (set in Vercel project settings).
-// Never invoked by the browser.
+/**
+ * GET /api/internal/cron/daily-summary
+ *
+ * Vercel Cron always issues a GET and signs it with
+ * `Authorization: Bearer ${CRON_SECRET}`. Never invoked by the browser.
+ */
 export async function GET(request: NextRequest) {
+  const requestId = correlationIdFromRequest(request);
+  const log = createLogger({ route: "api.cron.daily_summary", requestId });
+
   const authHeader = request.headers.get("authorization");
   const cronSecret = process.env["CRON_SECRET"];
 
   if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    log.warn("unauthorized cron invocation");
+    return NextResponse.json(
+      { error: "Unauthorized", requestId },
+      { status: 401, headers: { "x-request-id": requestId } },
+    );
   }
 
-  // TODO: Fetch all active grows
-  // TODO: For each grow, compile recent observations + findings
-  // TODO: Call AI to generate a daily summary
-  // TODO: Persist as grow_events with eventType = 'observation'
-  // TODO: Queue notifications (email / push) per user preferences
+  log.info("cron invoked");
 
-  return NextResponse.json({
-    status: "ok",
-    ran: new Date().toISOString(),
-    message: "TODO: Implement daily summary generation",
-  });
+  // TODO: Fetch all active grows, compile observations + findings, call AI,
+  // persist grow_events, queue notifications. Tracked separately; this route
+  // stays a no-op until that pipeline lands.
+  return NextResponse.json(
+    {
+      status: "ok",
+      ran: new Date().toISOString(),
+      message: "daily summary pipeline not yet implemented",
+      requestId,
+    },
+    { headers: { "x-request-id": requestId } },
+  );
 }

--- a/apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getServerUser, authorizePlantAccess, analysisRow, findingsRows } =
+  vi.hoisted(() => ({
+    getServerUser: vi.fn(),
+    authorizePlantAccess: vi.fn(),
+    analysisRow: { row: null as Record<string, unknown> | null },
+    findingsRows: { rows: [] as Array<Record<string, unknown>> },
+  }));
+
+vi.mock("@/lib/server/auth", () => ({ getServerUser }));
+vi.mock("@/lib/server/authorization", () => ({ authorizePlantAccess }));
+vi.mock("@/lib/server/db", () => ({
+  getDbClient: () => ({
+    from(table: string) {
+      if (table === "plant_analyses") {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          order: () => chain,
+          limit: () => chain,
+          maybeSingle: () =>
+            Promise.resolve({ data: analysisRow.row, error: null }),
+        };
+        return chain;
+      }
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        order: () => Promise.resolve({ data: findingsRows.rows, error: null }),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { GET } from "../route";
+
+function req(): Request {
+  return new Request("http://localhost/api/plants/p/analysis/latest", {
+    method: "GET",
+  });
+}
+
+async function callGet(plantId: string) {
+  return GET(req() as unknown as import("next/server").NextRequest, {
+    params: Promise.resolve({ plantId }),
+  });
+}
+
+describe("GET /api/plants/[plantId]/analysis/latest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    analysisRow.row = null;
+    findingsRows.rows = [];
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getServerUser.mockResolvedValue(null);
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when user cannot access the plant", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue(null);
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns analysis null when no record exists", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue({
+      plantId: "p",
+      growId: "g",
+      strain: null,
+      name: "P",
+    });
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { analysis: null };
+    expect(body.analysis).toBeNull();
+  });
+
+  it("maps a persisted analysis and its findings", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue({
+      plantId: "p",
+      growId: "g",
+      strain: null,
+      name: "P",
+    });
+    analysisRow.row = {
+      id: "a1",
+      plant_id: "p",
+      image_id: "img1",
+      overall_health_score: 82.5,
+      summary: "Healthy",
+      compared_to_image_id: null,
+      comparison_summary: null,
+      model_version: "gpt-4o-v1",
+      analyzed_at: "2026-04-12T00:00:00Z",
+    };
+    findingsRows.rows = [
+      {
+        category: "nutrient_deficiency",
+        severity: "low",
+        title: "Mild N",
+        description: "Some yellow",
+        recommendation: "Feed more N",
+      },
+    ];
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    const body = (await res.json()) as {
+      analysis: {
+        overallHealthScore: number;
+        findings: Array<{ recommendation?: string }>;
+      };
+    };
+    expect(body.analysis.overallHealthScore).toBe(82.5);
+    expect(body.analysis.findings[0]?.recommendation).toBe("Feed more N");
+  });
+});

--- a/apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts
@@ -1,37 +1,96 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "@/lib/server/auth";
-import { callAnalysisService } from "@/lib/server/analysis-proxy";
+import type { AnalysisResponse } from "@phenosage/shared";
+import { getServerUser } from "@/lib/server/auth";
+import { getDbClient } from "@/lib/server/db";
+import { authorizePlantAccess } from "@/lib/server/authorization";
+import { correlationIdFromRequest } from "@/lib/server/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 interface RouteParams {
   params: Promise<{ plantId: string }>;
 }
 
-// GET /api/plants/[plantId]/analysis/latest
-// Returns the most recent AnalysisResponse for a plant.
-// Proxied through Next.js — the browser never calls the analysis service directly.
-export async function GET(
-  request: NextRequest,
-  { params }: RouteParams,
-) {
-  const session = await getServerSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+/**
+ * GET /api/plants/[plantId]/analysis/latest
+ *
+ * Returns the most recent stored analysis for the plant plus the findings that
+ * were captured with it. Returns { analysis: null } when no analysis has run.
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const requestId = correlationIdFromRequest(request);
+  const user = await getServerUser();
+  if (!user) return errJson("Unauthorized", 401, requestId);
 
   const { plantId } = await params;
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) return errJson("Plant not found", 404, requestId);
 
-  // TODO: Look up the latest plant_image for this plant from DB
-  // TODO: Call analysis service via proxy if a new image is pending
-  // TODO: Return cached PlantFinding rows if analysis already ran
+  const db = getDbClient();
 
-  void callAnalysisService({
-    endpoint: `/plants/${plantId}/analysis/latest`,
-    method: "GET",
-  });
+  const { data: analysisRow, error: analysisErr } = await db
+    .from("plant_analyses")
+    .select(
+      "id, plant_id, image_id, overall_health_score, summary, compared_to_image_id, comparison_summary, model_version, analyzed_at",
+    )
+    .eq("plant_id", access.plantId)
+    .order("analyzed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
 
-  return NextResponse.json({
-    plantId,
-    analysis: null,
-    message: "TODO: Wire DB + analysis service proxy",
-  });
+  if (analysisErr) return errJson("Query failed", 500, requestId);
+
+  if (!analysisRow) {
+    return NextResponse.json(
+      {
+        plantId: access.plantId,
+        analysis: null,
+        requestId,
+      },
+      { status: 200, headers: { "x-request-id": requestId } },
+    );
+  }
+
+  const { data: findings } = await db
+    .from("plant_findings")
+    .select("category, severity, title, description, recommendation")
+    .eq("image_id", analysisRow.image_id as string)
+    .order("created_at", { ascending: true });
+
+  const analysis: AnalysisResponse = {
+    plantId: analysisRow.plant_id as string,
+    imageId: analysisRow.image_id as string,
+    overallHealthScore: Number(analysisRow.overall_health_score),
+    summary: analysisRow.summary as string,
+    findings: (findings ?? []).map((f) => ({
+      category: f.category as AnalysisResponse["findings"][number]["category"],
+      severity: f.severity as AnalysisResponse["findings"][number]["severity"],
+      title: f.title as string,
+      description: f.description as string,
+      ...(f.recommendation
+        ? { recommendation: f.recommendation as string }
+        : {}),
+    })),
+    analyzedAt: analysisRow.analyzed_at as string,
+    modelVersion: analysisRow.model_version as string,
+    ...(analysisRow.compared_to_image_id
+      ? { comparedToImageId: analysisRow.compared_to_image_id as string }
+      : {}),
+    ...(analysisRow.comparison_summary
+      ? { comparisonSummary: analysisRow.comparison_summary as string }
+      : {}),
+  };
+
+  return NextResponse.json(
+    { plantId: access.plantId, analysis, requestId },
+    { status: 200, headers: { "x-request-id": requestId } },
+  );
+}
+
+function errJson(message: string, status: number, requestId: string) {
+  return NextResponse.json(
+    { error: message, requestId },
+    { status, headers: { "x-request-id": requestId } },
+  );
 }

--- a/apps/web/src/app/api/plants/[plantId]/analyze/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analyze/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerUser } from "@/lib/server/auth";
+import { getDbClient } from "@/lib/server/db";
+import { authorizePlantAccess } from "@/lib/server/authorization";
+import { loadGrowContext } from "@/lib/server/plant-context";
+import {
+  analyzeImage,
+  AnalysisServiceError,
+} from "@/lib/server/analysis-proxy";
+import { correlationIdFromRequest, createLogger } from "@/lib/server/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+interface RouteParams {
+  params: Promise<{ plantId: string }>;
+}
+
+/**
+ * POST /api/plants/[plantId]/analyze
+ *
+ * Body: { imageId: uuid } — the plant_images row to analyze.
+ *
+ * Flow:
+ *   1. Authorize the user against the plant.
+ *   2. Load the image row + optional previous image.
+ *   3. Build a GrowContext snapshot.
+ *   4. Call the FastAPI analysis service via the proxy.
+ *   5. Persist AnalysisResponse to plant_analyses and findings to plant_findings.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const requestId = correlationIdFromRequest(request);
+  const log = createLogger({ route: "api.plants.analyze", requestId });
+
+  const user = await getServerUser();
+  if (!user) return errJson("Unauthorized", 401, requestId);
+
+  const { plantId } = await params;
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) return errJson("Plant not found", 404, requestId);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errJson("Invalid JSON body", 400, requestId);
+  }
+  const imageId =
+    body && typeof body === "object"
+      ? (body as Record<string, unknown>)["imageId"]
+      : undefined;
+  if (typeof imageId !== "string") {
+    return errJson("imageId is required", 400, requestId);
+  }
+
+  const db = getDbClient();
+  const { data: image, error: imageErr } = await db
+    .from("plant_images")
+    .select("id, plant_id, grow_id, storage_path, created_at")
+    .eq("id", imageId)
+    .eq("plant_id", access.plantId)
+    .maybeSingle();
+  if (imageErr || !image) return errJson("Image not found", 404, requestId);
+
+  const { data: prev } = await db
+    .from("plant_images")
+    .select("id, storage_path")
+    .eq("plant_id", access.plantId)
+    .lt("created_at", image.created_at as string)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const growCtx = await loadGrowContext(access.plantId, access.growId);
+
+  let analysis;
+  try {
+    const params: Parameters<typeof analyzeImage>[0] = {
+      plantId: access.plantId,
+      imageId: image.id as string,
+      storagePath: image.storage_path as string,
+      growContext: growCtx,
+      requestId,
+    };
+    if (prev?.id) params.previousImageId = prev.id as string;
+    if (prev?.storage_path) {
+      params.previousStoragePath = prev.storage_path as string;
+    }
+    analysis = await analyzeImage(params);
+  } catch (err) {
+    const status = err instanceof AnalysisServiceError ? err.status : 500;
+    log.error("analysis service call failed", {
+      imageId: image.id,
+      status,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return errJson("Analysis failed", status >= 500 ? 502 : status, requestId);
+  }
+
+  const { data: savedAnalysis, error: saveErr } = await db
+    .from("plant_analyses")
+    .insert({
+      plant_id: access.plantId,
+      grow_id: access.growId,
+      image_id: image.id,
+      overall_health_score: analysis.overallHealthScore,
+      summary: analysis.summary,
+      compared_to_image_id: analysis.comparedToImageId ?? null,
+      comparison_summary: analysis.comparisonSummary ?? null,
+      model_version: analysis.modelVersion,
+      analyzed_at: analysis.analyzedAt,
+    })
+    .select("id")
+    .single();
+
+  if (saveErr || !savedAnalysis) {
+    log.error("plant_analyses insert failed", {
+      imageId: image.id,
+      error: saveErr?.message,
+    });
+  }
+
+  if (analysis.findings.length > 0) {
+    const findingRows = analysis.findings.map((f) => ({
+      plant_id: access.plantId,
+      grow_id: access.growId,
+      image_id: image.id,
+      category: f.category,
+      severity: f.severity,
+      title: f.title,
+      description: f.description,
+      recommendation: f.recommendation ?? null,
+    }));
+    const { error: findErr } = await db
+      .from("plant_findings")
+      .insert(findingRows);
+    if (findErr) {
+      log.error("plant_findings insert failed", {
+        imageId: image.id,
+        error: findErr.message,
+      });
+    }
+  }
+
+  log.info("analysis stored", {
+    imageId: image.id,
+    analysisId: savedAnalysis?.id,
+    score: analysis.overallHealthScore,
+    findings: analysis.findings.length,
+  });
+
+  return NextResponse.json(
+    { analysis, requestId },
+    { status: 201, headers: { "x-request-id": requestId } },
+  );
+}
+function errJson(message: string, status: number, requestId: string) {
+  return NextResponse.json(
+    { error: message, requestId },
+    { status, headers: { "x-request-id": requestId } },
+  );
+}

--- a/apps/web/src/app/api/plants/[plantId]/images/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/images/route.ts
@@ -1,0 +1,190 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerUser } from "@/lib/server/auth";
+import { getDbClient } from "@/lib/server/db";
+import { authorizePlantAccess } from "@/lib/server/authorization";
+import { correlationIdFromRequest, createLogger } from "@/lib/server/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const BUCKET = "plant-images";
+
+interface RouteParams {
+  params: Promise<{ plantId: string }>;
+}
+
+/**
+ * POST /api/plants/[plantId]/images
+ *
+ * Called by the browser after a successful direct upload to Supabase Storage.
+ * Verifies that the uploaded path is under the authorized grow/plant prefix,
+ * then inserts a plant_images row via the service role.
+ *
+ * Body: { storagePath: string, takenAt?: ISO string, notes?: string }
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const requestId = correlationIdFromRequest(request);
+  const log = createLogger({ route: "api.plants.images.post", requestId });
+
+  const user = await getServerUser();
+  if (!user) return errorJson("Unauthorized", 401, requestId);
+
+  const { plantId } = await params;
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) return errorJson("Plant not found", 404, requestId);
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errorJson("Invalid JSON body", 400, requestId);
+  }
+  if (!body || typeof body !== "object") {
+    return errorJson("body must be an object", 400, requestId);
+  }
+  const v = body as Record<string, unknown>;
+  const storagePath = v["storagePath"];
+  if (typeof storagePath !== "string" || storagePath.length < 3) {
+    return errorJson("storagePath is required", 400, requestId);
+  }
+  const expectedPrefix = `${access.growId}/${access.plantId}/`;
+  if (!storagePath.startsWith(expectedPrefix)) {
+    return errorJson(
+      "storagePath does not match authorized plant scope",
+      400,
+      requestId,
+    );
+  }
+
+  const notes = typeof v["notes"] === "string" ? (v["notes"] as string) : null;
+  const takenAt =
+    typeof v["takenAt"] === "string" ? (v["takenAt"] as string) : null;
+
+  // Confirm the object actually landed in storage before we record it.
+  const db = getDbClient();
+  const verified = await verifyObjectExists(db, storagePath);
+  if (!verified) {
+    log.warn("upload not found in storage", { storagePath });
+    return errorJson("Uploaded object not found", 404, requestId);
+  }
+
+  const { data, error } = await db
+    .from("plant_images")
+    .insert({
+      plant_id: access.plantId,
+      grow_id: access.growId,
+      user_id: user.id,
+      storage_path: storagePath,
+      source: "upload",
+      notes,
+      taken_at: takenAt,
+    })
+    .select(
+      "id, plant_id, grow_id, user_id, storage_path, taken_at, source, notes, created_at",
+    )
+    .single();
+
+  if (error || !data) {
+    log.error("plant_images insert failed", {
+      plantId: access.plantId,
+      error: error?.message,
+    });
+    return errorJson("Could not persist image", 500, requestId);
+  }
+
+  log.info("plant image recorded", {
+    plantId: access.plantId,
+    imageId: data.id,
+    userId: user.id,
+  });
+
+  return NextResponse.json(
+    {
+      image: {
+        id: data.id as string,
+        plantId: data.plant_id as string,
+        growId: data.grow_id as string,
+        userId: data.user_id as string,
+        storagePath: data.storage_path as string,
+        takenAt: (data.taken_at as string | null) ?? undefined,
+        source: data.source as string,
+        notes: (data.notes as string | null) ?? undefined,
+        createdAt: data.created_at as string,
+      },
+      requestId,
+    },
+    { status: 201, headers: { "x-request-id": requestId } },
+  );
+}
+
+/**
+ * GET /api/plants/[plantId]/images
+ *
+ * Returns the plant's images ordered by created_at desc.
+ * Read-only sibling of POST; shares the same auth check.
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const requestId = correlationIdFromRequest(request);
+
+  const user = await getServerUser();
+  if (!user) return errorJson("Unauthorized", 401, requestId);
+
+  const { plantId } = await params;
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) return errorJson("Plant not found", 404, requestId);
+
+  const db = getDbClient();
+  const { data, error } = await db
+    .from("plant_images")
+    .select(
+      "id, plant_id, grow_id, user_id, storage_path, taken_at, source, notes, created_at",
+    )
+    .eq("plant_id", access.plantId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) return errorJson("Query failed", 500, requestId);
+
+  return NextResponse.json(
+    {
+      plantId: access.plantId,
+      images: (data ?? []).map((row) => ({
+        id: row.id as string,
+        plantId: row.plant_id as string,
+        growId: row.grow_id as string,
+        userId: row.user_id as string,
+        storagePath: row.storage_path as string,
+        takenAt: (row.taken_at as string | null) ?? undefined,
+        source: row.source as string,
+        notes: (row.notes as string | null) ?? undefined,
+        createdAt: row.created_at as string,
+      })),
+      requestId,
+    },
+    { status: 200, headers: { "x-request-id": requestId } },
+  );
+}
+
+async function verifyObjectExists(
+  // Loose typing because the service-role client is reused and we only need
+  // a single Storage API call; the full generated types aren't available here.
+  db: ReturnType<typeof getDbClient>,
+  path: string,
+): Promise<boolean> {
+  const slash = path.lastIndexOf("/");
+  const dir = slash >= 0 ? path.slice(0, slash) : "";
+  const name = slash >= 0 ? path.slice(slash + 1) : path;
+  const { data, error } = await db.storage.from(BUCKET).list(dir, {
+    limit: 100,
+    search: name,
+  });
+  if (error) return false;
+  return (data ?? []).some((entry) => entry.name === name);
+}
+
+function errorJson(message: string, status: number, requestId: string) {
+  return NextResponse.json(
+    { error: message, requestId },
+    { status, headers: { "x-request-id": requestId } },
+  );
+}

--- a/apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { getServerUser, authorizePlantAccess, dbState } = vi.hoisted(() => ({
+  getServerUser: vi.fn(),
+  authorizePlantAccess: vi.fn(),
+  dbState: {
+    images: [] as Array<Record<string, unknown>>,
+    observations: [] as Array<Record<string, unknown>>,
+    findings: [] as Array<Record<string, unknown>>,
+  } as {
+    images: Array<Record<string, unknown>>;
+    observations: Array<Record<string, unknown>>;
+    findings: Array<Record<string, unknown>>;
+    error?: string;
+  },
+}));
+
+vi.mock("@/lib/server/auth", () => ({ getServerUser }));
+vi.mock("@/lib/server/authorization", () => ({ authorizePlantAccess }));
+vi.mock("@/lib/server/db", () => ({
+  getDbClient: () => ({
+    from(table: string) {
+      const rows =
+        table === "plant_images"
+          ? dbState.images
+          : table === "plant_observations"
+            ? dbState.observations
+            : dbState.findings;
+      const result = {
+        data: rows,
+        error: dbState.error ? { message: dbState.error } : null,
+      };
+      const chain = {
+        select: () => chain,
+        eq: () => chain,
+        order: () => chain,
+        limit: () => Promise.resolve(result),
+      };
+      return chain;
+    },
+  }),
+}));
+
+import { GET } from "../route";
+
+function req(): Request {
+  return new Request("http://localhost/api/plants/p/timeline", {
+    method: "GET",
+  });
+}
+
+async function callGet(plantId: string) {
+  return GET(req() as unknown as import("next/server").NextRequest, {
+    params: Promise.resolve({ plantId }),
+  });
+}
+
+describe("GET /api/plants/[plantId]/timeline", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbState.images = [];
+    dbState.observations = [];
+    dbState.findings = [];
+    delete dbState.error;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getServerUser.mockResolvedValue(null);
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when user cannot access the plant", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue(null);
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns empty items when no records exist", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue({
+      plantId: "11111111-1111-1111-1111-111111111111",
+      growId: "22222222-2222-2222-2222-222222222222",
+      strain: null,
+      name: "P",
+    });
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: unknown[];
+      counts: { images: number };
+    };
+    expect(body.items).toEqual([]);
+    expect(body.counts.images).toBe(0);
+  });
+
+  it("merges and orders populated records by date desc", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue({
+      plantId: "p",
+      growId: "g",
+      strain: null,
+      name: "P",
+    });
+    dbState.images = [
+      {
+        id: "img1",
+        storage_path: "g/p/1.jpg",
+        taken_at: "2026-04-10T12:00:00Z",
+        source: "upload",
+        notes: null,
+        created_at: "2026-04-10T12:00:00Z",
+      },
+    ];
+    dbState.observations = [
+      {
+        id: "obs1",
+        observed_at: "2026-04-12T12:00:00Z",
+        height_cm: 30,
+        notes: "growing",
+        created_at: "2026-04-12T12:00:00Z",
+      },
+    ];
+    dbState.findings = [
+      {
+        id: "f1",
+        category: "positive",
+        severity: "info",
+        title: "Healthy",
+        description: "Looks good",
+        recommendation: null,
+        image_id: "img1",
+        created_at: "2026-04-11T12:00:00Z",
+      },
+    ];
+    const res = await callGet("11111111-1111-1111-1111-111111111111");
+    const body = (await res.json()) as {
+      items: Array<{ kind: string; at: string }>;
+    };
+    expect(body.items).toHaveLength(3);
+    expect(body.items[0]?.kind).toBe("observation");
+    expect(body.items[1]?.kind).toBe("finding");
+    expect(body.items[2]?.kind).toBe("image");
+  });
+});

--- a/apps/web/src/app/api/plants/[plantId]/timeline/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/timeline/route.ts
@@ -1,33 +1,127 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "@/lib/server/auth";
+import { getServerUser } from "@/lib/server/auth";
 import { getDbClient } from "@/lib/server/db";
+import { authorizePlantAccess } from "@/lib/server/authorization";
+import { correlationIdFromRequest } from "@/lib/server/logger";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
 
 interface RouteParams {
   params: Promise<{ plantId: string }>;
 }
 
-// GET /api/plants/[plantId]/timeline
-// Returns the ordered list of plant images + observations for a plant.
-export async function GET(
-  request: NextRequest,
-  { params }: RouteParams,
-) {
-  const session = await getServerSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+interface TimelineEntry {
+  kind: "image" | "observation" | "finding";
+  id: string;
+  at: string;
+  payload: Record<string, unknown>;
+}
+
+/**
+ * GET /api/plants/[plantId]/timeline
+ * Returns a merged, time-ordered list of plant_images, plant_observations,
+ * and plant_findings for the plant. Empty collections are returned as `[]`.
+ */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const requestId = correlationIdFromRequest(request);
+  const user = await getServerUser();
+  if (!user) return errJson("Unauthorized", 401, requestId);
 
   const { plantId } = await params;
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) return errJson("Plant not found", 404, requestId);
+
   const db = getDbClient();
 
-  // TODO: Verify user has access to this plant via grow_members RLS
-  // TODO: Query plant_images and plant_observations joined, ordered by takenAt/observedAt
+  const [imagesRes, obsRes, findingsRes] = await Promise.all([
+    db
+      .from("plant_images")
+      .select("id, storage_path, taken_at, source, notes, created_at")
+      .eq("plant_id", access.plantId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+    db
+      .from("plant_observations")
+      .select("id, observed_at, height_cm, notes, created_at")
+      .eq("plant_id", access.plantId)
+      .order("observed_at", { ascending: false })
+      .limit(50),
+    db
+      .from("plant_findings")
+      .select(
+        "id, category, severity, title, description, recommendation, image_id, created_at",
+      )
+      .eq("plant_id", access.plantId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+  ]);
 
-  void db; // placeholder until wired
+  if (imagesRes.error || obsRes.error || findingsRes.error) {
+    return errJson("Query failed", 500, requestId);
+  }
 
-  return NextResponse.json({
-    plantId,
-    items: [],
-    message: "TODO: Wire Supabase DB timeline query",
-  });
+  const items: TimelineEntry[] = [];
+
+  for (const img of imagesRes.data ?? []) {
+    items.push({
+      kind: "image",
+      id: img.id as string,
+      at: (img.taken_at as string | null) ?? (img.created_at as string),
+      payload: {
+        storagePath: img.storage_path as string,
+        source: img.source as string,
+        notes: (img.notes as string | null) ?? undefined,
+      },
+    });
+  }
+  for (const obs of obsRes.data ?? []) {
+    items.push({
+      kind: "observation",
+      id: obs.id as string,
+      at: (obs.observed_at as string) ?? (obs.created_at as string),
+      payload: {
+        heightCm: obs.height_cm ?? undefined,
+        notes: (obs.notes as string | null) ?? undefined,
+      },
+    });
+  }
+  for (const f of findingsRes.data ?? []) {
+    items.push({
+      kind: "finding",
+      id: f.id as string,
+      at: f.created_at as string,
+      payload: {
+        category: f.category,
+        severity: f.severity,
+        title: f.title,
+        description: f.description,
+        recommendation: (f.recommendation as string | null) ?? undefined,
+        imageId: (f.image_id as string | null) ?? undefined,
+      },
+    });
+  }
+
+  items.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));
+
+  return NextResponse.json(
+    {
+      plantId: access.plantId,
+      items: items.slice(0, 100),
+      counts: {
+        images: imagesRes.data?.length ?? 0,
+        observations: obsRes.data?.length ?? 0,
+        findings: findingsRes.data?.length ?? 0,
+      },
+      requestId,
+    },
+    { status: 200, headers: { "x-request-id": requestId } },
+  );
+}
+
+function errJson(message: string, status: number, requestId: string) {
+  return NextResponse.json(
+    { error: message, requestId },
+    { status, headers: { "x-request-id": requestId } },
+  );
 }

--- a/apps/web/src/app/api/uploads/sign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/uploads/sign/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+const { getServerUser, authorizePlantAccess, createSignedUploadUrl } =
+  vi.hoisted(() => ({
+    getServerUser: vi.fn(),
+    authorizePlantAccess: vi.fn(),
+    createSignedUploadUrl: vi.fn(),
+  }));
+
+vi.mock("@/lib/server/auth", () => ({
+  getServerUser,
+  getServerSession: vi.fn(),
+  createSupabaseServerClient: vi.fn(),
+}));
+vi.mock("@/lib/server/authorization", () => ({
+  authorizePlantAccess,
+  authorizeGrowAccess: vi.fn(),
+}));
+vi.mock("@/lib/server/storage", () => ({
+  getStorageClient: () => ({
+    from: () => ({ createSignedUploadUrl }),
+  }),
+}));
+
+import { POST } from "../route";
+
+function req(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://localhost/api/uploads/sign", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/uploads/sign", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getServerUser.mockResolvedValue(null);
+    const res = await POST(
+      req({
+        plantId: "11111111-1111-1111-1111-111111111111",
+        contentType: "image/jpeg",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for malformed body (missing plantId)", async () => {
+    getServerUser.mockResolvedValue({ id: "u1", email: "a@b" });
+    const res = await POST(
+      req({
+        contentType: "image/jpeg",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-uuid plantId", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    const res = await POST(
+      req({
+        plantId: "not-a-uuid",
+        contentType: "image/jpeg",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 415 for disallowed content types", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    const res = await POST(
+      req({
+        plantId: "11111111-1111-1111-1111-111111111111",
+        contentType: "application/pdf",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(415);
+  });
+
+  it("returns 404 when the user cannot access the plant", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue(null);
+    const res = await POST(
+      req({
+        plantId: "11111111-1111-1111-1111-111111111111",
+        contentType: "image/jpeg",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns a signed upload URL on success", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue({
+      plantId: "11111111-1111-1111-1111-111111111111",
+      growId: "22222222-2222-2222-2222-222222222222",
+      strain: "Blue Dream",
+      name: "Plant 1",
+    });
+    createSignedUploadUrl.mockResolvedValue({
+      data: { signedUrl: "https://s.example/upload?t=abc", token: "tok-xyz" },
+      error: null,
+    });
+    const res = await POST(
+      req({
+        plantId: "11111111-1111-1111-1111-111111111111",
+        contentType: "image/jpeg",
+        fileName: "IMG 12/34 weird!.JPG",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      bucket: string;
+      storagePath: string;
+      signedUrl: string;
+      token: string;
+    };
+    expect(body.bucket).toBe("plant-images");
+    expect(body.signedUrl).toContain("upload");
+    expect(body.token).toBe("tok-xyz");
+    expect(body.storagePath).toContain(
+      "22222222-2222-2222-2222-222222222222/11111111-1111-1111-1111-111111111111/",
+    );
+    expect(body.storagePath).not.toMatch(/[\s!]/);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+  });
+
+  it("returns 502 when Supabase returns an error", async () => {
+    getServerUser.mockResolvedValue({ id: "u1" });
+    authorizePlantAccess.mockResolvedValue({
+      plantId: "11111111-1111-1111-1111-111111111111",
+      growId: "22222222-2222-2222-2222-222222222222",
+      strain: null,
+      name: "P",
+    });
+    createSignedUploadUrl.mockResolvedValue({
+      data: null,
+      error: { message: "bucket not found" },
+    });
+    const res = await POST(
+      req({
+        plantId: "11111111-1111-1111-1111-111111111111",
+        contentType: "image/png",
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/api/uploads/sign/route.ts
+++ b/apps/web/src/app/api/uploads/sign/route.ts
@@ -1,53 +1,167 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "@/lib/server/auth";
+import { getServerUser } from "@/lib/server/auth";
 import { getStorageClient } from "@/lib/server/storage";
+import { authorizePlantAccess } from "@/lib/server/authorization";
+import { correlationIdFromRequest, createLogger } from "@/lib/server/logger";
 
-// POST /api/uploads/sign
-// Returns a short-lived Supabase Storage signed upload URL.
-// The browser uploads directly to Supabase; the signed URL is generated here
-// on the server so the service role key is never exposed.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export const PLANT_IMAGES_BUCKET = "plant-images";
+const ALLOWED_TYPES: ReadonlySet<string> = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+]);
+const EXT_BY_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/heic": "heic",
+};
+const MAX_FILENAME_LEN = 240;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * POST /api/uploads/sign
+ *
+ * Body: { plantId: uuid, contentType: string, fileName?: string }
+ *
+ * Returns a short-lived Supabase Storage signed upload URL scoped to a
+ * deterministic path under the private `plant-images` bucket. The browser uses
+ * the returned URL/token to upload directly to Supabase; the service role key
+ * never leaves the server.
+ */
 export async function POST(request: NextRequest) {
-  const session = await getServerSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const requestId = correlationIdFromRequest(request);
+  const log = createLogger({ route: "api.uploads.sign", requestId });
 
-  const body = (await request.json()) as {
-    plantId: string;
-    fileName: string;
-    contentType: string;
-  };
-
-  if (!body.plantId || !body.fileName || !body.contentType) {
+  const user = await getServerUser();
+  if (!user) {
     return NextResponse.json(
-      { error: "plantId, fileName, and contentType are required" },
-      { status: 400 },
+      { error: "Unauthorized", requestId },
+      { status: 401, headers: { "x-request-id": requestId } },
     );
   }
 
-  // Validate content type — images only
-  const allowedTypes = ["image/jpeg", "image/png", "image/webp", "image/heic"];
-  if (!allowedTypes.includes(body.contentType)) {
-    return NextResponse.json(
-      { error: "Unsupported content type" },
-      { status: 415 },
-    );
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonError("Invalid JSON body", 400, requestId);
   }
+
+  const parsed = parseBody(body);
+  if (!parsed.ok) return jsonError(parsed.error, 400, requestId);
+
+  const { plantId, contentType, fileName } = parsed.value;
+
+  if (!ALLOWED_TYPES.has(contentType)) {
+    return jsonError("Unsupported content type", 415, requestId);
+  }
+
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) {
+    return jsonError("Plant not found", 404, requestId);
+  }
+
+  const safeName = sanitizeFileName(fileName, contentType);
+  const storagePath = `${access.growId}/${plantId}/${Date.now()}-${crypto
+    .randomUUID()
+    .slice(0, 8)}-${safeName}`;
 
   const storage = getStorageClient();
-  const storagePath = `plants/${body.plantId}/${Date.now()}-${body.fileName}`;
+  const { data, error } = await storage
+    .from(PLANT_IMAGES_BUCKET)
+    .createSignedUploadUrl(storagePath);
 
-  // TODO: Replace with actual Supabase Storage createSignedUploadUrl call
-  // const { data, error } = await storage
-  //   .from("plant-images")
-  //   .createSignedUploadUrl(storagePath);
+  if (error || !data) {
+    log.error("createSignedUploadUrl failed", {
+      plantId,
+      error: error?.message,
+    });
+    return jsonError("Could not create upload URL", 502, requestId);
+  }
 
-  void storage; // placeholder until wired
-
-  return NextResponse.json({
-    storagePath,
-    // signedUrl: data.signedUrl,
-    // token: data.token,
-    message: "TODO: Wire Supabase Storage signed upload URL",
+  log.info("signed upload issued", {
+    plantId,
+    userId: user.id,
+    bucket: PLANT_IMAGES_BUCKET,
   });
+
+  return NextResponse.json(
+    {
+      bucket: PLANT_IMAGES_BUCKET,
+      storagePath,
+      signedUrl: data.signedUrl,
+      token: data.token,
+      contentType,
+      requestId,
+    },
+    { status: 200, headers: { "x-request-id": requestId } },
+  );
+}
+
+type ParsedBody = {
+  plantId: string;
+  contentType: string;
+  fileName: string | undefined;
+};
+
+function parseBody(
+  value: unknown,
+): { ok: true; value: ParsedBody } | { ok: false; error: string } {
+  if (!value || typeof value !== "object") {
+    return { ok: false, error: "body must be an object" };
+  }
+  const v = value as Record<string, unknown>;
+
+  const plantId = v["plantId"];
+  if (typeof plantId !== "string" || !UUID_RE.test(plantId)) {
+    return { ok: false, error: "plantId must be a uuid" };
+  }
+  const contentType = v["contentType"];
+  if (typeof contentType !== "string" || contentType.length > 128) {
+    return { ok: false, error: "contentType is required" };
+  }
+  const fileName = v["fileName"];
+  if (
+    fileName !== undefined &&
+    (typeof fileName !== "string" || fileName.length > MAX_FILENAME_LEN)
+  ) {
+    return { ok: false, error: "fileName is invalid" };
+  }
+  return {
+    ok: true,
+    value: {
+      plantId,
+      contentType,
+      fileName: typeof fileName === "string" ? fileName : undefined,
+    },
+  };
+}
+
+function sanitizeFileName(
+  fileName: string | undefined,
+  contentType: string,
+): string {
+  const ext = EXT_BY_TYPE[contentType] ?? "bin";
+  if (!fileName) return `upload.${ext}`;
+  const base = fileName.split(/[\\/]/).pop() ?? "upload";
+  const cleaned = base.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120);
+  if (!cleaned) return `upload.${ext}`;
+  return cleaned.includes(".") ? cleaned : `${cleaned}.${ext}`;
+}
+
+function jsonError(
+  message: string,
+  status: number,
+  requestId: string,
+): NextResponse {
+  return NextResponse.json(
+    { error: message, requestId },
+    { status, headers: { "x-request-id": requestId } },
+  );
 }

--- a/apps/web/src/app/assistant/assistant-chat.tsx
+++ b/apps/web/src/app/assistant/assistant-chat.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+interface GrowOption {
+  id: string;
+  name: string;
+}
+
+interface ChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+}
+
+interface Props {
+  grows: GrowOption[];
+}
+
+export function AssistantChat({ grows }: Props) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [threadId, setThreadId] = useState<string | null>(null);
+  const [growId, setGrowId] = useState<string>(grows[0]?.id ?? "");
+  const [input, setInput] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  const send = useCallback(async () => {
+    const text = input.trim();
+    if (!text || busy) return;
+    setError(null);
+    setBusy(true);
+
+    const localUser: ChatMessage = {
+      id: `local-${Date.now()}`,
+      role: "user",
+      content: text,
+      createdAt: new Date().toISOString(),
+    };
+    setMessages((prev) => [...prev, localUser]);
+    setInput("");
+
+    try {
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          threadId: threadId ?? undefined,
+          growId: threadId ? undefined : growId || undefined,
+        }),
+      });
+      if (!res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const j = (await res.json()) as { error?: string };
+          if (j.error) detail = j.error;
+        } catch {
+          // ignore json parse error
+        }
+        setError(detail);
+        return;
+      }
+      const data = (await res.json()) as {
+        threadId: string;
+        message: ChatMessage;
+      };
+      setThreadId(data.threadId);
+      setMessages((prev) => [...prev, data.message]);
+      setTimeout(
+        () => endRef.current?.scrollIntoView({ behavior: "smooth" }),
+        0,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Network error");
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, input, threadId, growId]);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    void send();
+  };
+
+  return (
+    <>
+      <div className="flex-1 overflow-y-auto px-4 py-6">
+        <div className="mx-auto max-w-2xl space-y-4">
+          {messages.length === 0 ? (
+            <div className="flex gap-3">
+              <Avatar role="assistant" />
+              <Bubble role="assistant">
+                Hello! I&apos;m your grow copilot.
+                {grows.length > 0
+                  ? " Pick a grow below and ask me anything about it."
+                  : " You don't have any grows linked yet, so I can only answer general questions."}
+              </Bubble>
+            </div>
+          ) : (
+            messages.map((m) => (
+              <div
+                key={m.id}
+                className={`flex gap-3 ${m.role === "user" ? "justify-end" : ""}`}
+              >
+                {m.role === "assistant" ? <Avatar role="assistant" /> : null}
+                <Bubble role={m.role}>{m.content}</Bubble>
+                {m.role === "user" ? <Avatar role="user" /> : null}
+              </div>
+            ))
+          )}
+          {busy ? (
+            <div className="flex gap-3">
+              <Avatar role="assistant" />
+              <Bubble role="assistant">Thinking…</Bubble>
+            </div>
+          ) : null}
+          {error ? (
+            <p className="text-center text-xs text-red-600" role="alert">
+              {error}
+            </p>
+          ) : null}
+          <div ref={endRef} />
+        </div>
+      </div>
+
+      <form onSubmit={onSubmit} className="border-t bg-white px-4 py-4">
+        <div className="mx-auto flex max-w-2xl flex-col gap-2">
+          {grows.length > 0 && !threadId ? (
+            <label className="flex items-center gap-2 text-xs text-gray-500">
+              Grounded in:
+              <select
+                className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs"
+                value={growId}
+                onChange={(e) => setGrowId(e.target.value)}
+                disabled={busy}
+              >
+                <option value="">No grow (general advice)</option>
+                {grows.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              placeholder="Ask about your grow…"
+              className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm focus:border-brand-400 focus:outline-none focus:ring-1 focus:ring-brand-400"
+              disabled={busy}
+            />
+            <button
+              type="submit"
+              className="rounded-xl bg-brand-600 px-5 py-3 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
+              disabled={busy || !input.trim()}
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      </form>
+    </>
+  );
+}
+
+function Avatar({ role }: { role: "user" | "assistant" }) {
+  if (role === "assistant") {
+    return (
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-xs font-bold text-brand-600">
+        AI
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200 text-xs font-bold text-gray-600">
+      You
+    </div>
+  );
+}
+
+function Bubble({
+  role,
+  children,
+}: {
+  role: "user" | "assistant";
+  children: React.ReactNode;
+}) {
+  const base = "whitespace-pre-wrap rounded-2xl px-4 py-3 text-sm max-w-lg";
+  if (role === "assistant") {
+    return (
+      <div className={`${base} rounded-tl-none border bg-white text-gray-700`}>
+        {children}
+      </div>
+    );
+  }
+  return (
+    <div className={`${base} rounded-tr-none bg-brand-600 text-white`}>
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/app/assistant/page.tsx
+++ b/apps/web/src/app/assistant/page.tsx
@@ -1,19 +1,71 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getServerUser } from "@/lib/server/auth";
+import { getDbClient } from "@/lib/server/db";
+import { AssistantChat } from "./assistant-chat";
 
 export const metadata: Metadata = { title: "Assistant" };
+export const dynamic = "force-dynamic";
 
-export default function AssistantPage() {
+interface GrowOption {
+  id: string;
+  name: string;
+}
+
+export default async function AssistantPage() {
+  const user = await getServerUser();
+  if (!user) redirect("/auth?next=/assistant");
+
+  const db = getDbClient();
+  const [ownedRes, memberRes] = await Promise.all([
+    db
+      .from("grows")
+      .select("id, name")
+      .eq("owner_id", user.id)
+      .eq("is_archived", false)
+      .order("created_at", { ascending: false })
+      .limit(20),
+    db
+      .from("grow_members")
+      .select("grow_id, grows(id, name, is_archived)")
+      .eq("user_id", user.id),
+  ]);
+
+  const owned = ((ownedRes.data ?? []) as GrowOption[]).map((g) => ({
+    id: g.id,
+    name: g.name,
+  }));
+
+  const memberRows = (memberRes.data ?? []) as unknown as Array<{
+    grows:
+      | { id: string; name: string; is_archived: boolean }
+      | { id: string; name: string; is_archived: boolean }[]
+      | null;
+  }>;
+  const memberOf: GrowOption[] = memberRows.flatMap((r) => {
+    const rows = Array.isArray(r.grows) ? r.grows : r.grows ? [r.grows] : [];
+    return rows
+      .filter((g) => !g.is_archived)
+      .map((g) => ({ id: g.id, name: g.name }));
+  });
+
+  const seen = new Set<string>();
+  const grows: GrowOption[] = [];
+  for (const g of [...owned, ...memberOf]) {
+    if (!seen.has(g.id)) {
+      seen.add(g.id);
+      grows.push(g);
+    }
+  }
+
   return (
     <main className="flex h-screen flex-col">
-      {/* Header */}
-      <header className="border-b bg-white px-6 py-4 flex items-center justify-between">
+      <header className="flex items-center justify-between border-b bg-white px-6 py-4">
         <div>
-          <h1 className="text-lg font-semibold text-gray-900">
-            Grow Copilot
-          </h1>
+          <h1 className="text-lg font-semibold text-gray-900">Grow Copilot</h1>
           <p className="text-xs text-gray-400">
-            AI assistant scoped to your grow
+            AI assistant grounded in your grow data
           </p>
         </div>
         <Link
@@ -24,42 +76,7 @@ export default function AssistantPage() {
         </Link>
       </header>
 
-      {/* Messages area */}
-      <div className="flex-1 overflow-y-auto px-4 py-6">
-        <div className="mx-auto max-w-2xl space-y-4">
-          {/* AI welcome message */}
-          <div className="flex gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-600 text-sm font-bold">
-              AI
-            </div>
-            <div className="rounded-2xl rounded-tl-none bg-white border px-4 py-3 text-sm text-gray-700 max-w-lg">
-              Hello! I&apos;m your grow copilot. I have access to your plants,
-              timeline, and observations. Ask me anything about your grow.
-            </div>
-          </div>
-
-          {/* TODO: Render ChatMessage list from /api/chat thread */}
-        </div>
-      </div>
-
-      {/* Input area */}
-      <div className="border-t bg-white px-4 py-4">
-        <div className="mx-auto flex max-w-2xl gap-2">
-          {/* TODO: Wire to POST /api/chat with streaming */}
-          <input
-            type="text"
-            placeholder="Ask about your grow..."
-            className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm focus:border-brand-400 focus:outline-none focus:ring-1 focus:ring-brand-400"
-            disabled
-          />
-          <button
-            className="rounded-xl bg-brand-600 px-5 py-3 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
-            disabled
-          >
-            Send
-          </button>
-        </div>
-      </div>
+      <AssistantChat grows={grows} />
     </main>
   );
 }

--- a/apps/web/src/app/plants/[plantId]/page.tsx
+++ b/apps/web/src/app/plants/[plantId]/page.tsx
@@ -1,72 +1,242 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { getServerUser } from "@/lib/server/auth";
+import { authorizePlantAccess } from "@/lib/server/authorization";
+import { getDbClient } from "@/lib/server/db";
+import { getSignedImageUrl } from "@/lib/server/storage";
+import { PhotoUploader } from "./photo-uploader";
 
-export const metadata: Metadata = { title: "Plant Detail" };
+export const metadata: Metadata = { title: "Plant" };
+export const dynamic = "force-dynamic";
 
 interface Props {
   params: Promise<{ plantId: string }>;
 }
 
+interface ImageRow {
+  id: string;
+  storage_path: string;
+  created_at: string;
+  taken_at: string | null;
+}
+
+interface AnalysisRow {
+  overall_health_score: number;
+  summary: string;
+  model_version: string;
+  analyzed_at: string;
+  image_id: string;
+  comparison_summary: string | null;
+}
+
+interface FindingRow {
+  category: string;
+  severity: string;
+  title: string;
+  description: string;
+  recommendation: string | null;
+  created_at: string;
+}
+
 export default async function PlantPage({ params }: Props) {
   const { plantId } = await params;
+  const user = await getServerUser();
+  if (!user) redirect(`/auth?next=/plants/${plantId}`);
+
+  const access = await authorizePlantAccess(user.id, plantId);
+  if (!access) notFound();
+
+  const db = getDbClient();
+  const [imagesRes, analysisRes] = await Promise.all([
+    db
+      .from("plant_images")
+      .select("id, storage_path, created_at, taken_at")
+      .eq("plant_id", access.plantId)
+      .order("created_at", { ascending: false })
+      .limit(12),
+    db
+      .from("plant_analyses")
+      .select(
+        "overall_health_score, summary, model_version, analyzed_at, image_id, comparison_summary",
+      )
+      .eq("plant_id", access.plantId)
+      .order("analyzed_at", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+  const images = (imagesRes.data ?? []) as ImageRow[];
+  const analysis = (analysisRes.data ?? null) as AnalysisRow | null;
+
+  let findings: FindingRow[] = [];
+  if (analysis) {
+    const { data } = await db
+      .from("plant_findings")
+      .select(
+        "category, severity, title, description, recommendation, created_at",
+      )
+      .eq("image_id", analysis.image_id)
+      .order("severity", { ascending: false });
+    findings = (data ?? []) as FindingRow[];
+  }
+
+  const signedImages = await Promise.all(
+    images.map(async (img) => ({
+      id: img.id,
+      createdAt: img.created_at,
+      url: await getSignedImageUrl(img.storage_path),
+    })),
+  );
 
   return (
     <main className="mx-auto max-w-5xl px-6 py-10">
       <div className="mb-6">
-        <Link href="/grows" className="text-sm text-gray-500 hover:text-gray-700">
+        <Link
+          href="/grows"
+          className="text-sm text-gray-500 hover:text-gray-700"
+        >
           ← Back to grows
         </Link>
       </div>
 
-      <h1 className="mb-2 text-2xl font-bold text-gray-900">Plant</h1>
-      <p className="mb-8 text-sm text-gray-400">ID: {plantId}</p>
+      <h1 className="mb-2 text-2xl font-bold text-gray-900">
+        {access.name || "Plant"}
+      </h1>
+      <p className="mb-8 text-sm text-gray-400">
+        {access.strain ? `Strain: ${access.strain}` : "No strain recorded"} ·
+        ID: <span className="font-mono text-xs">{plantId}</span>
+      </p>
 
       <div className="grid gap-6 lg:grid-cols-3">
-        {/* Timeline column */}
         <div className="lg:col-span-2 space-y-4">
-          <div className="rounded-xl border bg-white p-6">
+          <section className="rounded-xl border bg-white p-6">
             <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              Photo Timeline
+              Photo timeline
             </h2>
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-10 text-center text-sm text-gray-400">
-              {/* TODO: Render plant_images ordered by takenAt */}
-              No photos yet. Upload the first photo.
-            </div>
-          </div>
+            {signedImages.length === 0 ? (
+              <div className="rounded-lg border-2 border-dashed border-gray-200 p-10 text-center text-sm text-gray-400">
+                No photos yet. Upload your first photo on the right.
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {signedImages.map((img) => (
+                  <figure
+                    key={img.id}
+                    className="overflow-hidden rounded-lg border bg-gray-50"
+                  >
+                    {img.url ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img
+                        src={img.url}
+                        alt="Plant photo"
+                        className="h-32 w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-32 items-center justify-center text-xs text-gray-400">
+                        Image unavailable
+                      </div>
+                    )}
+                    <figcaption className="px-2 py-1 text-xs text-gray-500">
+                      {new Date(img.createdAt).toLocaleString()}
+                    </figcaption>
+                  </figure>
+                ))}
+              </div>
+            )}
+          </section>
 
-          <div className="rounded-xl border bg-white p-6">
+          <section className="rounded-xl border bg-white p-6">
             <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              AI Analysis
+              AI analysis
             </h2>
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-10 text-center text-sm text-gray-400">
-              {/* TODO: Render latest AnalysisResponse */}
-              Upload a photo to trigger analysis.
-            </div>
-          </div>
+            {analysis ? (
+              <div className="space-y-3">
+                <div className="flex items-baseline justify-between">
+                  <span className="text-3xl font-bold text-gray-900">
+                    {Number(analysis.overall_health_score).toFixed(1)}
+                    <span className="ml-1 text-sm text-gray-400">/ 100</span>
+                  </span>
+                  <span className="text-xs text-gray-400">
+                    {new Date(analysis.analyzed_at).toLocaleString()} ·{" "}
+                    {analysis.model_version}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-700">{analysis.summary}</p>
+                {analysis.comparison_summary ? (
+                  <p className="text-sm italic text-gray-500">
+                    {analysis.comparison_summary}
+                  </p>
+                ) : null}
+              </div>
+            ) : (
+              <div className="rounded-lg border-2 border-dashed border-gray-200 p-10 text-center text-sm text-gray-400">
+                Upload a photo to trigger analysis.
+              </div>
+            )}
+          </section>
         </div>
 
-        {/* Sidebar */}
         <div className="space-y-4">
-          <div className="rounded-xl border bg-white p-6">
+          <section className="rounded-xl border bg-white p-6">
             <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              Upload Photo
+              Upload photo
             </h2>
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-8 text-center text-sm text-gray-400">
-              {/* TODO: Wire upload to /api/uploads/sign → Supabase Storage */}
-              Photo upload component
-            </div>
-          </div>
+            <PhotoUploader plantId={access.plantId} />
+          </section>
 
-          <div className="rounded-xl border bg-white p-6">
+          <section className="rounded-xl border bg-white p-6">
             <h2 className="mb-4 text-lg font-semibold text-gray-900">
               Findings
             </h2>
-            <p className="text-sm text-gray-400">
-              No findings yet.
-            </p>
-          </div>
+            {findings.length === 0 ? (
+              <p className="text-sm text-gray-400">No findings yet.</p>
+            ) : (
+              <ul className="space-y-3">
+                {findings.map((f, i) => (
+                  <li
+                    key={`${f.title}-${i}`}
+                    className="rounded-lg border border-gray-100 p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm font-semibold text-gray-800">
+                        {f.title}
+                      </span>
+                      <span className={severityBadgeClass(f.severity)}>
+                        {f.severity}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-gray-600">
+                      {f.description}
+                    </p>
+                    {f.recommendation ? (
+                      <p className="mt-1 text-xs text-brand-700">
+                        Rec: {f.recommendation}
+                      </p>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
         </div>
       </div>
     </main>
   );
+}
+
+function severityBadgeClass(severity: string): string {
+  const base = "rounded px-2 py-0.5 text-[10px] font-semibold uppercase";
+  switch (severity) {
+    case "critical":
+      return `${base} bg-red-100 text-red-700`;
+    case "high":
+      return `${base} bg-orange-100 text-orange-700`;
+    case "medium":
+      return `${base} bg-yellow-100 text-yellow-700`;
+    case "low":
+      return `${base} bg-blue-100 text-blue-700`;
+    default:
+      return `${base} bg-gray-100 text-gray-600`;
+  }
 }

--- a/apps/web/src/app/plants/[plantId]/photo-uploader.tsx
+++ b/apps/web/src/app/plants/[plantId]/photo-uploader.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+interface Props {
+  plantId: string;
+}
+
+type UIState =
+  | { kind: "idle" }
+  | { kind: "signing" }
+  | { kind: "uploading" }
+  | { kind: "registering" }
+  | { kind: "analyzing" }
+  | { kind: "done" }
+  | { kind: "error"; message: string };
+
+const ALLOWED = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+]);
+
+export function PhotoUploader({ plantId }: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [state, setState] = useState<UIState>({ kind: "idle" });
+  const router = useRouter();
+
+  const handle = useCallback(
+    async (file: File) => {
+      if (!ALLOWED.has(file.type)) {
+        setState({ kind: "error", message: "Unsupported image type" });
+        return;
+      }
+      if (file.size > 15 * 1024 * 1024) {
+        setState({ kind: "error", message: "Image is larger than 15 MB" });
+        return;
+      }
+
+      setState({ kind: "signing" });
+      const signRes = await fetch("/api/uploads/sign", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          plantId,
+          contentType: file.type,
+          fileName: file.name,
+        }),
+      });
+      if (!signRes.ok) {
+        const err = await safeText(signRes);
+        setState({ kind: "error", message: `Could not sign upload: ${err}` });
+        return;
+      }
+      const signed = (await signRes.json()) as {
+        signedUrl: string;
+        token: string;
+        storagePath: string;
+      };
+
+      setState({ kind: "uploading" });
+      const put = await fetch(signed.signedUrl, {
+        method: "PUT",
+        headers: { "Content-Type": file.type },
+        body: file,
+      });
+      if (!put.ok) {
+        const err = await safeText(put);
+        setState({ kind: "error", message: `Upload failed: ${err}` });
+        return;
+      }
+
+      setState({ kind: "registering" });
+      const register = await fetch(`/api/plants/${plantId}/images`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ storagePath: signed.storagePath }),
+      });
+      if (!register.ok) {
+        const err = await safeText(register);
+        setState({
+          kind: "error",
+          message: `Could not save image record: ${err}`,
+        });
+        return;
+      }
+      const registered = (await register.json()) as {
+        image: { id: string };
+      };
+
+      setState({ kind: "analyzing" });
+      const analyze = await fetch(`/api/plants/${plantId}/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ imageId: registered.image.id }),
+      });
+      if (!analyze.ok) {
+        const err = await safeText(analyze);
+        setState({
+          kind: "error",
+          message: `Analysis failed: ${err}`,
+        });
+        router.refresh();
+        return;
+      }
+
+      setState({ kind: "done" });
+      router.refresh();
+    },
+    [plantId, router],
+  );
+
+  const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handle(file);
+  };
+
+  const statusMessage = (() => {
+    switch (state.kind) {
+      case "signing":
+        return "Requesting upload URL…";
+      case "uploading":
+        return "Uploading image…";
+      case "registering":
+        return "Saving image record…";
+      case "analyzing":
+        return "Running AI analysis…";
+      case "done":
+        return "Analysis complete.";
+      case "error":
+        return state.message;
+      default:
+        return "Choose a photo to upload.";
+    }
+  })();
+
+  return (
+    <div className="space-y-3">
+      <input
+        ref={inputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/heic"
+        className="hidden"
+        onChange={onInputChange}
+      />
+      <button
+        type="button"
+        className="w-full rounded-lg bg-brand-600 px-4 py-3 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-60"
+        onClick={() => inputRef.current?.click()}
+        disabled={
+          state.kind === "signing" ||
+          state.kind === "uploading" ||
+          state.kind === "registering" ||
+          state.kind === "analyzing"
+        }
+      >
+        Upload plant photo
+      </button>
+      <p
+        className={`text-xs ${
+          state.kind === "error" ? "text-red-600" : "text-gray-500"
+        }`}
+        role={state.kind === "error" ? "alert" : undefined}
+      >
+        {statusMessage}
+      </p>
+    </div>
+  );
+}
+
+async function safeText(r: Response): Promise<string> {
+  try {
+    const j = (await r.json()) as { error?: string };
+    return j.error ?? `HTTP ${r.status}`;
+  } catch {
+    return `HTTP ${r.status}`;
+  }
+}

--- a/apps/web/src/lib/server/__tests__/analysis-proxy.test.ts
+++ b/apps/web/src/lib/server/__tests__/analysis-proxy.test.ts
@@ -7,7 +7,12 @@ import {
   vi,
   type MockInstance,
 } from "vitest";
-import { analyzeImage, callAnalysisService } from "../analysis-proxy";
+import {
+  AnalysisServiceError,
+  analyzeImage,
+  callAnalysisService,
+  mapAnalysisResponse,
+} from "../analysis-proxy";
 
 const ORIGINAL_ENV = process.env;
 
@@ -50,6 +55,15 @@ describe("analysis-proxy", () => {
     );
   });
 
+  it("propagates x-request-id when provided", async () => {
+    mockOk({ ok: true });
+    await callAnalysisService({ endpoint: "/status", requestId: "req-123" });
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)["x-request-id"]).toBe(
+      "req-123",
+    );
+  });
+
   it("serializes the body on POST", async () => {
     mockOk({ ok: true });
     await callAnalysisService({
@@ -62,35 +76,79 @@ describe("analysis-proxy", () => {
     expect(init.body).toBe('{"a":1}');
   });
 
-  it("analyzeImage calls /analyze with the expected payload", async () => {
+  it("analyzeImage sends snake_case and maps snake_case response to camelCase", async () => {
     mockOk({
-      plantId: "p1",
-      imageId: "i1",
-      overallHealthScore: 80,
-      summary: "",
-      findings: [],
-      analyzedAt: "2026-04-01T00:00:00Z",
-      modelVersion: "v1",
+      plant_id: "p1",
+      image_id: "i1",
+      overall_health_score: 80,
+      summary: "healthy",
+      findings: [
+        {
+          category: "positive",
+          severity: "info",
+          title: "Healthy",
+          description: "Looks good",
+          recommendation: null,
+        },
+      ],
+      compared_to_image_id: null,
+      comparison_summary: null,
+      analyzed_at: "2026-04-01T00:00:00Z",
+      model_version: "v1",
     });
-    await analyzeImage({
+
+    const result = await analyzeImage({
       plantId: "p1",
       imageId: "i1",
       storagePath: "plants/p1/i1.jpg",
-      growContext: { stage: "vegetative" },
+      growContext: { growId: "g1", stage: "vegetative" },
     });
+
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
     expect(url).toBe("https://analysis.example.com/analyze");
     expect(init.method).toBe("POST");
-    expect(JSON.parse(init.body as string)).toMatchObject({
-      plantId: "p1",
-      imageId: "i1",
-    });
+    const sent = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(sent["plant_id"]).toBe("p1");
+    expect(sent["image_id"]).toBe("i1");
+    expect(sent["storage_path"]).toBe("plants/p1/i1.jpg");
+    expect((sent["grow_context"] as Record<string, unknown>)["grow_id"]).toBe(
+      "g1",
+    );
+
+    expect(result.plantId).toBe("p1");
+    expect(result.imageId).toBe("i1");
+    expect(result.overallHealthScore).toBe(80);
+    expect(result.findings[0]?.category).toBe("positive");
+    expect(result.comparedToImageId).toBeUndefined();
   });
 
-  it("throws with status code when the upstream errors", async () => {
+  it("mapAnalysisResponse preserves comparison fields when present", () => {
+    const mapped = mapAnalysisResponse({
+      plant_id: "p1",
+      image_id: "i2",
+      overall_health_score: 90,
+      summary: "improved",
+      findings: [],
+      compared_to_image_id: "i1",
+      comparison_summary: "less yellow",
+      analyzed_at: "2026-04-01T00:00:00Z",
+      model_version: "v1",
+    });
+    expect(mapped.comparedToImageId).toBe("i1");
+    expect(mapped.comparisonSummary).toBe("less yellow");
+  });
+
+  it("throws AnalysisServiceError with status code when the upstream errors", async () => {
     fetchSpy.mockResolvedValue(new Response("boom", { status: 502 }));
-    await expect(callAnalysisService({ endpoint: "/broken" })).rejects.toThrow(
-      /502/,
+    await expect(
+      callAnalysisService({ endpoint: "/broken" }),
+    ).rejects.toBeInstanceOf(AnalysisServiceError);
+  });
+
+  it("wraps network errors as AnalysisServiceError(502)", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+    await expect(callAnalysisService({ endpoint: "/x" })).rejects.toMatchObject(
+      { status: 502 },
     );
   });
 });

--- a/apps/web/src/lib/server/analysis-proxy.ts
+++ b/apps/web/src/lib/server/analysis-proxy.ts
@@ -1,12 +1,29 @@
 import "server-only";
-import type { AnalysisResponse } from "@phenosage/shared";
+import type { AnalysisFinding, AnalysisResponse } from "@phenosage/shared";
 import { getAnalysisServiceConfig } from "./analysis-config";
+import { createLogger } from "./logger";
 
 interface ProxyOptions {
   endpoint: string;
   method?: "GET" | "POST";
   body?: unknown;
+  requestId?: string;
+  signal?: AbortSignal;
 }
+
+export class AnalysisServiceError extends Error {
+  public readonly status: number;
+  public readonly detail?: string;
+  constructor(message: string, status: number, detail?: string) {
+    super(message);
+    this.name = "AnalysisServiceError";
+    this.status = status;
+    if (detail !== undefined) this.detail = detail;
+  }
+}
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const log = createLogger({ component: "analysis-proxy" });
 
 /**
  * Proxy client for the Railway analysis service.
@@ -17,42 +34,150 @@ export async function callAnalysisService<T = unknown>(
   options: ProxyOptions,
 ): Promise<T> {
   const { url, apiKey } = getAnalysisServiceConfig();
-  const { endpoint, method = "GET", body } = options;
+  const { endpoint, method = "GET", body, requestId, signal } = options;
 
-  const init: RequestInit = {
-    method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${apiKey}`,
   };
+  if (requestId) headers["x-request-id"] = requestId;
+
+  const init: RequestInit = { method, headers };
   if (body !== undefined) {
     init.body = JSON.stringify(body);
   }
 
-  const response = await fetch(`${url}${endpoint}`, init);
+  const timeout = new AbortController();
+  const timer = setTimeout(() => timeout.abort(), DEFAULT_TIMEOUT_MS);
+  init.signal = signal ?? timeout.signal;
 
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`Analysis service error ${response.status}: ${text}`);
+  try {
+    const response = await fetch(`${url}${endpoint}`, init);
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      log.warn("analysis service error", {
+        endpoint,
+        status: response.status,
+        requestId,
+      });
+      throw new AnalysisServiceError(
+        `Analysis service error ${response.status}: ${text.slice(0, 500)}`,
+        response.status,
+        text.slice(0, 500),
+      );
+    }
+    return (await response.json()) as T;
+  } catch (err) {
+    if (err instanceof AnalysisServiceError) throw err;
+    const cause = err as { name?: string; message?: string };
+    if (cause?.name === "AbortError") {
+      throw new AnalysisServiceError("Analysis service timeout", 504);
+    }
+    throw new AnalysisServiceError(
+      `Analysis service unreachable: ${cause?.message ?? "unknown"}`,
+      502,
+    );
+  } finally {
+    clearTimeout(timer);
   }
-
-  return response.json() as Promise<T>;
 }
 
-/**
- * Submit a plant image for analysis.
- */
-export async function analyzeImage(params: {
+interface AnalyzeParams {
   plantId: string;
   imageId: string;
   storagePath: string;
-  growContext: Record<string, unknown>;
+  growContext: {
+    growId: string;
+    strain?: string | null;
+    stage?: string | null;
+    medium?: string | null;
+    lightType?: string | null;
+    daysSinceStart?: number | null;
+    notes?: string | null;
+  };
   previousImageId?: string;
-}): Promise<AnalysisResponse> {
-  return callAnalysisService<AnalysisResponse>({
-    endpoint: "/analyze",
-    method: "POST",
-    body: params,
-  });
+  previousStoragePath?: string;
+  requestId?: string;
+}
+
+interface RawAnalysisResponse {
+  plant_id: string;
+  image_id: string;
+  overall_health_score: number;
+  summary: string;
+  findings: RawAnalysisFinding[];
+  compared_to_image_id?: string | null;
+  comparison_summary?: string | null;
+  analyzed_at: string;
+  model_version: string;
+}
+
+interface RawAnalysisFinding {
+  category: AnalysisFinding["category"];
+  severity: AnalysisFinding["severity"];
+  title: string;
+  description: string;
+  recommendation?: string | null;
+}
+
+/**
+ * Submit a plant image for analysis. Maps camelCase (web) ↔ snake_case (service).
+ */
+export async function analyzeImage(
+  params: AnalyzeParams,
+): Promise<AnalysisResponse> {
+  const body = {
+    plant_id: params.plantId,
+    image_id: params.imageId,
+    storage_path: params.storagePath,
+    previous_image_id: params.previousImageId ?? null,
+    previous_storage_path: params.previousStoragePath ?? null,
+    grow_context: {
+      grow_id: params.growContext.growId,
+      strain: params.growContext.strain ?? null,
+      stage: params.growContext.stage ?? null,
+      medium: params.growContext.medium ?? null,
+      light_type: params.growContext.lightType ?? null,
+      days_since_start: params.growContext.daysSinceStart ?? null,
+      notes: params.growContext.notes ?? null,
+    },
+  };
+
+  const opts: ProxyOptions = { endpoint: "/analyze", method: "POST", body };
+  if (params.requestId !== undefined) opts.requestId = params.requestId;
+  const raw = await callAnalysisService<RawAnalysisResponse>(opts);
+
+  return mapAnalysisResponse(raw);
+}
+
+export function mapAnalysisResponse(
+  raw: RawAnalysisResponse,
+): AnalysisResponse {
+  const response: AnalysisResponse = {
+    plantId: raw.plant_id,
+    imageId: raw.image_id,
+    overallHealthScore: raw.overall_health_score,
+    summary: raw.summary,
+    findings: raw.findings.map(mapFinding),
+    analyzedAt: raw.analyzed_at,
+    modelVersion: raw.model_version,
+  };
+  if (raw.compared_to_image_id) {
+    response.comparedToImageId = raw.compared_to_image_id;
+  }
+  if (raw.comparison_summary) {
+    response.comparisonSummary = raw.comparison_summary;
+  }
+  return response;
+}
+
+function mapFinding(raw: RawAnalysisFinding): AnalysisFinding {
+  const finding: AnalysisFinding = {
+    category: raw.category,
+    severity: raw.severity,
+    title: raw.title,
+    description: raw.description,
+  };
+  if (raw.recommendation) finding.recommendation = raw.recommendation;
+  return finding;
 }

--- a/apps/web/src/lib/server/authorization.ts
+++ b/apps/web/src/lib/server/authorization.ts
@@ -1,0 +1,129 @@
+import "server-only";
+import { getDbClient } from "./db";
+
+export interface PlantAccess {
+  plantId: string;
+  growId: string;
+  strain: string | null;
+  name: string;
+}
+
+export interface GrowAccess {
+  growId: string;
+  ownerId: string;
+  role: "owner" | "collaborator" | "viewer";
+  name: string;
+  stage: string;
+  medium: string;
+  lightType: string;
+  startDate: string;
+  strain: string | null;
+}
+
+/**
+ * Verify the user can access a plant (owner or grow member).
+ * Returns null when the plant doesn't exist or the user has no access.
+ * Uses service role to resolve plant→grow, then checks membership explicitly.
+ */
+export async function authorizePlantAccess(
+  userId: string,
+  plantId: string,
+): Promise<PlantAccess | null> {
+  if (!isLikelyUuid(plantId)) return null;
+  const db = getDbClient();
+
+  const { data: plant, error } = await db
+    .from("plants")
+    .select("id, grow_id, strain, name")
+    .eq("id", plantId)
+    .maybeSingle();
+
+  if (error || !plant) return null;
+
+  const growId = plant.grow_id as string;
+  const ok = await userCanReadGrow(userId, growId);
+  if (!ok) return null;
+
+  return {
+    plantId: plant.id as string,
+    growId,
+    strain: (plant.strain as string | null) ?? null,
+    name: (plant.name as string) ?? "",
+  };
+}
+
+export async function authorizeGrowAccess(
+  userId: string,
+  growId: string,
+): Promise<GrowAccess | null> {
+  if (!isLikelyUuid(growId)) return null;
+  const db = getDbClient();
+
+  const { data: grow, error } = await db
+    .from("grows")
+    .select(
+      "id, owner_id, name, stage, medium, light_type, start_date, description",
+    )
+    .eq("id", growId)
+    .maybeSingle();
+
+  if (error || !grow) return null;
+
+  const isOwner = grow.owner_id === userId;
+  let role: "owner" | "collaborator" | "viewer" | null = isOwner
+    ? "owner"
+    : null;
+
+  if (!isOwner) {
+    const { data: member } = await db
+      .from("grow_members")
+      .select("role")
+      .eq("grow_id", growId)
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (!member) return null;
+    role = (member.role as "collaborator" | "viewer") ?? "viewer";
+  }
+
+  return {
+    growId: grow.id as string,
+    ownerId: grow.owner_id as string,
+    role: role ?? "viewer",
+    name: grow.name as string,
+    stage: grow.stage as string,
+    medium: grow.medium as string,
+    lightType: grow.light_type as string,
+    startDate: grow.start_date as string,
+    strain: null,
+  };
+}
+
+async function userCanReadGrow(
+  userId: string,
+  growId: string,
+): Promise<boolean> {
+  const db = getDbClient();
+  const { data: grow } = await db
+    .from("grows")
+    .select("owner_id")
+    .eq("id", growId)
+    .maybeSingle();
+  if (!grow) return false;
+  if (grow.owner_id === userId) return true;
+
+  const { data: member } = await db
+    .from("grow_members")
+    .select("user_id")
+    .eq("grow_id", growId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  return Boolean(member);
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isLikelyUuid(v: string): boolean {
+  return typeof v === "string" && UUID_RE.test(v);
+}

--- a/apps/web/src/lib/server/logger.ts
+++ b/apps/web/src/lib/server/logger.ts
@@ -1,0 +1,117 @@
+import "server-only";
+
+type Level = "debug" | "info" | "warn" | "error";
+
+const LEVEL_RANK: Record<Level, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const SECRET_KEYS = new Set([
+  "authorization",
+  "cookie",
+  "set-cookie",
+  "openai_api_key",
+  "supabase_service_role_key",
+  "analysis_service_api_key",
+  "cron_secret",
+  "apikey",
+  "api_key",
+  "token",
+  "password",
+]);
+
+function currentLevel(): Level {
+  const raw = (process.env["LOG_LEVEL"] ?? "info").toLowerCase();
+  if (raw === "debug" || raw === "info" || raw === "warn" || raw === "error") {
+    return raw;
+  }
+  return "info";
+}
+
+function redact(value: unknown, depth = 0): unknown {
+  if (value === null || value === undefined) return value;
+  if (depth > 4) return "[truncated]";
+  if (typeof value === "string") {
+    if (value.startsWith("sk-") || value.startsWith("eyJ")) return "[redacted]";
+    return value.length > 2_000 ? value.slice(0, 2_000) + "…" : value;
+  }
+  if (Array.isArray(value)) return value.map((v) => redact(v, depth + 1));
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (SECRET_KEYS.has(k.toLowerCase())) {
+        out[k] = "[redacted]";
+      } else {
+        out[k] = redact(v, depth + 1);
+      }
+    }
+    return out;
+  }
+  return value;
+}
+
+function emit(level: Level, message: string, fields: Record<string, unknown>) {
+  if (LEVEL_RANK[level] < LEVEL_RANK[currentLevel()]) return;
+  const record = {
+    level,
+    msg: message,
+    ts: new Date().toISOString(),
+    ...(redact(fields) as Record<string, unknown>),
+  };
+  const line = JSON.stringify(record);
+  if (level === "error") {
+    console.error(line);
+  } else if (level === "warn") {
+    console.warn(line);
+  } else {
+    // eslint-disable-next-line no-console -- structured logger is the last step in the write path
+    console.log(line);
+  }
+}
+
+export interface Logger {
+  debug: (_msg: string, _fields?: Record<string, unknown>) => void;
+  info: (_msg: string, _fields?: Record<string, unknown>) => void;
+  warn: (_msg: string, _fields?: Record<string, unknown>) => void;
+  error: (_msg: string, _fields?: Record<string, unknown>) => void;
+  child: (_fields: Record<string, unknown>) => Logger;
+}
+
+export function createLogger(base: Record<string, unknown> = {}): Logger {
+  return {
+    debug(msg, fields = {}) {
+      emit("debug", msg, { ...base, ...fields });
+    },
+    info(msg, fields = {}) {
+      emit("info", msg, { ...base, ...fields });
+    },
+    warn(msg, fields = {}) {
+      emit("warn", msg, { ...base, ...fields });
+    },
+    error(msg, fields = {}) {
+      emit("error", msg, { ...base, ...fields });
+    },
+    child(fields) {
+      return createLogger({ ...base, ...fields });
+    },
+  };
+}
+
+/**
+ * Extract or mint a correlation ID for a request.
+ * Honors an existing `x-request-id` header so callers can stitch traces together.
+ */
+export function correlationIdFromRequest(request: Request): string {
+  const existing = request.headers.get("x-request-id");
+  if (existing && existing.length <= 128) return existing;
+  return cryptoRandomId();
+}
+
+function cryptoRandomId(): string {
+  const cryptoApi = (globalThis as { crypto?: Crypto }).crypto;
+  if (cryptoApi?.randomUUID) return cryptoApi.randomUUID();
+  return `req_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}

--- a/apps/web/src/lib/server/plant-context.ts
+++ b/apps/web/src/lib/server/plant-context.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import { getDbClient } from "./db";
+
+export interface GrowContextSnapshot {
+  growId: string;
+  strain: string | null;
+  stage: string | null;
+  medium: string | null;
+  lightType: string | null;
+  daysSinceStart: number | null;
+  notes: string | null;
+}
+
+/**
+ * Build a GrowContext snapshot for a plant by joining the grow + plant rows.
+ * Uses service role — callers must have already authorized access.
+ */
+export async function loadGrowContext(
+  plantId: string,
+  growId: string,
+): Promise<GrowContextSnapshot> {
+  const db = getDbClient();
+
+  const [plantRes, growRes] = await Promise.all([
+    db.from("plants").select("strain, notes").eq("id", plantId).maybeSingle(),
+    db
+      .from("grows")
+      .select("stage, medium, light_type, start_date")
+      .eq("id", growId)
+      .maybeSingle(),
+  ]);
+
+  const plant = plantRes.data as {
+    strain: string | null;
+    notes: string | null;
+  } | null;
+  const grow = growRes.data as {
+    stage: string | null;
+    medium: string | null;
+    light_type: string | null;
+    start_date: string | null;
+  } | null;
+
+  return {
+    growId,
+    strain: plant?.strain ?? null,
+    stage: grow?.stage ?? null,
+    medium: grow?.medium ?? null,
+    lightType: grow?.light_type ?? null,
+    daysSinceStart: grow?.start_date
+      ? Math.max(
+          0,
+          Math.floor(
+            (Date.now() - new Date(grow.start_date).getTime()) /
+              (24 * 60 * 60 * 1000),
+          ),
+        )
+      : null,
+    notes: plant?.notes ?? null,
+  };
+}

--- a/apps/web/src/lib/server/storage.ts
+++ b/apps/web/src/lib/server/storage.ts
@@ -1,6 +1,9 @@
 import "server-only";
 import { createClient } from "@supabase/supabase-js";
 
+export const PLANT_IMAGES_BUCKET = "plant-images";
+const DEFAULT_SIGNED_URL_TTL_S = 60 * 10; // 10 minutes
+
 /**
  * Returns a Supabase Storage client using the service role key.
  * Used server-side to generate signed upload/download URLs.
@@ -24,4 +27,20 @@ export function getStorageClient() {
   });
 
   return supabase.storage;
+}
+
+/**
+ * Return a short-lived signed download URL for a private storage object.
+ * Returns null if Supabase returns an error (e.g. object missing).
+ */
+export async function getSignedImageUrl(
+  storagePath: string,
+  ttlSeconds: number = DEFAULT_SIGNED_URL_TTL_S,
+): Promise<string | null> {
+  const storage = getStorageClient();
+  const { data, error } = await storage
+    .from(PLANT_IMAGES_BUCKET)
+    .createSignedUrl(storagePath, ttlSeconds);
+  if (error || !data?.signedUrl) return null;
+  return data.signedUrl;
 }

--- a/supabase/migrations/002_plant_analyses.sql
+++ b/supabase/migrations/002_plant_analyses.sql
@@ -1,0 +1,41 @@
+-- Migration: 002_plant_analyses
+-- Adds a dedicated table to persist a snapshot of each AI analysis response
+-- so the "latest analysis" endpoint can return real data without re-calling
+-- the AI service, and the UI can render the full response (summary, score,
+-- comparison) without reassembling it from plant_findings.
+
+create table plant_analyses (
+  id                      uuid primary key default gen_random_uuid(),
+  plant_id                uuid not null references plants(id) on delete cascade,
+  grow_id                 uuid not null references grows(id) on delete cascade,
+  image_id                uuid not null references plant_images(id) on delete cascade,
+  overall_health_score    numeric(5, 2) not null check (
+    overall_health_score >= 0 and overall_health_score <= 100
+  ),
+  summary                 text not null,
+  compared_to_image_id    uuid references plant_images(id) on delete set null,
+  comparison_summary      text,
+  model_version           text not null,
+  analyzed_at             timestamptz not null,
+  created_at              timestamptz not null default now()
+);
+
+alter table plant_analyses enable row level security;
+
+create policy "plant_analyses: grow member read"
+  on plant_analyses for select
+  using (
+    exists (
+      select 1 from grows g
+      left join grow_members gm on gm.grow_id = g.id
+      where g.id = plant_analyses.grow_id
+        and (g.owner_id = auth.uid() or gm.user_id = auth.uid())
+    )
+  );
+
+-- Writes come from the service role only (Next.js route handlers).
+-- No user-facing insert policy.
+
+create index idx_plant_analyses_plant_id on plant_analyses(plant_id);
+create index idx_plant_analyses_image_id on plant_analyses(image_id);
+create index idx_plant_analyses_analyzed_at on plant_analyses(analyzed_at desc);


### PR DESCRIPTION
## Outcome

Implements the complete core loop: users can upload plant photos, trigger AI analysis via a FastAPI service, and chat with an assistant that has access to grow/plant context. Adds structured logging, request correlation IDs, and authorization checks across all new routes.

## Scope

- [x] Single concern; no drive-by refactors
- [x] Affected paths listed below

Affected paths:

```
apps/web/src/app/api/chat/route.ts (new, 400 lines)
apps/web/src/app/api/chat/__tests__/route.test.ts (new, 213 lines)
apps/web/src/app/api/uploads/sign/route.ts (refactored, +114 lines)
apps/web/src/app/api/uploads/sign/__tests__/route.test.ts (new, 154 lines)
apps/web/src/app/api/plants/[plantId]/images/route.ts (new, 190 lines)
apps/web/src/app/api/plants/[plantId]/analyze/route.ts (new, 162 lines)
apps/web/src/app/api/plants/[plantId]/timeline/route.ts (refactored, +94 lines)
apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts (new, 146 lines)
apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts (refactored, +59 lines)
apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts (new, 123 lines)
apps/web/src/app/plants/[plantId]/page.tsx (refactored, +170 lines)
apps/web/src/app/plants/[plantId]/photo-uploader.tsx (new, 180 lines)
apps/web/src/app/assistant/page.tsx (refactored, +62 lines)
apps/web/src/app/assistant/assistant-chat.tsx (new, 207 lines)
apps/web/src/lib/server/authorization.ts (new, 129 lines)
apps/web/src/lib/server/logger.ts (new, 117 lines)
apps/web/src/lib/server/plant-context.ts (new, 61 lines)
apps/web/src/lib/server/analysis-proxy.ts (refactored, +117 lines)
apps/web/src/lib/server/storage.ts (minor, +3 lines)
apps/web/instrumentation.ts (new, 123 lines)
apps/web/src/app/api/internal/cron/daily-summary/route.ts (minor, +13 lines)
apps/analysis/app/services/image_analysis.py (new impl, 241 lines)
apps/analysis/app/services/image_comparison.py (new impl, 81 lines)
apps/analysis/app/services/storage.py (new, 70 lines)
apps/analysis/app/middleware.py (new, 70 lines)
apps/analysis/app/main.py (refactored, +17 lines)
apps/analysis/app/telemetry.py (minor)
apps/analysis/tests/test_image_analysis.py (new, 196 lines)
apps/analysis/tests/test_image_comparison.py (refactored)
supabase/migrations/002_plant_analyses.sql (new)
.env.example (updated)
requirements.txt (updated)
README.md (minor)
WORKLOG.md (updated)
```

## Validation

- [x] `pnpm run validate` — passes
- [x] `pnpm turbo run type-check lint test` — all new tests pass
- [x] `pnpm turbo run build` — builds successfully
- [x] `pnpm run security:routes` — no forbidden patterns detected
- [x] `ruff check . && mypy app/ && pytest

https://claude.ai/code/session_01WgGu2WhBbRp6VaGAf7CDqk