### PR TITLE
feat(ui): design system, app shell, and dark mode

### DIFF
--- a/apps/web/src/app/assistant/page.tsx
+++ b/apps/web/src/app/assistant/page.tsx
@@ -23,7 +23,7 @@ export default async function AssistantPage() {
 
   return (
     <AppShell user={{ email: user.email ?? user.id }}>
-      <div className="flex h-[calc(100vh-4rem)] flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
         {/* Page header strip */}
         <div className="border-b border-border bg-card">
           <Container

--- a/apps/web/src/app/assistant/page.tsx
+++ b/apps/web/src/app/assistant/page.tsx
@@ -1,65 +1,128 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { redirect } from "next/navigation";
+import { AppShell } from "@/components/app-shell/app-shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import { ChatIcon, SendIcon, SparklesIcon } from "@/components/ui/icons";
+import { getServerUser } from "@/lib/server/auth";
 
 export const metadata: Metadata = { title: "Assistant" };
+export const dynamic = "force-dynamic";
 
-export default function AssistantPage() {
+const SUGGESTIONS = [
+  "What's the most likely cause of yellowing on lower leaves?",
+  "When should I switch this grow to flower?",
+  "Summarize what changed in the last 7 days.",
+];
+
+export default async function AssistantPage() {
+  const user = await getServerUser();
+  if (!user) redirect("/auth?next=/assistant");
+
   return (
-    <main className="flex h-screen flex-col">
-      {/* Header */}
-      <header className="border-b bg-white px-6 py-4 flex items-center justify-between">
-        <div>
-          <h1 className="text-lg font-semibold text-gray-900">
-            Grow Copilot
-          </h1>
-          <p className="text-xs text-gray-400">
-            AI assistant scoped to your grow
-          </p>
-        </div>
-        <Link
-          href="/dashboard"
-          className="text-sm text-gray-500 hover:text-gray-700"
-        >
-          ← Dashboard
-        </Link>
-      </header>
-
-      {/* Messages area */}
-      <div className="flex-1 overflow-y-auto px-4 py-6">
-        <div className="mx-auto max-w-2xl space-y-4">
-          {/* AI welcome message */}
-          <div className="flex gap-3">
-            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-100 text-brand-600 text-sm font-bold">
-              AI
-            </div>
-            <div className="rounded-2xl rounded-tl-none bg-white border px-4 py-3 text-sm text-gray-700 max-w-lg">
-              Hello! I&apos;m your grow copilot. I have access to your plants,
-              timeline, and observations. Ask me anything about your grow.
-            </div>
-          </div>
-
-          {/* TODO: Render ChatMessage list from /api/chat thread */}
-        </div>
-      </div>
-
-      {/* Input area */}
-      <div className="border-t bg-white px-4 py-4">
-        <div className="mx-auto flex max-w-2xl gap-2">
-          {/* TODO: Wire to POST /api/chat with streaming */}
-          <input
-            type="text"
-            placeholder="Ask about your grow..."
-            className="flex-1 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm focus:border-brand-400 focus:outline-none focus:ring-1 focus:ring-brand-400"
-            disabled
-          />
-          <button
-            className="rounded-xl bg-brand-600 px-5 py-3 text-sm font-semibold text-white hover:bg-brand-700 disabled:opacity-50"
-            disabled
+    <AppShell user={{ email: user.email ?? user.id }}>
+      <div className="flex h-[calc(100vh-4rem)] flex-col">
+        {/* Page header strip */}
+        <div className="border-b border-border bg-card">
+          <Container
+            width="lg"
+            className="flex items-center justify-between py-4"
           >
-            Send
-          </button>
+            <div className="flex items-center gap-3">
+              <span
+                aria-hidden="true"
+                className="flex h-9 w-9 items-center justify-center rounded-md bg-primary/15 text-primary"
+              >
+                <ChatIcon width={18} height={18} />
+              </span>
+              <div>
+                <h1 className="text-base font-semibold tracking-tight text-foreground">
+                  Grow copilot
+                </h1>
+                <p className="text-xs text-muted-foreground">
+                  Scoped to your grow data — never the open web.
+                </p>
+              </div>
+            </div>
+            <Badge variant="info" className="hidden sm:inline-flex">
+              <SparklesIcon width={12} height={12} className="mr-1" />
+              Context-aware
+            </Badge>
+          </Container>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-y-auto bg-background">
+          <Container width="lg" className="py-8">
+            <div className="space-y-6">
+              {/* AI welcome bubble */}
+              <div className="flex gap-3 animate-fade-in-up">
+                <div
+                  aria-hidden="true"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/15 text-xs font-semibold text-primary"
+                >
+                  AI
+                </div>
+                <Card className="max-w-xl">
+                  <CardContent className="p-4 text-sm leading-relaxed">
+                    Hi — I&apos;m your grow copilot. I can see your plants,
+                    timeline, and observations. Ask me anything about your grow,
+                    or pick a starter below.
+                  </CardContent>
+                </Card>
+              </div>
+
+              {/* Suggestions */}
+              <div className="ml-12 flex flex-wrap gap-2">
+                {SUGGESTIONS.map((s) => (
+                  <button
+                    key={s}
+                    type="button"
+                    disabled
+                    className="cursor-not-allowed rounded-full border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground transition hover:border-primary/40 hover:text-foreground disabled:opacity-70"
+                  >
+                    {s}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </Container>
+        </div>
+
+        {/* Composer */}
+        <div className="border-t border-border bg-card">
+          <Container width="lg" className="py-4">
+            <form
+              className="flex items-end gap-2 rounded-lg border border-input bg-background p-2 shadow-elevation-1 focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/40"
+              aria-label="Send message"
+            >
+              <label htmlFor="composer" className="sr-only">
+                Ask the copilot
+              </label>
+              <textarea
+                id="composer"
+                rows={1}
+                placeholder="Ask about your grow…  (Enter to send, Shift+Enter for newline)"
+                disabled
+                className="max-h-32 min-h-[2.5rem] flex-1 resize-none border-0 bg-transparent px-2 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+              />
+              <Button
+                type="submit"
+                size="md"
+                disabled
+                rightIcon={<SendIcon width={14} height={14} />}
+              >
+                Send
+              </Button>
+            </form>
+            <p className="mt-2 text-center text-[11px] text-muted-foreground">
+              Chat is wiring up to /api/chat — coming soon.
+            </p>
+          </Container>
         </div>
       </div>
-    </main>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/auth/page.tsx
+++ b/apps/web/src/app/auth/page.tsx
@@ -1,5 +1,13 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { redirect } from "next/navigation";
+import { ThemeToggle } from "@/components/app-shell/theme-toggle";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  ArrowLeftIcon,
+  LeafIcon,
+  CheckCircleIcon,
+} from "@/components/ui/icons";
 import { getServerUser } from "@/lib/server/auth";
 import { SignInForm } from "./sign-in-form";
 
@@ -7,6 +15,13 @@ export const metadata: Metadata = { title: "Sign In" };
 export const dynamic = "force-dynamic";
 
 type SearchParams = Promise<{ error?: string; next?: string }>;
+
+const HIGHLIGHTS = [
+  "Visual AI diagnosis on every photo",
+  "Longitudinal trend tracking across grows",
+  "Grow-aware copilot grounded in your data",
+  "Daily alerts so issues never linger",
+];
 
 export default async function AuthPage({
   searchParams,
@@ -19,15 +34,92 @@ export default async function AuthPage({
   const { error } = await searchParams;
 
   return (
-    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
-      <div className="w-full max-w-sm rounded-2xl border bg-white p-8 shadow-sm">
-        <h1 className="mb-2 text-2xl font-bold text-gray-900">
-          Welcome to PhenoSage
-        </h1>
-        <p className="mb-6 text-sm text-gray-500">
-          Sign in or create your account to get started.
-        </p>
-        <SignInForm {...(error ? { initialError: error } : {})} />
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="relative min-h-screen bg-background outline-none"
+    >
+      {/* Top utility bar */}
+      <div className="absolute inset-x-0 top-0 z-10 flex items-center justify-between px-5 py-4">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeftIcon width={16} height={16} />
+          Back home
+        </Link>
+        <ThemeToggle />
+      </div>
+
+      <div className="grid min-h-screen lg:grid-cols-2">
+        {/* Decorative panel */}
+        <aside
+          aria-hidden="true"
+          className="relative hidden overflow-hidden bg-hero-gradient lg:flex lg:flex-col lg:justify-between lg:p-12"
+        >
+          <div className="flex items-center gap-2 font-semibold tracking-tight">
+            <span className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground">
+              <LeafIcon width={18} height={18} />
+            </span>
+            <span>PhenoSage</span>
+          </div>
+
+          <div className="max-w-md">
+            <p className="text-xs font-medium uppercase tracking-wider text-primary">
+              Built for serious growers
+            </p>
+            <h2 className="mt-3 text-3xl font-semibold tracking-tight text-foreground">
+              A second pair of eyes on every plant.
+            </h2>
+            <ul className="mt-6 space-y-3">
+              {HIGHLIGHTS.map((line) => (
+                <li
+                  key={line}
+                  className="flex items-start gap-2 text-sm text-muted-foreground"
+                >
+                  <CheckCircleIcon
+                    width={18}
+                    height={18}
+                    className="mt-0.5 shrink-0 text-primary"
+                  />
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            © {new Date().getFullYear()} PhenoSage
+          </p>
+        </aside>
+
+        {/* Form panel */}
+        <section className="flex items-center justify-center px-5 py-20 sm:px-8">
+          <div className="w-full max-w-sm">
+            <div className="mb-6 flex items-center gap-2 lg:hidden">
+              <span className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground">
+                <LeafIcon width={18} height={18} />
+              </span>
+              <span className="font-semibold tracking-tight">PhenoSage</span>
+            </div>
+            <Card className="shadow-elevation-2">
+              <CardContent className="space-y-6 p-6 sm:p-8">
+                <div>
+                  <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+                    Welcome back
+                  </h1>
+                  <p className="mt-1.5 text-sm text-muted-foreground">
+                    Sign in or create an account to start tracking grows.
+                  </p>
+                </div>
+                <SignInForm {...(error ? { initialError: error } : {})} />
+              </CardContent>
+            </Card>
+            <p className="mt-6 text-center text-xs text-muted-foreground">
+              Protected by Supabase Auth · Row-level security on every query.
+            </p>
+          </div>
+        </section>
       </div>
     </main>
   );

--- a/apps/web/src/app/auth/sign-in-form.tsx
+++ b/apps/web/src/app/auth/sign-in-form.tsx
@@ -109,6 +109,9 @@ export function SignInForm({
     null,
   );
 
+  const tabId = (id: Mode) => `auth-tab-${id}`;
+  const panelId = (id: Mode) => `auth-panel-${id}`;
+
   return (
     <div className="space-y-5">
       <div
@@ -121,9 +124,12 @@ export function SignInForm({
           return (
             <button
               key={tab.id}
+              id={tabId(tab.id)}
               role="tab"
               type="button"
               aria-selected={active}
+              aria-controls={panelId(tab.id)}
+              tabIndex={active ? 0 : -1}
               onClick={() => setMode(tab.id)}
               className={cn(
                 "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
@@ -140,7 +146,13 @@ export function SignInForm({
       </div>
 
       {mode === "sign-in" && (
-        <form action={signInFormAction} className="space-y-4">
+        <form
+          action={signInFormAction}
+          className="space-y-4"
+          role="tabpanel"
+          id={panelId("sign-in")}
+          aria-labelledby={tabId("sign-in")}
+        >
           <EmailField />
           <PasswordField autoComplete="current-password" />
           <Feedback state={signInState} initialError={initialError} />
@@ -149,7 +161,13 @@ export function SignInForm({
       )}
 
       {mode === "sign-up" && (
-        <form action={signUpFormAction} className="space-y-4">
+        <form
+          action={signUpFormAction}
+          className="space-y-4"
+          role="tabpanel"
+          id={panelId("sign-up")}
+          aria-labelledby={tabId("sign-up")}
+        >
           <EmailField />
           <PasswordField autoComplete="new-password" />
           <Feedback state={signUpState} />
@@ -158,7 +176,13 @@ export function SignInForm({
       )}
 
       {mode === "magic-link" && (
-        <form action={otpFormAction} className="space-y-4">
+        <form
+          action={otpFormAction}
+          className="space-y-4"
+          role="tabpanel"
+          id={panelId("magic-link")}
+          aria-labelledby={tabId("magic-link")}
+        >
           <EmailField />
           <Feedback state={otpState} />
           <SubmitButton label="Send magic link" />

--- a/apps/web/src/app/auth/sign-in-form.tsx
+++ b/apps/web/src/app/auth/sign-in-form.tsx
@@ -2,6 +2,10 @@
 
 import { useActionState, useState } from "react";
 import { useFormStatus } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/cn";
 import {
   signInAction,
   signUpAction,
@@ -20,32 +24,23 @@ const TABS: { id: Mode; label: string }[] = [
 function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
-    <button
-      type="submit"
-      disabled={pending}
-      className="w-full rounded-lg bg-brand-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:cursor-not-allowed disabled:bg-brand-400"
-    >
+    <Button type="submit" loading={pending} fullWidth size="md">
       {pending ? "Please wait…" : label}
-    </button>
+    </Button>
   );
 }
 
 function EmailField() {
   return (
-    <div>
-      <label
-        htmlFor="email"
-        className="mb-1 block text-sm font-medium text-gray-700"
-      >
-        Email
-      </label>
-      <input
+    <div className="space-y-1.5">
+      <Label htmlFor="email">Email</Label>
+      <Input
         id="email"
         name="email"
         type="email"
         autoComplete="email"
+        placeholder="you@example.com"
         required
-        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
       />
     </div>
   );
@@ -53,23 +48,18 @@ function EmailField() {
 
 function PasswordField({ autoComplete }: { autoComplete: string }) {
   return (
-    <div>
-      <label
-        htmlFor="password"
-        className="mb-1 block text-sm font-medium text-gray-700"
-      >
-        Password
-      </label>
-      <input
+    <div className="space-y-1.5">
+      <Label htmlFor="password">Password</Label>
+      <Input
         id="password"
         name="password"
         type="password"
         minLength={8}
         autoComplete={autoComplete}
+        placeholder="••••••••"
         required
-        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
       />
-      <p className="mt-1 text-xs text-gray-500">Minimum 8 characters.</p>
+      <p className="text-xs text-muted-foreground">Minimum 8 characters.</p>
     </div>
   );
 }
@@ -87,11 +77,12 @@ function Feedback({
   return (
     <div
       role={isOk ? "status" : "alert"}
-      className={`rounded-lg border px-3 py-2 text-sm ${
+      className={cn(
+        "rounded-md border px-3 py-2 text-sm animate-fade-in",
         isOk
-          ? "border-green-200 bg-green-50 text-green-800"
-          : "border-red-200 bg-red-50 text-red-800"
-      }`}
+          ? "border-success/30 bg-success/10 text-success"
+          : "border-destructive/30 bg-destructive/10 text-destructive",
+      )}
     >
       {message}
     </div>
@@ -119,23 +110,33 @@ export function SignInForm({
   );
 
   return (
-    <div className="space-y-6">
-      <div role="tablist" className="flex rounded-lg border bg-gray-50 p-1">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            role="tab"
-            aria-selected={mode === tab.id}
-            onClick={() => setMode(tab.id)}
-            className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition ${
-              mode === tab.id
-                ? "bg-white text-gray-900 shadow-sm"
-                : "text-gray-600 hover:text-gray-900"
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+    <div className="space-y-5">
+      <div
+        role="tablist"
+        aria-label="Authentication method"
+        className="flex rounded-md border border-border bg-muted/50 p-1"
+      >
+        {TABS.map((tab) => {
+          const active = mode === tab.id;
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              type="button"
+              aria-selected={active}
+              onClick={() => setMode(tab.id)}
+              className={cn(
+                "flex-1 rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+                active
+                  ? "bg-card text-foreground shadow-elevation-1"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
       </div>
 
       {mode === "sign-in" && (
@@ -164,9 +165,9 @@ export function SignInForm({
         </form>
       )}
 
-      <p className="text-center text-xs text-gray-500">
-        {mode === "sign-in" && "No account yet? Switch to Sign up."}
-        {mode === "sign-up" && "Already have one? Switch to Sign in."}
+      <p className="text-center text-xs text-muted-foreground">
+        {mode === "sign-in" && "No account yet? Switch to Sign up above."}
+        {mode === "sign-up" && "Already have one? Switch to Sign in above."}
         {mode === "magic-link" && "We'll email you a one-click sign-in link."}
       </p>
     </div>

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,91 +1,240 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { AppShell } from "@/components/app-shell/app-shell";
+import { PageHeader } from "@/components/app-shell/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  ArrowRightIcon,
+  BellIcon,
+  ChatIcon,
+  ImageIcon,
+  LeafIcon,
+  PlusIcon,
+  SparklesIcon,
+  TrendIcon,
+} from "@/components/ui/icons";
 import { getServerUser } from "@/lib/server/auth";
-import { signOutAction } from "../auth/actions";
 
 export const metadata: Metadata = { title: "Dashboard" };
 export const dynamic = "force-dynamic";
+
+const STATS = [
+  {
+    label: "Active grows",
+    value: "—",
+    delta: null,
+    Icon: LeafIcon,
+  },
+  {
+    label: "Plants tracked",
+    value: "—",
+    delta: null,
+    Icon: ImageIcon,
+  },
+  {
+    label: "Health checks (7d)",
+    value: "—",
+    delta: null,
+    Icon: TrendIcon,
+  },
+];
+
+const QUICK_ACTIONS = [
+  {
+    href: "/grows",
+    title: "Start a grow",
+    description: "Create a grow, link your plants, and pick a stage.",
+    Icon: LeafIcon,
+  },
+  {
+    href: "/plants",
+    title: "Upload a photo",
+    description: "Trigger a visual analysis on your most recent shot.",
+    Icon: ImageIcon,
+  },
+  {
+    href: "/assistant",
+    title: "Ask the copilot",
+    description: "Talk to an AI grounded in your strains and history.",
+    Icon: ChatIcon,
+  },
+];
 
 export default async function DashboardPage() {
   const user = await getServerUser();
   if (!user) redirect("/auth?next=/dashboard");
 
+  const userEmail = user.email ?? user.id;
+
   return (
-    <main className="mx-auto max-w-5xl px-6 py-10">
-      <div className="mb-8 flex items-center justify-between gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Dashboard</h1>
-          <p className="text-sm text-gray-500">
-            Signed in as {user.email ?? user.id}
-          </p>
+    <AppShell user={{ email: userEmail }}>
+      <Container width="xl" className="space-y-8 py-8 md:py-10">
+        <PageHeader
+          eyebrow="Overview"
+          title={`Welcome back${user.email ? `, ${user.email.split("@")[0]}` : ""}`}
+          description="Snapshot of your grow operation. Pick up where you left off."
+          actions={
+            <>
+              <Link href="/assistant">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  leftIcon={<ChatIcon width={16} height={16} />}
+                >
+                  Ask copilot
+                </Button>
+              </Link>
+              <Link href="/grows">
+                <Button
+                  size="sm"
+                  leftIcon={<PlusIcon width={16} height={16} />}
+                >
+                  New grow
+                </Button>
+              </Link>
+            </>
+          }
+        />
+
+        {/* Stats */}
+        <section aria-label="Key metrics" className="grid gap-4 sm:grid-cols-3">
+          {STATS.map(({ label, value, Icon }) => (
+            <Card key={label}>
+              <CardContent className="flex items-start justify-between p-5">
+                <div>
+                  <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    {label}
+                  </p>
+                  <p className="mt-2 text-3xl font-semibold tracking-tight text-foreground">
+                    {value}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Awaiting first data
+                  </p>
+                </div>
+                <span
+                  aria-hidden="true"
+                  className="flex h-10 w-10 items-center justify-center rounded-md bg-accent text-accent-foreground"
+                >
+                  <Icon width={20} height={20} />
+                </span>
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+
+        {/* Two-column: activity + quick actions */}
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Card className="lg:col-span-2">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <CardTitle>Recent activity</CardTitle>
+                  <CardDescription>
+                    Findings, uploads, and copilot answers across your grows.
+                  </CardDescription>
+                </div>
+                <Badge variant="secondary">Live</Badge>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <EmptyState
+                icon={<TrendIcon width={20} height={20} />}
+                title="No activity yet"
+                description="Create a grow and upload a photo to start the timeline."
+                action={
+                  <Link href="/grows">
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      rightIcon={<ArrowRightIcon width={14} height={14} />}
+                    >
+                      Create your first grow
+                    </Button>
+                  </Link>
+                }
+              />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Quick actions</CardTitle>
+              <CardDescription>Frequent things you do.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {QUICK_ACTIONS.map(({ href, title, description, Icon }) => (
+                <Link
+                  key={href}
+                  href={href}
+                  className="group flex items-start gap-3 rounded-md border border-transparent p-3 transition-all hover:border-border hover:bg-muted"
+                >
+                  <span
+                    aria-hidden="true"
+                    className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-accent text-accent-foreground transition-colors group-hover:bg-primary group-hover:text-primary-foreground"
+                  >
+                    <Icon width={16} height={16} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-foreground">
+                      {title}
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {description}
+                    </p>
+                  </div>
+                  <ArrowRightIcon
+                    width={16}
+                    height={16}
+                    className="mt-1 text-muted-foreground transition-transform group-hover:translate-x-0.5 group-hover:text-foreground"
+                  />
+                </Link>
+              ))}
+            </CardContent>
+          </Card>
         </div>
-        <div className="flex items-center gap-2">
-          <Link
-            href="/grows"
-            className="rounded-lg bg-brand-600 px-4 py-2 text-sm font-semibold text-white hover:bg-brand-700"
-          >
-            My Grows
-          </Link>
-          <form action={signOutAction}>
-            <button
-              type="submit"
-              className="rounded-lg border px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50"
+
+        {/* Tips */}
+        <Card className="border-primary/20 bg-accent/40">
+          <CardContent className="flex flex-col items-start gap-4 p-5 sm:flex-row sm:items-center">
+            <span
+              aria-hidden="true"
+              className="flex h-10 w-10 items-center justify-center rounded-md bg-primary/15 text-primary"
             >
-              Sign out
-            </button>
-          </form>
-        </div>
-      </div>
-
-      {/* Quick stats */}
-      <div className="mb-8 grid gap-4 sm:grid-cols-3">
-        {[
-          { label: "Active Grows", value: "—" },
-          { label: "Plants Tracked", value: "—" },
-          { label: "Health Checks", value: "—" },
-        ].map((stat) => (
-          <div key={stat.label} className="rounded-xl border bg-white p-6">
-            <p className="text-sm text-gray-500">{stat.label}</p>
-            <p className="mt-1 text-3xl font-bold text-gray-900">
-              {stat.value}
-            </p>
-          </div>
-        ))}
-      </div>
-
-      {/* Recent activity placeholder */}
-      <div className="rounded-xl border bg-white p-6">
-        <h2 className="mb-4 text-lg font-semibold text-gray-900">
-          Recent activity
-        </h2>
-        <p className="text-sm text-gray-400">
-          No activity yet. Create a grow to get started.
-        </p>
-      </div>
-
-      {/* Navigation shortcuts */}
-      <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        {navLinks.map((link) => (
-          <Link
-            key={link.href}
-            href={link.href}
-            className="flex flex-col items-center rounded-xl border bg-white p-6 text-center hover:bg-gray-50"
-          >
-            <span className="mb-2 text-2xl">{link.icon}</span>
-            <span className="text-sm font-medium text-gray-700">
-              {link.label}
+              <SparklesIcon width={20} height={20} />
             </span>
-          </Link>
-        ))}
-      </div>
-    </main>
+            <div className="flex-1">
+              <p className="text-sm font-semibold text-foreground">
+                Pro tip — enable daily alerts
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Get a morning summary with new findings, suggested tasks, and
+                stage-aware reminders.
+              </p>
+            </div>
+            <Link href="/settings">
+              <Button
+                variant="outline"
+                size="sm"
+                leftIcon={<BellIcon width={14} height={14} />}
+              >
+                Configure
+              </Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </Container>
+    </AppShell>
   );
 }
-
-const navLinks = [
-  { href: "/grows", icon: "🌱", label: "Grows" },
-  { href: "/assistant", icon: "💬", label: "Assistant" },
-  { href: "/settings", icon: "⚙️", label: "Settings" },
-  { href: "/plants", icon: "🌿", label: "Plants" },
-];

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -86,23 +86,21 @@ export default async function DashboardPage() {
           description="Snapshot of your grow operation. Pick up where you left off."
           actions={
             <>
-              <Link href="/assistant">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  leftIcon={<ChatIcon width={16} height={16} />}
-                >
-                  Ask copilot
-                </Button>
-              </Link>
-              <Link href="/grows">
-                <Button
-                  size="sm"
-                  leftIcon={<PlusIcon width={16} height={16} />}
-                >
-                  New grow
-                </Button>
-              </Link>
+              <Button
+                asChild
+                variant="outline"
+                size="sm"
+                leftIcon={<ChatIcon width={16} height={16} />}
+              >
+                <Link href="/assistant">Ask copilot</Link>
+              </Button>
+              <Button
+                asChild
+                size="sm"
+                leftIcon={<PlusIcon width={16} height={16} />}
+              >
+                <Link href="/grows">New grow</Link>
+              </Button>
             </>
           }
         />
@@ -154,15 +152,14 @@ export default async function DashboardPage() {
                 title="No activity yet"
                 description="Create a grow and upload a photo to start the timeline."
                 action={
-                  <Link href="/grows">
-                    <Button
-                      variant="primary"
-                      size="sm"
-                      rightIcon={<ArrowRightIcon width={14} height={14} />}
-                    >
-                      Create your first grow
-                    </Button>
-                  </Link>
+                  <Button
+                    asChild
+                    variant="primary"
+                    size="sm"
+                    rightIcon={<ArrowRightIcon width={14} height={14} />}
+                  >
+                    <Link href="/grows">Create your first grow</Link>
+                  </Button>
                 }
               />
             </CardContent>
@@ -223,15 +220,14 @@ export default async function DashboardPage() {
                 stage-aware reminders.
               </p>
             </div>
-            <Link href="/settings">
-              <Button
-                variant="outline"
-                size="sm"
-                leftIcon={<BellIcon width={14} height={14} />}
-              >
-                Configure
-              </Button>
-            </Link>
+            <Button
+              asChild
+              variant="outline"
+              size="sm"
+              leftIcon={<BellIcon width={14} height={14} />}
+            >
+              <Link href="/settings">Configure</Link>
+            </Button>
           </CardContent>
         </Card>
       </Container>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,19 +2,215 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 15, 15, 15;
-  --background-rgb: 250, 250, 250;
-}
-
-@media (prefers-color-scheme: dark) {
+/* -----------------------------------------------------------
+ * Design tokens
+ *
+ * Inspired by shadcn/ui — semantic, theme-aware HSL variables
+ * consumed by Tailwind via tailwind.config.js. To rebrand or
+ * tune contrast, edit values here only; Tailwind classes
+ * (bg-card, text-foreground, etc.) update everywhere.
+ * --------------------------------------------------------- */
+@layer base {
   :root {
-    --foreground-rgb: 245, 245, 245;
-    --background-rgb: 15, 15, 15;
+    --background: 140 30% 99%;
+    --foreground: 150 14% 12%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 150 14% 12%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 150 14% 12%;
+
+    --primary: 142 71% 35%;
+    --primary-foreground: 0 0% 100%;
+
+    --secondary: 140 25% 95%;
+    --secondary-foreground: 150 14% 18%;
+
+    --muted: 140 16% 95%;
+    --muted-foreground: 150 8% 42%;
+
+    --accent: 142 60% 92%;
+    --accent-foreground: 142 71% 22%;
+
+    --destructive: 0 72% 50%;
+    --destructive-foreground: 0 0% 100%;
+
+    --success: 142 71% 35%;
+    --success-foreground: 0 0% 100%;
+
+    --warning: 38 92% 48%;
+    --warning-foreground: 30 50% 12%;
+
+    --info: 211 92% 50%;
+    --info-foreground: 0 0% 100%;
+
+    --border: 140 12% 88%;
+    --input: 140 12% 88%;
+    --ring: 142 71% 40%;
+
+    --radius: 0.75rem;
+  }
+
+  .dark {
+    --background: 150 14% 7%;
+    --foreground: 140 8% 95%;
+
+    --card: 150 14% 10%;
+    --card-foreground: 140 8% 95%;
+
+    --popover: 150 14% 9%;
+    --popover-foreground: 140 8% 95%;
+
+    --primary: 142 65% 48%;
+    --primary-foreground: 150 24% 8%;
+
+    --secondary: 150 10% 15%;
+    --secondary-foreground: 140 8% 92%;
+
+    --muted: 150 10% 14%;
+    --muted-foreground: 140 6% 65%;
+
+    --accent: 142 40% 18%;
+    --accent-foreground: 142 65% 78%;
+
+    --destructive: 0 65% 55%;
+    --destructive-foreground: 0 0% 100%;
+
+    --success: 142 65% 48%;
+    --success-foreground: 150 24% 8%;
+
+    --warning: 38 90% 55%;
+    --warning-foreground: 30 50% 8%;
+
+    --info: 211 85% 60%;
+    --info-foreground: 220 30% 8%;
+
+    --border: 150 10% 18%;
+    --input: 150 10% 18%;
+    --ring: 142 65% 50%;
+  }
+
+  * {
+    border-color: hsl(var(--border));
+  }
+
+  html {
+    color-scheme: light;
+    -webkit-text-size-adjust: 100%;
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  html.dark {
+    color-scheme: dark;
+  }
+
+  body {
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    font-feature-settings: "rlig" 1, "calt" 1, "ss01" 1;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* Visible, theme-aware focus ring */
+  :focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
+
+  /* Hide focus ring on mouse, keep for keyboard */
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  /* Selection */
+  ::selection {
+    background-color: hsl(var(--primary) / 0.25);
+    color: hsl(var(--primary-foreground));
+  }
+
+  /* Scrollbar — subtle, themed */
+  @media (pointer: fine) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+    }
+    *::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+    *::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    *::-webkit-scrollbar-thumb {
+      background-color: hsl(var(--muted-foreground) / 0.25);
+      border-radius: 9999px;
+      border: 2px solid transparent;
+      background-clip: padding-box;
+    }
+    *::-webkit-scrollbar-thumb:hover {
+      background-color: hsl(var(--muted-foreground) / 0.45);
+    }
   }
 }
 
-body {
-  color: rgb(var(--foreground-rgb));
-  background: rgb(var(--background-rgb));
+@layer utilities {
+  /* Container helpers */
+  .container-page {
+    width: 100%;
+    margin-inline: auto;
+    padding-inline: 1.25rem;
+    max-width: 80rem;
+  }
+
+  /* Soft surface gradient for hero / empty regions */
+  .bg-hero-gradient {
+    background-image:
+      radial-gradient(
+        circle at 20% 10%,
+        hsl(var(--primary) / 0.12),
+        transparent 45%
+      ),
+      radial-gradient(
+        circle at 85% 0%,
+        hsl(var(--info) / 0.08),
+        transparent 50%
+      );
+  }
+
+  /* Skip-link visible only on focus */
+  .skip-link {
+    position: absolute;
+    top: -100px;
+    left: 1rem;
+    z-index: 100;
+    padding: 0.5rem 0.875rem;
+    border-radius: 0.5rem;
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    font-size: 0.875rem;
+    font-weight: 600;
+    box-shadow: 0 8px 20px hsl(var(--primary) / 0.25);
+    transition: top 0.15s ease;
+  }
+  .skip-link:focus,
+  .skip-link:focus-visible {
+    top: 0.75rem;
+    outline: none;
+  }
+}
+
+/* Respect users who prefer reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/apps/web/src/app/grows/page.tsx
+++ b/apps/web/src/app/grows/page.tsx
@@ -35,11 +35,9 @@ export default async function GrowsPage() {
           title="No grows yet"
           description="Create your first grow to start tracking plants, photos, and AI findings."
           action={
-            <Link href="#">
-              <Button leftIcon={<PlusIcon width={16} height={16} />}>
-                Create your first grow
-              </Button>
-            </Link>
+            <Button asChild leftIcon={<PlusIcon width={16} height={16} />}>
+              <Link href="#">Create your first grow</Link>
+            </Button>
           }
         />
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,15 +1,29 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
+import { SkipLink } from "@/components/app-shell/skip-link";
+import { ThemeScript } from "@/components/app-shell/theme-script";
 import "./globals.css";
 
 export const metadata: Metadata = {
   title: {
-    default: "PhenoSage",
-    template: "%s | PhenoSage",
+    default: "PhenoSage — AI Grow Operating System",
+    template: "%s · PhenoSage",
   },
   description:
-    "AI-powered cannabis grow operating system. Professional plant analysis, timeline tracking, proactive alerts, and grow-aware chatbot.",
+    "AI-powered cannabis grow OS. Visual plant analysis, longitudinal tracking, proactive alerts, and a grow-aware copilot.",
+  applicationName: "PhenoSage",
+  authors: [{ name: "PhenoSage" }],
+  formatDetection: { email: false, telephone: false, address: false },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#fafdf9" },
+    { media: "(prefers-color-scheme: dark)", color: "#0f1411" },
+  ],
 };
 
 export default function RootLayout({
@@ -18,8 +32,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-background antialiased">
+    <html lang="en" suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
+      <body className="min-h-screen bg-background text-foreground antialiased">
+        <SkipLink />
         {children}
         <Analytics />
         <SpeedInsights />

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Container } from "@/components/ui/container";
+import { ArrowLeftIcon, LeafIcon } from "@/components/ui/icons";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center bg-hero-gradient">
+      <Container width="md" className="text-center">
+        <div className="mx-auto mb-6 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground">
+          <LeafIcon width={26} height={26} />
+        </div>
+        <p className="text-xs font-medium uppercase tracking-wider text-primary">
+          404
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+          We couldn&apos;t find that page
+        </h1>
+        <p className="mx-auto mt-3 max-w-md text-muted-foreground">
+          The link may have changed, or the page hasn&apos;t shipped yet. Head
+          back to the dashboard to keep going.
+        </p>
+        <div className="mt-8 flex justify-center gap-3">
+          <Link href="/">
+            <Button
+              variant="outline"
+              leftIcon={<ArrowLeftIcon width={16} height={16} />}
+            >
+              Home
+            </Button>
+          </Link>
+          <Link href="/dashboard">
+            <Button>Open dashboard</Button>
+          </Link>
+        </div>
+      </Container>
+    </main>
+  );
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -21,17 +21,16 @@ export default function NotFound() {
           back to the dashboard to keep going.
         </p>
         <div className="mt-8 flex justify-center gap-3">
-          <Link href="/">
-            <Button
-              variant="outline"
-              leftIcon={<ArrowLeftIcon width={16} height={16} />}
-            >
-              Home
-            </Button>
-          </Link>
-          <Link href="/dashboard">
-            <Button>Open dashboard</Button>
-          </Link>
+          <Button
+            asChild
+            variant="outline"
+            leftIcon={<ArrowLeftIcon width={16} height={16} />}
+          >
+            <Link href="/">Home</Link>
+          </Button>
+          <Button asChild>
+            <Link href="/dashboard">Open dashboard</Link>
+          </Button>
         </div>
       </Container>
     </main>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -79,19 +79,21 @@ export default function LandingPage() {
           </Link>
           <div className="flex items-center gap-3">
             <ThemeToggle />
-            <Link href="/auth" className="hidden sm:block">
-              <Button variant="ghost" size="sm">
-                Sign in
-              </Button>
-            </Link>
-            <Link href="/auth">
-              <Button
-                size="sm"
-                rightIcon={<ArrowRightIcon width={14} height={14} />}
-              >
-                Get started
-              </Button>
-            </Link>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="hidden sm:inline-flex"
+            >
+              <Link href="/auth">Sign in</Link>
+            </Button>
+            <Button
+              asChild
+              size="sm"
+              rightIcon={<ArrowRightIcon width={14} height={14} />}
+            >
+              <Link href="/auth">Get started</Link>
+            </Button>
           </div>
         </Container>
       </header>
@@ -117,19 +119,16 @@ export default function LandingPage() {
                 one fast web app.
               </p>
               <div className="mt-10 flex flex-col gap-3 sm:flex-row">
-                <Link href="/auth">
-                  <Button
-                    size="lg"
-                    rightIcon={<ArrowRightIcon width={16} height={16} />}
-                  >
-                    Get started free
-                  </Button>
-                </Link>
-                <Link href="/dashboard">
-                  <Button size="lg" variant="outline">
-                    View demo
-                  </Button>
-                </Link>
+                <Button
+                  asChild
+                  size="lg"
+                  rightIcon={<ArrowRightIcon width={16} height={16} />}
+                >
+                  <Link href="/auth">Get started free</Link>
+                </Button>
+                <Button asChild size="lg" variant="outline">
+                  <Link href="/dashboard">View demo</Link>
+                </Button>
               </div>
               <p className="mt-6 text-xs text-muted-foreground">
                 No credit card. RLS-secured. Cancel anytime.
@@ -207,14 +206,13 @@ export default function LandingPage() {
               seconds.
             </p>
             <div className="mt-6 flex justify-center">
-              <Link href="/auth">
-                <Button
-                  size="lg"
-                  rightIcon={<ArrowRightIcon width={16} height={16} />}
-                >
-                  Create your account
-                </Button>
-              </Link>
+              <Button
+                asChild
+                size="lg"
+                rightIcon={<ArrowRightIcon width={16} height={16} />}
+              >
+                <Link href="/auth">Create your account</Link>
+              </Button>
             </div>
           </Container>
         </section>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,89 +1,244 @@
 import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import {
+  ArrowRightIcon,
+  BellIcon,
+  ChatIcon,
+  LeafIcon,
+  ScopeIcon,
+  SparklesIcon,
+  TrendIcon,
+} from "@/components/ui/icons";
+import { ThemeToggle } from "@/components/app-shell/theme-toggle";
+
+const PILLARS = [
+  {
+    Icon: ScopeIcon,
+    title: "Visual Grow Doctor",
+    description:
+      "Upload a photo, get structured findings ranked by severity with concrete recommendations.",
+  },
+  {
+    Icon: TrendIcon,
+    title: "Longitudinal Intelligence",
+    description:
+      "Compare new shots to prior uploads. Trend health scores across the entire grow cycle.",
+  },
+  {
+    Icon: ChatIcon,
+    title: "Grow-aware Copilot",
+    description:
+      "Chat with an AI grounded in your strains, observations, and environment — not the open web.",
+  },
+  {
+    Icon: BellIcon,
+    title: "Proactive Alerts",
+    description:
+      "Daily summaries, generated tasks, and stage-aware reminders so nothing slips.",
+  },
+];
+
+const PRINCIPLES = [
+  {
+    label: "Web-first",
+    body: "No app store gates. Open a URL, get to work — desktop, tablet, or phone.",
+  },
+  {
+    label: "Privacy-respecting",
+    body: "Photos and chat live behind row-level security. Service-role keys never leave the server.",
+  },
+  {
+    label: "AI as copilot",
+    body: "Suggestions are auditable. You approve before anything mutates your grow.",
+  },
+];
 
 export default function LandingPage() {
   return (
-    <main className="flex min-h-screen flex-col">
-      {/* Hero */}
-      <section className="flex flex-1 flex-col items-center justify-center px-6 py-24 text-center">
-        <div className="mb-4 inline-flex items-center rounded-full border border-brand-200 bg-brand-50 px-3 py-1 text-sm text-brand-700">
-          Web-first AI grow OS
-        </div>
-        <h1 className="mb-6 text-5xl font-bold tracking-tight text-gray-900 sm:text-6xl">
-          Your plants deserve
-          <br />
-          <span className="text-brand-600">professional intelligence</span>
-        </h1>
-        <p className="mb-10 max-w-2xl text-xl text-gray-600">
-          PhenoSage combines visual AI diagnosis, longitudinal plant tracking,
-          a grow-aware chatbot, and proactive alerts — all in one web app.
-        </p>
-        <div className="flex flex-col gap-4 sm:flex-row">
+    <div className="min-h-screen">
+      {/* Top bar */}
+      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur">
+        <Container
+          width="xl"
+          className="flex h-16 items-center justify-between"
+        >
           <Link
-            href="/auth"
-            className="rounded-lg bg-brand-600 px-8 py-3 text-lg font-semibold text-white shadow-sm hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            href="/"
+            className="flex items-center gap-2 font-semibold tracking-tight"
           >
-            Get started free
+            <span
+              aria-hidden="true"
+              className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground"
+            >
+              <LeafIcon width={18} height={18} />
+            </span>
+            <span>PhenoSage</span>
           </Link>
-          <Link
-            href="/dashboard"
-            className="rounded-lg border border-gray-300 px-8 py-3 text-lg font-semibold text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-brand-500"
-          >
-            View demo
-          </Link>
-        </div>
-      </section>
-
-      {/* Pillars */}
-      <section className="border-t bg-white px-6 py-20">
-        <div className="mx-auto max-w-5xl">
-          <h2 className="mb-12 text-center text-3xl font-bold text-gray-900">
-            Four pillars of grow intelligence
-          </h2>
-          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
-            {pillars.map((pillar) => (
-              <div key={pillar.title} className="rounded-xl border p-6">
-                <div className="mb-3 text-3xl">{pillar.icon}</div>
-                <h3 className="mb-2 font-semibold text-gray-900">
-                  {pillar.title}
-                </h3>
-                <p className="text-sm text-gray-600">{pillar.description}</p>
-              </div>
-            ))}
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link href="/auth" className="hidden sm:block">
+              <Button variant="ghost" size="sm">
+                Sign in
+              </Button>
+            </Link>
+            <Link href="/auth">
+              <Button
+                size="sm"
+                rightIcon={<ArrowRightIcon width={14} height={14} />}
+              >
+                Get started
+              </Button>
+            </Link>
           </div>
-        </div>
-      </section>
+        </Container>
+      </header>
 
-      {/* Footer */}
-      <footer className="border-t px-6 py-8 text-center text-sm text-gray-500">
-        © {new Date().getFullYear()} PhenoSage. Web-first, privacy-respecting.
+      <main id="main-content" tabIndex={-1} className="outline-none">
+        {/* Hero */}
+        <section className="bg-hero-gradient">
+          <Container width="xl" className="py-20 sm:py-28 lg:py-32">
+            <div className="mx-auto flex max-w-3xl flex-col items-center text-center animate-fade-in-up">
+              <Badge variant="info" className="mb-5">
+                <SparklesIcon width={14} height={14} className="mr-1.5" />
+                Web-first AI grow OS
+              </Badge>
+              <h1 className="text-balance text-5xl font-semibold tracking-tight text-foreground sm:text-6xl lg:text-7xl">
+                Your plants deserve{" "}
+                <span className="bg-gradient-to-r from-primary to-success bg-clip-text text-transparent">
+                  professional intelligence
+                </span>
+              </h1>
+              <p className="mt-6 max-w-2xl text-pretty text-lg text-muted-foreground sm:text-xl">
+                PhenoSage combines visual AI diagnosis, longitudinal plant
+                tracking, a grow-aware chatbot, and proactive alerts — all in
+                one fast web app.
+              </p>
+              <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+                <Link href="/auth">
+                  <Button
+                    size="lg"
+                    rightIcon={<ArrowRightIcon width={16} height={16} />}
+                  >
+                    Get started free
+                  </Button>
+                </Link>
+                <Link href="/dashboard">
+                  <Button size="lg" variant="outline">
+                    View demo
+                  </Button>
+                </Link>
+              </div>
+              <p className="mt-6 text-xs text-muted-foreground">
+                No credit card. RLS-secured. Cancel anytime.
+              </p>
+            </div>
+          </Container>
+        </section>
+
+        {/* Pillars */}
+        <section className="border-t border-border bg-card">
+          <Container width="xl" className="py-20 sm:py-24">
+            <div className="mx-auto max-w-2xl text-center">
+              <p className="text-xs font-medium uppercase tracking-wider text-primary">
+                The four pillars
+              </p>
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+                Everything a grower actually needs
+              </h2>
+              <p className="mt-3 text-muted-foreground">
+                Built around the work, not the dashboard.
+              </p>
+            </div>
+            <div className="mt-14 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+              {PILLARS.map(({ Icon, title, description }) => (
+                <Card
+                  key={title}
+                  className="group transition-all duration-200 hover:-translate-y-0.5 hover:shadow-elevation-2"
+                >
+                  <CardContent className="p-6 pt-6">
+                    <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-md bg-accent text-accent-foreground transition-colors group-hover:bg-primary group-hover:text-primary-foreground">
+                      <Icon width={22} height={22} />
+                    </div>
+                    <h3 className="text-base font-semibold text-foreground">
+                      {title}
+                    </h3>
+                    <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground">
+                      {description}
+                    </p>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </Container>
+        </section>
+
+        {/* Principles */}
+        <section className="border-t border-border">
+          <Container width="xl" className="py-20 sm:py-24">
+            <div className="grid gap-8 lg:grid-cols-3">
+              {PRINCIPLES.map((p) => (
+                <div
+                  key={p.label}
+                  className="border-l-2 border-primary/40 pl-5"
+                >
+                  <p className="text-sm font-semibold text-primary">
+                    {p.label}
+                  </p>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    {p.body}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </Container>
+        </section>
+
+        {/* CTA */}
+        <section className="border-t border-border bg-accent/40">
+          <Container width="md" className="py-16 text-center">
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+              Ready to give your grow a copilot?
+            </h2>
+            <p className="mt-2 text-muted-foreground">
+              Sign in with email and you&apos;re tracking your first plant in 60
+              seconds.
+            </p>
+            <div className="mt-6 flex justify-center">
+              <Link href="/auth">
+                <Button
+                  size="lg"
+                  rightIcon={<ArrowRightIcon width={16} height={16} />}
+                >
+                  Create your account
+                </Button>
+              </Link>
+            </div>
+          </Container>
+        </section>
+      </main>
+
+      <footer className="border-t border-border bg-card">
+        <Container
+          width="xl"
+          className="flex flex-col items-center justify-between gap-2 py-8 text-xs text-muted-foreground sm:flex-row"
+        >
+          <p>
+            © {new Date().getFullYear()} PhenoSage. Web-first,
+            privacy-respecting.
+          </p>
+          <div className="flex items-center gap-4">
+            <Link href="/auth" className="hover:text-foreground">
+              Sign in
+            </Link>
+            <Link href="/dashboard" className="hover:text-foreground">
+              Dashboard
+            </Link>
+          </div>
+        </Container>
       </footer>
-    </main>
+    </div>
   );
 }
-
-const pillars = [
-  {
-    icon: "🔬",
-    title: "Visual Grow Doctor",
-    description:
-      "Upload plant photos and receive structured AI evaluations with severity-ranked findings.",
-  },
-  {
-    icon: "📊",
-    title: "Longitudinal Intelligence",
-    description:
-      "Compare new photos to prior uploads. Track health scores over your entire grow timeline.",
-  },
-  {
-    icon: "💬",
-    title: "Grow-aware Copilot",
-    description:
-      "Chat with an AI that knows your strains, your history, and your grow environment.",
-  },
-  {
-    icon: "🔔",
-    title: "Proactive Alerts",
-    description:
-      "Daily summaries, task generation, and reminders tailored to your grow stage.",
-  },
-];

--- a/apps/web/src/app/plants/[plantId]/page.tsx
+++ b/apps/web/src/app/plants/[plantId]/page.tsx
@@ -1,72 +1,158 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { AppShell } from "@/components/app-shell/app-shell";
+import { PageHeader } from "@/components/app-shell/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  ArrowLeftIcon,
+  ImageIcon,
+  ScopeIcon,
+  UploadIcon,
+} from "@/components/ui/icons";
+import { getServerUser } from "@/lib/server/auth";
 
 export const metadata: Metadata = { title: "Plant Detail" };
+export const dynamic = "force-dynamic";
 
 interface Props {
   params: Promise<{ plantId: string }>;
 }
 
 export default async function PlantPage({ params }: Props) {
+  const user = await getServerUser();
+  if (!user) redirect("/auth?next=/plants");
+
   const { plantId } = await params;
+  const shortId = plantId.length > 12 ? `${plantId.slice(0, 8)}…` : plantId;
 
   return (
-    <main className="mx-auto max-w-5xl px-6 py-10">
-      <div className="mb-6">
-        <Link href="/grows" className="text-sm text-gray-500 hover:text-gray-700">
-          ← Back to grows
-        </Link>
-      </div>
+    <AppShell user={{ email: user.email ?? user.id }}>
+      <Container width="xl" className="space-y-6 py-8 md:py-10">
+        <nav aria-label="Breadcrumb" className="text-sm">
+          <Link
+            href="/grows"
+            className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeftIcon width={14} height={14} />
+            Grows
+          </Link>
+        </nav>
 
-      <h1 className="mb-2 text-2xl font-bold text-gray-900">Plant</h1>
-      <p className="mb-8 text-sm text-gray-400">ID: {plantId}</p>
+        <PageHeader
+          eyebrow="Plant"
+          title="Untitled plant"
+          description={
+            <span className="inline-flex items-center gap-2">
+              <Badge variant="outline" className="font-mono">
+                {shortId}
+              </Badge>
+              <span>Track photos, findings, and analyses for this plant.</span>
+            </span>
+          }
+          actions={
+            <Button leftIcon={<UploadIcon width={16} height={16} />}>
+              Upload photo
+            </Button>
+          }
+        />
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* Timeline column */}
-        <div className="lg:col-span-2 space-y-4">
-          <div className="rounded-xl border bg-white p-6">
-            <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              Photo Timeline
-            </h2>
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-10 text-center text-sm text-gray-400">
-              {/* TODO: Render plant_images ordered by takenAt */}
-              No photos yet. Upload the first photo.
-            </div>
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Timeline + analysis */}
+          <div className="space-y-6 lg:col-span-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>Photo timeline</CardTitle>
+                <CardDescription>
+                  Chronological feed, newest first.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <EmptyState
+                  icon={<ImageIcon width={20} height={20} />}
+                  title="No photos yet"
+                  description="Upload your first shot to begin tracking growth and health."
+                  action={
+                    <Button
+                      size="sm"
+                      leftIcon={<UploadIcon width={14} height={14} />}
+                    >
+                      Upload first photo
+                    </Button>
+                  }
+                />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>AI analysis</CardTitle>
+                <CardDescription>
+                  Latest findings and severity-ranked recommendations.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <EmptyState
+                  icon={<ScopeIcon width={20} height={20} />}
+                  title="Nothing to analyze yet"
+                  description="Once you upload a photo, the visual doctor runs automatically."
+                />
+              </CardContent>
+            </Card>
           </div>
 
-          <div className="rounded-xl border bg-white p-6">
-            <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              AI Analysis
-            </h2>
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-10 text-center text-sm text-gray-400">
-              {/* TODO: Render latest AnalysisResponse */}
-              Upload a photo to trigger analysis.
-            </div>
+          {/* Sidebar */}
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle>Upload</CardTitle>
+                <CardDescription>JPG or PNG, up to 10 MB.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className="flex cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-border bg-muted/30 px-4 py-10 text-center transition-colors hover:border-primary/40 hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <UploadIcon
+                    width={24}
+                    height={24}
+                    className="mb-2 text-muted-foreground"
+                  />
+                  <p className="text-sm font-medium text-foreground">
+                    Drag a photo here
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    or click to browse
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Findings</CardTitle>
+                <CardDescription>Open issues for this plant.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <p className="text-sm text-muted-foreground">
+                  No findings yet — your plant looks all clear.
+                </p>
+              </CardContent>
+            </Card>
           </div>
         </div>
-
-        {/* Sidebar */}
-        <div className="space-y-4">
-          <div className="rounded-xl border bg-white p-6">
-            <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              Upload Photo
-            </h2>
-            <div className="rounded-lg border-2 border-dashed border-gray-200 p-8 text-center text-sm text-gray-400">
-              {/* TODO: Wire upload to /api/uploads/sign → Supabase Storage */}
-              Photo upload component
-            </div>
-          </div>
-
-          <div className="rounded-xl border bg-white p-6">
-            <h2 className="mb-4 text-lg font-semibold text-gray-900">
-              Findings
-            </h2>
-            <p className="text-sm text-gray-400">
-              No findings yet.
-            </p>
-          </div>
-        </div>
-      </div>
-    </main>
+      </Container>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/plants/page.tsx
+++ b/apps/web/src/app/plants/page.tsx
@@ -24,11 +24,9 @@ export default async function PlantsIndexPage() {
           title="Plants"
           description="Every plant across your grows, with their latest health snapshot."
           actions={
-            <Link href="/grows">
-              <Button leftIcon={<PlusIcon width={16} height={16} />}>
-                Add a plant
-              </Button>
-            </Link>
+            <Button asChild leftIcon={<PlusIcon width={16} height={16} />}>
+              <Link href="/grows">Add a plant</Link>
+            </Button>
           }
         />
 
@@ -37,11 +35,13 @@ export default async function PlantsIndexPage() {
           title="No plants yet"
           description="Plants live inside grows. Create a grow to add your first plant."
           action={
-            <Link href="/grows">
-              <Button size="sm" leftIcon={<PlusIcon width={14} height={14} />}>
-                Go to grows
-              </Button>
-            </Link>
+            <Button
+              asChild
+              size="sm"
+              leftIcon={<PlusIcon width={14} height={14} />}
+            >
+              <Link href="/grows">Go to grows</Link>
+            </Button>
           }
         />
       </Container>

--- a/apps/web/src/app/plants/page.tsx
+++ b/apps/web/src/app/plants/page.tsx
@@ -6,46 +6,44 @@ import { PageHeader } from "@/components/app-shell/page-header";
 import { Button } from "@/components/ui/button";
 import { Container } from "@/components/ui/container";
 import { EmptyState } from "@/components/ui/empty-state";
-import { LeafIcon, PlusIcon } from "@/components/ui/icons";
+import { ImageIcon, PlusIcon } from "@/components/ui/icons";
 import { getServerUser } from "@/lib/server/auth";
 
-export const metadata: Metadata = { title: "Grows" };
+export const metadata: Metadata = { title: "Plants" };
 export const dynamic = "force-dynamic";
 
-export default async function GrowsPage() {
+export default async function PlantsIndexPage() {
   const user = await getServerUser();
-  if (!user) redirect("/auth?next=/grows");
+  if (!user) redirect("/auth?next=/plants");
 
   return (
     <AppShell user={{ email: user.email ?? user.id }}>
       <Container width="xl" className="space-y-8 py-8 md:py-10">
         <PageHeader
           eyebrow="Workspace"
-          title="My grows"
-          description="Each grow groups its plants, photos, and findings."
+          title="Plants"
+          description="Every plant across your grows, with their latest health snapshot."
           actions={
-            <Button leftIcon={<PlusIcon width={16} height={16} />}>
-              New grow
-            </Button>
-          }
-        />
-
-        <EmptyState
-          icon={<LeafIcon width={20} height={20} />}
-          title="No grows yet"
-          description="Create your first grow to start tracking plants, photos, and AI findings."
-          action={
-            <Link href="#">
+            <Link href="/grows">
               <Button leftIcon={<PlusIcon width={16} height={16} />}>
-                Create your first grow
+                Add a plant
               </Button>
             </Link>
           }
         />
 
-        <p className="text-xs text-muted-foreground">
-          Grows are loaded server-side via Supabase with row-level security.
-        </p>
+        <EmptyState
+          icon={<ImageIcon width={20} height={20} />}
+          title="No plants yet"
+          description="Plants live inside grows. Create a grow to add your first plant."
+          action={
+            <Link href="/grows">
+              <Button size="sm" leftIcon={<PlusIcon width={14} height={14} />}>
+                Go to grows
+              </Button>
+            </Link>
+          }
+        />
       </Container>
     </AppShell>
   );

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,61 +1,111 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { redirect } from "next/navigation";
+import { AppShell } from "@/components/app-shell/app-shell";
+import { PageHeader } from "@/components/app-shell/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Container } from "@/components/ui/container";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { getServerUser } from "@/lib/server/auth";
 
 export const metadata: Metadata = { title: "Settings" };
+export const dynamic = "force-dynamic";
 
-export default function SettingsPage() {
+export default async function SettingsPage() {
+  const user = await getServerUser();
+  if (!user) redirect("/auth?next=/settings");
+
   return (
-    <main className="mx-auto max-w-2xl px-6 py-10">
-      <h1 className="mb-8 text-2xl font-bold text-gray-900">Settings</h1>
+    <AppShell user={{ email: user.email ?? user.id }}>
+      <Container width="md" className="space-y-8 py-8 md:py-10">
+        <PageHeader
+          eyebrow="Account"
+          title="Settings"
+          description="Profile, notifications, and account controls."
+        />
 
-      <div className="space-y-6">
-        <section className="rounded-xl border bg-white p-6">
-          <h2 className="mb-4 text-lg font-semibold text-gray-900">Profile</h2>
-          <div className="space-y-3">
-            <div>
-              <label className="block text-sm font-medium text-gray-700">
-                Display name
-              </label>
-              {/* TODO: Wire to Supabase profiles table update */}
-              <input
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+            <CardDescription>How you appear inside PhenoSage.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={user.email ?? ""}
+                readOnly
+                aria-readonly
+                className="bg-muted/40"
+              />
+              <p className="text-xs text-muted-foreground">
+                Used for login and alerts. Contact support to change.
+              </p>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="display-name">Display name</Label>
+              <Input
+                id="display-name"
                 type="text"
-                className="mt-1 w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-brand-400 focus:outline-none"
                 placeholder="Your name"
                 disabled
               />
             </div>
-          </div>
-        </section>
+            <div className="flex justify-end">
+              <Button disabled size="sm">
+                Save changes
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
 
-        <section className="rounded-xl border bg-white p-6">
-          <h2 className="mb-4 text-lg font-semibold text-gray-900">
-            Notifications
-          </h2>
-          <p className="text-sm text-gray-400">
-            {/* TODO: Add notification preferences */}
-            Notification preferences coming in Milestone 2.
-          </p>
-        </section>
+        <Card>
+          <CardHeader>
+            <div className="flex items-center justify-between">
+              <div>
+                <CardTitle>Notifications</CardTitle>
+                <CardDescription>Daily summaries and alerts.</CardDescription>
+              </div>
+              <Badge variant="secondary">Milestone 2</Badge>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Notification preferences land with the alerts cron. You&apos;ll be
+              able to choose summary cadence, severity threshold, and quiet
+              hours.
+            </p>
+          </CardContent>
+        </Card>
 
-        <section className="rounded-xl border bg-white p-6">
-          <h2 className="mb-4 text-lg font-semibold text-gray-900 text-red-600">
-            Danger Zone
-          </h2>
-          <p className="text-sm text-gray-400">
-            {/* TODO: Delete account flow */}
-            Account deletion coming soon.
-          </p>
-        </section>
-      </div>
-
-      <div className="mt-8">
-        <Link
-          href="/dashboard"
-          className="text-sm text-gray-500 hover:text-gray-700"
-        >
-          ← Back to dashboard
-        </Link>
-      </div>
-    </main>
+        <Card className="border-destructive/40">
+          <CardHeader>
+            <CardTitle className="text-destructive">Danger zone</CardTitle>
+            <CardDescription>
+              Irreversible actions on your account.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Account deletion will be wired in once it has a confirmation flow
+              with two-factor verification.
+            </p>
+            <Button variant="destructive" size="sm" disabled>
+              Delete account
+            </Button>
+          </CardContent>
+        </Card>
+      </Container>
+    </AppShell>
   );
 }

--- a/apps/web/src/components/app-shell/app-shell.tsx
+++ b/apps/web/src/components/app-shell/app-shell.tsx
@@ -66,7 +66,7 @@ export function AppShell({ user, children }: AppShellProps) {
           <main
             id="main-content"
             tabIndex={-1}
-            className="flex-1 pb-20 outline-none md:pb-0"
+            className="flex flex-1 flex-col pb-20 outline-none md:pb-0"
           >
             {children}
           </main>

--- a/apps/web/src/components/app-shell/app-shell.tsx
+++ b/apps/web/src/components/app-shell/app-shell.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { LeafIcon } from "@/components/ui/icons";
+import { MobileBottomNav, SidebarNav } from "./nav";
+import { ThemeToggle } from "./theme-toggle";
+import { UserMenu } from "./user-menu";
+
+interface AppShellProps {
+  user: { email: string };
+  children: ReactNode;
+}
+
+/**
+ * Authenticated layout with persistent sidebar (md+) and bottom nav (mobile).
+ * Pages render inside <main id="main-content"> for skip-link targeting.
+ */
+export function AppShell({ user, children }: AppShellProps) {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="flex">
+        {/* Sidebar — desktop */}
+        <aside
+          aria-label="Sidebar"
+          className="sticky top-0 hidden h-screen w-60 shrink-0 border-r border-border bg-card md:flex md:flex-col"
+        >
+          <Link
+            href="/dashboard"
+            className="flex h-16 items-center gap-2 border-b border-border px-5 font-semibold tracking-tight"
+          >
+            <span
+              aria-hidden="true"
+              className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground"
+            >
+              <LeafIcon width={18} height={18} />
+            </span>
+            <span>PhenoSage</span>
+          </Link>
+          <SidebarNav className="flex-1" />
+          <div className="border-t border-border p-3 text-[11px] text-muted-foreground">
+            <p>v0.1 · Web-first OS</p>
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          {/* Top bar */}
+          <header className="sticky top-0 z-20 flex h-16 items-center justify-between gap-3 border-b border-border bg-background/85 px-4 backdrop-blur md:px-6">
+            {/* Mobile brand */}
+            <Link
+              href="/dashboard"
+              className="flex items-center gap-2 font-semibold tracking-tight md:hidden"
+            >
+              <span
+                aria-hidden="true"
+                className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground"
+              >
+                <LeafIcon width={16} height={16} />
+              </span>
+              <span>PhenoSage</span>
+            </Link>
+            <div className="flex flex-1 items-center justify-end gap-3">
+              <ThemeToggle />
+              <UserMenu email={user.email} />
+            </div>
+          </header>
+
+          <main
+            id="main-content"
+            tabIndex={-1}
+            className="flex-1 pb-20 outline-none md:pb-0"
+          >
+            {children}
+          </main>
+        </div>
+      </div>
+
+      <MobileBottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/components/app-shell/nav.tsx
+++ b/apps/web/src/components/app-shell/nav.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  HomeIcon,
+  LeafIcon,
+  ChatIcon,
+  SettingsIcon,
+  ImageIcon,
+} from "@/components/ui/icons";
+import { cn } from "@/lib/cn";
+
+export interface NavItem {
+  href: string;
+  label: string;
+  Icon: typeof HomeIcon;
+}
+
+export const NAV_ITEMS: NavItem[] = [
+  { href: "/dashboard", label: "Dashboard", Icon: HomeIcon },
+  { href: "/grows", label: "Grows", Icon: LeafIcon },
+  { href: "/plants", label: "Plants", Icon: ImageIcon },
+  { href: "/assistant", label: "Assistant", Icon: ChatIcon },
+  { href: "/settings", label: "Settings", Icon: SettingsIcon },
+];
+
+function isActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false;
+  if (href === "/dashboard") return pathname === href;
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function SidebarNav({ className }: { className?: string }) {
+  const pathname = usePathname();
+  return (
+    <nav
+      aria-label="Primary"
+      className={cn("flex flex-col gap-0.5 px-3 py-4", className)}
+    >
+      {NAV_ITEMS.map(({ href, label, Icon }) => {
+        const active = isActive(pathname, href);
+        return (
+          <Link
+            key={href}
+            href={href}
+            aria-current={active ? "page" : undefined}
+            className={cn(
+              "group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium",
+              "transition-colors duration-150",
+              active
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <Icon
+              width={18}
+              height={18}
+              className={cn(
+                "transition-colors",
+                active
+                  ? "text-primary"
+                  : "text-muted-foreground group-hover:text-foreground",
+              )}
+            />
+            <span>{label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function MobileBottomNav() {
+  const pathname = usePathname();
+  return (
+    <nav
+      aria-label="Primary"
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/90 backdrop-blur md:hidden"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <ul className="grid grid-cols-5">
+        {NAV_ITEMS.map(({ href, label, Icon }) => {
+          const active = isActive(pathname, href);
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                aria-current={active ? "page" : undefined}
+                aria-label={label}
+                className={cn(
+                  "flex h-14 flex-col items-center justify-center gap-0.5 text-[11px]",
+                  active
+                    ? "text-primary"
+                    : "text-muted-foreground active:text-foreground",
+                )}
+              >
+                <Icon
+                  width={20}
+                  height={20}
+                  className={cn(active && "drop-shadow")}
+                />
+                <span className="leading-none">{label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/web/src/components/app-shell/page-header.tsx
+++ b/apps/web/src/components/app-shell/page-header.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+interface PageHeaderProps {
+  eyebrow?: string;
+  title: string;
+  description?: ReactNode;
+  actions?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between",
+        className,
+      )}
+    >
+      <div className="space-y-1">
+        {eyebrow && (
+          <p className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+            {eyebrow}
+          </p>
+        )}
+        <h1 className="text-2xl font-semibold tracking-tight text-foreground sm:text-[1.75rem]">
+          {title}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions && (
+        <div className="flex flex-wrap items-center gap-2">{actions}</div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/app-shell/skip-link.tsx
+++ b/apps/web/src/components/app-shell/skip-link.tsx
@@ -1,0 +1,7 @@
+export function SkipLink({ href = "#main-content" }: { href?: string }) {
+  return (
+    <a href={href} className="skip-link">
+      Skip to main content
+    </a>
+  );
+}

--- a/apps/web/src/components/app-shell/theme-script.tsx
+++ b/apps/web/src/components/app-shell/theme-script.tsx
@@ -1,0 +1,17 @@
+/**
+ * Inline theme bootstrap. Runs before paint to prevent the dark/light flash.
+ * Reads `theme` from localStorage (set by ThemeToggle) or falls back to OS pref.
+ */
+const SCRIPT = `(() => {
+  try {
+    const saved = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = saved === 'light' || saved === 'dark' ? saved : (prefersDark ? 'dark' : 'light');
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    document.documentElement.style.colorScheme = theme;
+  } catch (_) {}
+})();`;
+
+export function ThemeScript() {
+  return <script dangerouslySetInnerHTML={{ __html: SCRIPT }} />;
+}

--- a/apps/web/src/components/app-shell/theme-toggle.tsx
+++ b/apps/web/src/components/app-shell/theme-toggle.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { MoonIcon, SunIcon, SystemIcon } from "@/components/ui/icons";
+import { cn } from "@/lib/cn";
+
+type Theme = "light" | "dark" | "system";
+
+function applyTheme(theme: Theme): void {
+  const root = document.documentElement;
+  const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const dark = theme === "dark" || (theme === "system" && prefersDark);
+  root.classList.toggle("dark", dark);
+  root.style.colorScheme = dark ? "dark" : "light";
+  if (theme === "system") {
+    localStorage.removeItem("theme");
+  } else {
+    localStorage.setItem("theme", theme);
+  }
+}
+
+function readTheme(): Theme {
+  if (typeof window === "undefined") return "system";
+  const saved = localStorage.getItem("theme");
+  return saved === "light" || saved === "dark" ? saved : "system";
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("system");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setTheme(readTheme());
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (theme !== "system") return;
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = () => applyTheme("system");
+    media.addEventListener("change", onChange);
+    return () => media.removeEventListener("change", onChange);
+  }, [theme]);
+
+  function pick(next: Theme): void {
+    setTheme(next);
+    applyTheme(next);
+  }
+
+  // Avoid hydration mismatch — render disabled placeholder on server
+  if (!mounted) {
+    return (
+      <div
+        aria-hidden="true"
+        className="h-9 w-[7.25rem] rounded-md border border-input bg-muted/40"
+      />
+    );
+  }
+
+  const options: { value: Theme; label: string; Icon: typeof SunIcon }[] = [
+    { value: "light", label: "Light theme", Icon: SunIcon },
+    { value: "system", label: "Match system theme", Icon: SystemIcon },
+    { value: "dark", label: "Dark theme", Icon: MoonIcon },
+  ];
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Color theme"
+      className="inline-flex items-center rounded-md border border-input bg-background p-0.5"
+    >
+      {options.map(({ value, label, Icon }) => {
+        const active = theme === value;
+        return (
+          <Button
+            key={value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={label}
+            variant="ghost"
+            size="sm"
+            onClick={() => pick(value)}
+            className={cn(
+              "h-8 w-8 p-0",
+              active && "bg-accent text-accent-foreground",
+            )}
+          >
+            <Icon width={16} height={16} />
+          </Button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/app-shell/user-menu.tsx
+++ b/apps/web/src/components/app-shell/user-menu.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { signOutAction } from "@/app/auth/actions";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/cn";
+
+function initials(email: string): string {
+  const local = email.split("@")[0] ?? email;
+  const parts = local.split(/[._-]+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return ((parts[0]?.[0] ?? "") + (parts[1]?.[0] ?? "")).toUpperCase();
+  }
+  return local.slice(0, 2).toUpperCase();
+}
+
+export function UserMenu({ email }: { email: string }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-label="Account menu"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className={cn(
+          "flex h-9 w-9 items-center justify-center rounded-full",
+          "bg-accent text-xs font-semibold text-accent-foreground",
+          "ring-offset-background transition hover:opacity-90",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        )}
+      >
+        {initials(email)}
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-11 z-40 w-56 origin-top-right animate-fade-in-up rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-elevation-3"
+        >
+          <div className="border-b border-border px-3 py-2 text-xs">
+            <p className="font-semibold text-foreground">Signed in</p>
+            <p className="truncate text-muted-foreground">{email}</p>
+          </div>
+          <form action={signOutAction} className="p-1">
+            <Button
+              type="submit"
+              variant="ghost"
+              size="sm"
+              fullWidth
+              className="justify-start"
+              role="menuitem"
+            >
+              Sign out
+            </Button>
+          </form>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,0 +1,43 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+type Variant =
+  | "default"
+  | "secondary"
+  | "outline"
+  | "success"
+  | "warning"
+  | "destructive"
+  | "info";
+
+const VARIANTS: Record<Variant, string> = {
+  default: "bg-primary text-primary-foreground",
+  secondary: "bg-secondary text-secondary-foreground",
+  outline: "border border-border bg-transparent text-foreground",
+  success: "bg-success/15 text-success border border-success/30",
+  warning: "bg-warning/15 text-warning border border-warning/30",
+  destructive:
+    "bg-destructive/15 text-destructive border border-destructive/30",
+  info: "bg-info/15 text-info border border-info/30",
+};
+
+interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  variant?: Variant;
+}
+
+export function Badge({
+  variant = "default",
+  className,
+  ...props
+}: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium leading-none",
+        VARIANTS[variant],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,4 +1,13 @@
-import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { cn } from "@/lib/cn";
 
 type Variant =
@@ -30,6 +39,25 @@ const SIZES: Record<Size, string> = {
   icon: "h-10 w-10 p-0",
 };
 
+export function buttonVariants({
+  variant = "primary",
+  size = "md",
+  fullWidth,
+}: {
+  variant?: Variant;
+  size?: Size;
+  fullWidth?: boolean;
+} = {}): string {
+  return cn(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-colors duration-150 ease-out-expo",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "disabled:pointer-events-none disabled:opacity-50",
+    VARIANTS[variant],
+    SIZES[size],
+    fullWidth && "w-full",
+  );
+}
+
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
   size?: Size;
@@ -37,6 +65,36 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
   fullWidth?: boolean;
+  /**
+   * When true, clone the single child element and apply button styles to it
+   * instead of rendering a <button>. Use this to style a <Link> as a button
+   * without nesting <a> > <button> (which is invalid interactive markup).
+   */
+  asChild?: boolean;
+}
+
+function buttonContent({
+  loading,
+  leftIcon,
+  rightIcon,
+  children,
+}: Pick<ButtonProps, "loading" | "leftIcon" | "rightIcon"> & {
+  children: ReactNode;
+}) {
+  return (
+    <>
+      {loading ? (
+        <span
+          className="h-4 w-4 animate-spin rounded-full border-2 border-current border-r-transparent"
+          aria-hidden="true"
+        />
+      ) : (
+        leftIcon
+      )}
+      {children}
+      {!loading && rightIcon}
+    </>
+  );
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -52,37 +110,57 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       fullWidth,
       children,
       type = "button",
+      asChild = false,
       ...rest
     },
     ref,
   ) {
+    const classes = cn(
+      buttonVariants({
+        variant,
+        size,
+        ...(fullWidth !== undefined && { fullWidth }),
+      }),
+      className,
+    );
+
+    if (asChild) {
+      const child = Children.only(children);
+      if (!isValidElement(child)) {
+        throw new Error("Button asChild requires a single valid React element");
+      }
+      const el = child as ReactElement<{
+        className?: string;
+        children?: ReactNode;
+      }>;
+      return cloneElement(
+        el,
+        {
+          ...(rest as AnchorHTMLAttributes<HTMLAnchorElement>),
+          ref,
+          className: cn(classes, el.props.className),
+          "aria-busy": loading || undefined,
+          "aria-disabled": disabled || loading || undefined,
+        } as Partial<typeof el.props>,
+        buttonContent({
+          loading,
+          leftIcon,
+          rightIcon,
+          children: el.props.children,
+        }),
+      );
+    }
+
     return (
       <button
         ref={ref}
         type={type}
         disabled={disabled || loading}
         aria-busy={loading || undefined}
-        className={cn(
-          "inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-colors duration-150 ease-out-expo",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-          "disabled:pointer-events-none disabled:opacity-50",
-          VARIANTS[variant],
-          SIZES[size],
-          fullWidth && "w-full",
-          className,
-        )}
+        className={classes}
         {...rest}
       >
-        {loading ? (
-          <span
-            className="h-4 w-4 animate-spin rounded-full border-2 border-current border-r-transparent"
-            aria-hidden="true"
-          />
-        ) : (
-          leftIcon
-        )}
-        {children}
-        {!loading && rightIcon}
+        {buttonContent({ loading, leftIcon, rightIcon, children })}
       </button>
     );
   },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,0 +1,89 @@
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type Variant =
+  | "primary"
+  | "secondary"
+  | "outline"
+  | "ghost"
+  | "destructive"
+  | "link";
+type Size = "sm" | "md" | "lg" | "icon";
+
+const VARIANTS: Record<Variant, string> = {
+  primary:
+    "bg-primary text-primary-foreground shadow-elevation-1 hover:bg-primary/90 active:bg-primary/95",
+  secondary:
+    "bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70",
+  outline:
+    "border border-border bg-transparent text-foreground hover:bg-muted active:bg-muted/80",
+  ghost: "bg-transparent text-foreground hover:bg-muted active:bg-muted/80",
+  destructive:
+    "bg-destructive text-destructive-foreground shadow-elevation-1 hover:bg-destructive/90",
+  link: "bg-transparent text-primary underline-offset-4 hover:underline px-0 h-auto",
+};
+
+const SIZES: Record<Size, string> = {
+  sm: "h-8 px-3 text-xs gap-1.5",
+  md: "h-10 px-4 text-sm gap-2",
+  lg: "h-11 px-6 text-base gap-2",
+  icon: "h-10 w-10 p-0",
+};
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+  loading?: boolean;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
+  fullWidth?: boolean;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      className,
+      variant = "primary",
+      size = "md",
+      loading = false,
+      disabled,
+      leftIcon,
+      rightIcon,
+      fullWidth,
+      children,
+      type = "button",
+      ...rest
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        disabled={disabled || loading}
+        aria-busy={loading || undefined}
+        className={cn(
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-colors duration-150 ease-out-expo",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "disabled:pointer-events-none disabled:opacity-50",
+          VARIANTS[variant],
+          SIZES[size],
+          fullWidth && "w-full",
+          className,
+        )}
+        {...rest}
+      >
+        {loading ? (
+          <span
+            className="h-4 w-4 animate-spin rounded-full border-2 border-current border-r-transparent"
+            aria-hidden="true"
+          />
+        ) : (
+          leftIcon
+        )}
+        {children}
+        {!loading && rightIcon}
+      </button>
+    );
+  },
+);

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,80 @@
+import { forwardRef, type HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export const Card = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  function Card({ className, ...props }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "rounded-lg border bg-card text-card-foreground shadow-elevation-1",
+          "transition-shadow duration-200",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+export const CardHeader = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardHeader({ className, ...props }, ref) {
+  return (
+    <div
+      ref={ref}
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  );
+});
+
+export const CardTitle = forwardRef<
+  HTMLHeadingElement,
+  HTMLAttributes<HTMLHeadingElement>
+>(function CardTitle({ className, ...props }, ref) {
+  return (
+    <h3
+      ref={ref}
+      className={cn(
+        "text-base font-semibold leading-tight tracking-tight",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+
+export const CardDescription = forwardRef<
+  HTMLParagraphElement,
+  HTMLAttributes<HTMLParagraphElement>
+>(function CardDescription({ className, ...props }, ref) {
+  return (
+    <p
+      ref={ref}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  );
+});
+
+export const CardContent = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardContent({ className, ...props }, ref) {
+  return <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />;
+});
+
+export const CardFooter = forwardRef<
+  HTMLDivElement,
+  HTMLAttributes<HTMLDivElement>
+>(function CardFooter({ className, ...props }, ref) {
+  return (
+    <div
+      ref={ref}
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  );
+});

--- a/apps/web/src/components/ui/container.tsx
+++ b/apps/web/src/components/ui/container.tsx
@@ -1,0 +1,33 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+type Width = "sm" | "md" | "lg" | "xl" | "full";
+
+const WIDTHS: Record<Width, string> = {
+  sm: "max-w-2xl",
+  md: "max-w-4xl",
+  lg: "max-w-5xl",
+  xl: "max-w-7xl",
+  full: "max-w-none",
+};
+
+interface ContainerProps extends HTMLAttributes<HTMLDivElement> {
+  width?: Width;
+}
+
+export function Container({
+  width = "lg",
+  className,
+  ...props
+}: ContainerProps) {
+  return (
+    <div
+      className={cn(
+        "mx-auto w-full px-5 sm:px-6 lg:px-8",
+        WIDTHS[width],
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+interface EmptyStateProps {
+  icon?: ReactNode;
+  title: string;
+  description?: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-muted/30 px-6 py-14 text-center",
+        className,
+      )}
+    >
+      {icon && (
+        <div
+          aria-hidden="true"
+          className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accent text-accent-foreground"
+        >
+          {icon}
+        </div>
+      )}
+      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      {description && (
+        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+          {description}
+        </p>
+      )}
+      {action && <div className="mt-5">{action}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/icons.tsx
+++ b/apps/web/src/components/ui/icons.tsx
@@ -1,0 +1,155 @@
+/**
+ * Inline SVG icon set — kept minimal so we don't ship a dependency.
+ * All icons inherit currentColor and accept any SVGProps.
+ */
+import type { ReactElement, SVGProps } from "react";
+
+type Icon = (_props: SVGProps<SVGSVGElement>) => ReactElement;
+
+const base = (props: SVGProps<SVGSVGElement>) => ({
+  width: 20,
+  height: 20,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.75,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  "aria-hidden": true,
+  focusable: false,
+  ...props,
+});
+
+export const LeafIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M11 20A7 7 0 0 1 4 13c0-7 7-9 16-9 0 9-2 16-9 16Z" />
+    <path d="M2 21c2-4 6-9 16-12" />
+  </svg>
+);
+
+export const ScopeIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <circle cx="11" cy="11" r="7" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+);
+
+export const TrendIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="m3 17 6-6 4 4 8-8" />
+    <path d="M14 7h7v7" />
+  </svg>
+);
+
+export const ChatIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M21 12a8 8 0 0 1-11.5 7.2L3 21l1.8-6.5A8 8 0 1 1 21 12Z" />
+  </svg>
+);
+
+export const BellIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" />
+    <path d="M10 21a2 2 0 0 0 4 0" />
+  </svg>
+);
+
+export const HomeIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M3 11.5 12 4l9 7.5" />
+    <path d="M5 10v10h14V10" />
+  </svg>
+);
+
+export const SettingsIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h0a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v0a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1Z" />
+  </svg>
+);
+
+export const SunIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+  </svg>
+);
+
+export const MoonIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+  </svg>
+);
+
+export const SystemIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <rect x="3" y="4" width="18" height="13" rx="2" />
+    <path d="M8 21h8M12 17v4" />
+  </svg>
+);
+
+export const PlusIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M12 5v14M5 12h14" />
+  </svg>
+);
+
+export const ArrowRightIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M5 12h14M13 5l7 7-7 7" />
+  </svg>
+);
+
+export const ArrowLeftIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M19 12H5M11 5l-7 7 7 7" />
+  </svg>
+);
+
+export const SparklesIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="m12 3 1.9 5.1L19 10l-5.1 1.9L12 17l-1.9-5.1L5 10l5.1-1.9Z" />
+    <path d="M5 18l.7 1.8L7.5 20l-1.8.7L5 22.5 4.3 20.7 2.5 20l1.8-.7Z" />
+  </svg>
+);
+
+export const UploadIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <path d="M17 8 12 3 7 8M12 3v12" />
+  </svg>
+);
+
+export const CheckCircleIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M22 11.1V12a10 10 0 1 1-5.9-9.1" />
+    <path d="m9 11 3 3L22 4" />
+  </svg>
+);
+
+export const ImageIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <circle cx="9" cy="9" r="2" />
+    <path d="m21 15-5-5L5 21" />
+  </svg>
+);
+
+export const MenuIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+);
+
+export const CloseIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M18 6 6 18M6 6l12 12" />
+  </svg>
+);
+
+export const SendIcon: Icon = (props) => (
+  <svg {...base(props)}>
+    <path d="M22 2 11 13" />
+    <path d="m22 2-7 20-4-9-9-4Z" />
+  </svg>
+);

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,30 @@
+import { forwardRef, type InputHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  invalid?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, invalid, type = "text", ...props },
+  ref,
+) {
+  return (
+    <input
+      ref={ref}
+      type={type}
+      aria-invalid={invalid || undefined}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm",
+        "text-foreground placeholder:text-muted-foreground",
+        "transition-colors duration-150",
+        "focus-visible:outline-none focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40",
+        "disabled:cursor-not-allowed disabled:opacity-60",
+        "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+        invalid && "border-destructive focus-visible:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import { forwardRef, type LabelHTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export const Label = forwardRef<
+  HTMLLabelElement,
+  LabelHTMLAttributes<HTMLLabelElement>
+>(function Label({ className, ...props }, ref) {
+  return (
+    <label
+      ref={ref}
+      className={cn(
+        "text-sm font-medium leading-none text-foreground",
+        "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+        className,
+      )}
+      {...props}
+    />
+  );
+});

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,21 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "@/lib/cn";
+
+export function Skeleton({
+  className,
+  ...props
+}: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        "relative overflow-hidden rounded-md bg-muted",
+        "before:absolute before:inset-0 before:-translate-x-full",
+        "before:bg-gradient-to-r before:from-transparent before:via-foreground/5 before:to-transparent",
+        "before:animate-shimmer",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/lib/cn.ts
+++ b/apps/web/src/lib/cn.ts
@@ -1,13 +1,20 @@
 /**
  * Tiny class-name joiner. Filters falsy values and dedupes whitespace.
  * Avoids pulling in clsx/tailwind-merge as runtime dependencies.
+ *
+ * Supports strings, numbers, arrays, and `{ "class-name": boolean }` objects.
+ * It does NOT resolve Tailwind conflicts — rely on intentional ordering when
+ * overriding component styles via `className` props.
  */
+export type ClassDict = { [key: string]: unknown };
+
 export type ClassValue =
   | string
   | number
   | null
   | false
   | undefined
+  | ClassDict
   | ClassValue[];
 
 export function cn(...inputs: ClassValue[]): string {
@@ -20,6 +27,12 @@ export function cn(...inputs: ClassValue[]): string {
     }
     if (Array.isArray(v)) {
       for (const item of v) walk(item);
+      return;
+    }
+    if (typeof v === "object") {
+      for (const key in v) {
+        if (v[key]) out.push(key);
+      }
     }
   };
   for (const v of inputs) walk(v);

--- a/apps/web/src/lib/cn.ts
+++ b/apps/web/src/lib/cn.ts
@@ -1,0 +1,27 @@
+/**
+ * Tiny class-name joiner. Filters falsy values and dedupes whitespace.
+ * Avoids pulling in clsx/tailwind-merge as runtime dependencies.
+ */
+export type ClassValue =
+  | string
+  | number
+  | null
+  | false
+  | undefined
+  | ClassValue[];
+
+export function cn(...inputs: ClassValue[]): string {
+  const out: string[] = [];
+  const walk = (v: ClassValue): void => {
+    if (!v && v !== 0) return;
+    if (typeof v === "string" || typeof v === "number") {
+      out.push(String(v));
+      return;
+    }
+    if (Array.isArray(v)) {
+      for (const item of v) walk(item);
+    }
+  };
+  for (const v of inputs) walk(v);
+  return out.join(" ").replace(/\s+/g, " ").trim();
+}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,13 +1,71 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    container: {
+      center: true,
+      padding: "1.25rem",
+      screens: {
+        sm: "640px",
+        md: "768px",
+        lg: "1024px",
+        xl: "1280px",
+        "2xl": "1280px",
+      },
+    },
     extend: {
       colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
+        info: {
+          DEFAULT: "hsl(var(--info))",
+          foreground: "hsl(var(--info-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        // Brand palette retained for landing decorative pieces
         brand: {
           50: "#f0fdf4",
           100: "#dcfce7",
@@ -21,6 +79,66 @@ module.exports = {
           900: "#14532d",
           950: "#052e16",
         },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      fontFamily: {
+        sans: [
+          "ui-sans-serif",
+          "-apple-system",
+          "BlinkMacSystemFont",
+          "Segoe UI",
+          "Roboto",
+          "Helvetica",
+          "Arial",
+          "sans-serif",
+        ],
+        mono: [
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Monaco",
+          "Consolas",
+          "monospace",
+        ],
+      },
+      boxShadow: {
+        "elevation-1":
+          "0 1px 2px 0 hsl(var(--foreground) / 0.05), 0 1px 1px -1px hsl(var(--foreground) / 0.04)",
+        "elevation-2":
+          "0 4px 12px -2px hsl(var(--foreground) / 0.08), 0 2px 4px -2px hsl(var(--foreground) / 0.04)",
+        "elevation-3":
+          "0 12px 32px -8px hsl(var(--foreground) / 0.12), 0 4px 8px -4px hsl(var(--foreground) / 0.06)",
+        glow: "0 0 0 1px hsl(var(--ring) / 0.4), 0 8px 24px -8px hsl(var(--ring) / 0.4)",
+      },
+      keyframes: {
+        "fade-in": {
+          from: { opacity: "0" },
+          to: { opacity: "1" },
+        },
+        "fade-in-up": {
+          from: { opacity: "0", transform: "translateY(8px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        shimmer: {
+          "100%": { transform: "translateX(100%)" },
+        },
+        "pulse-soft": {
+          "0%, 100%": { opacity: "1" },
+          "50%": { opacity: "0.5" },
+        },
+      },
+      animation: {
+        "fade-in": "fade-in 0.2s ease-out",
+        "fade-in-up": "fade-in-up 0.25s ease-out",
+        shimmer: "shimmer 1.6s infinite",
+        "pulse-soft": "pulse-soft 2s ease-in-out infinite",
+      },
+      transitionTimingFunction: {
+        "out-expo": "cubic-bezier(0.16, 1, 0.3, 1)",
       },
     },
   },


### PR DESCRIPTION
## Summary

UX overhaul grounded in 2026 SaaS design research — scoped entirely to `apps/web/**`. Zero new npm dependencies, zero schema changes, zero analysis-service changes.

- **Design system**: HSL token set in `globals.css` + `tailwind.config.js` with semantic colors, elevation shadows, reduced-motion support, `.bg-hero-gradient`.
- **UI primitives** (shadcn-style, no new deps): `Button`, `Card`, `Input`, `Label`, `Badge`, `Skeleton`, `EmptyState`, `Container`, 19 inline-SVG icons.
- **App shell**: persistent sidebar + topbar + mobile bottom-nav (with safe-area padding), `PageHeader`, user menu, theme toggle (light / system / dark), FOUC-free theme bootstrap.
- **Dark mode**: `.dark` class override, inline `<script>` reads `localStorage.getItem('theme')` before hydration.
- **Accessibility**: skip-link, `#main-content` target, focus-visible ring token, `aria-current` nav handling, `prefers-reduced-motion` guard.
- **Routes refreshed**: landing, `/auth`, `/dashboard`, `/grows`, `/plants`, `/plants/[id]`, `/assistant`, `/settings`, new `not-found.tsx`.

## Deployment impact

- **Vercel**: will auto-deploy the web app on merge to `main`.
- **Railway**: no change (no `apps/analysis/**` diff).
- **Supabase**: no change (no `supabase/migrations/**` diff).

## Test plan

- [x] `pnpm turbo run type-check lint test` — 5/5 tasks green, 21/21 + 5/5 unit tests
- [x] `pnpm run validate` — guardrails pass
- [x] `pnpm --filter web build` — production build OK
- [x] Route smoke (curl): `/`, `/auth`, `/api/health`, `/api/ready` = 200; authed routes = 307 → `/auth?next=...`; 404 custom page renders
- [x] Security headers verified intact (CSP, HSTS, X-Frame-Options, Permissions-Policy, COOP, CORP)
- [x] Theme bootstrap inlined, `.dark` tokens compiled into layout CSS
- [ ] Vercel preview deploy green
- [ ] Post-merge production deploy green

https://claude.ai/code/session_01T9pQSmS7Rn2LTkMnFnyVeV