### PR TITLE
fix: close PR45 correctness and security blockers

### DIFF
--- a/apps/analysis/app/main.py
+++ b/apps/analysis/app/main.py
@@ -1,5 +1,7 @@
 import logging
 import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -8,6 +10,7 @@ from app.config import settings
 from app.middleware import CorrelationIdMiddleware
 from app.routers.analyze import router as analyze_router
 from app.routers.health import router as health_router
+from app.services.storage import close_http_client
 from app.telemetry import init_all as init_telemetry
 
 
@@ -25,6 +28,14 @@ _configure_logging()
 init_telemetry()
 
 
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    try:
+        yield
+    finally:
+        await close_http_client()
+
+
 app = FastAPI(
     title="PhenoSage Analysis Service",
     description=(
@@ -35,6 +46,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/docs" if settings.app_env != "production" else None,
     redoc_url=None,
+    lifespan=lifespan,
 )
 
 # CORS: only the configured origins (the Vercel app URL in production).

--- a/apps/analysis/app/middleware.py
+++ b/apps/analysis/app/middleware.py
@@ -6,52 +6,56 @@ import json
 import logging
 import time
 import uuid
-from collections.abc import Awaitable, Callable
 
-from fastapi import Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger("phenosage.access")
 REQUEST_ID_HEADER = "x-request-id"
 
 
-class CorrelationIdMiddleware(BaseHTTPMiddleware):
-    """Ensures every request has an ``x-request-id`` header on the response.
+class CorrelationIdMiddleware:
+    """Ensures every request has an ``x-request-id`` header on the response."""
 
-    Honors an inbound ``x-request-id`` so the Next.js proxy can stitch traces
-    across service boundaries. Attaches the ID to ``request.state`` for handlers
-    that want to include it in structured logs.
-    """
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
 
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        inbound = request.headers.get(REQUEST_ID_HEADER)
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        inbound = headers.get(REQUEST_ID_HEADER)
         correlation_id = (
-            inbound
-            if inbound and 1 <= len(inbound) <= 128
-            else uuid.uuid4().hex
+            inbound if inbound and 1 <= len(inbound) <= 128 else uuid.uuid4().hex
         )
-        request.state.correlation_id = correlation_id
+        scope.setdefault("state", {})["correlation_id"] = correlation_id
 
         started = time.perf_counter()
+        status_code: int | None = None
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code
+            if message["type"] == "http.response.start":
+                status_code = int(message["status"])
+                response_headers = MutableHeaders(scope=message)
+                response_headers[REQUEST_ID_HEADER] = correlation_id
+            await send(message)
+
         try:
-            response = await call_next(request)
+            await self.app(scope, receive, send_wrapper)
         except Exception:
             elapsed_ms = (time.perf_counter() - started) * 1000.0
-            _access_log(request, None, elapsed_ms, correlation_id, error=True)
+            _access_log(scope, None, elapsed_ms, correlation_id, error=True)
             raise
 
-        response.headers[REQUEST_ID_HEADER] = correlation_id
         elapsed_ms = (time.perf_counter() - started) * 1000.0
-        _access_log(request, response.status_code, elapsed_ms, correlation_id)
-        return response
+        _access_log(scope, status_code, elapsed_ms, correlation_id)
 
 
 def _access_log(
-    request: Request,
+    scope: Scope,
     status: int | None,
     elapsed_ms: float,
     correlation_id: str,
@@ -61,8 +65,8 @@ def _access_log(
     record = {
         "level": "error" if error else "info",
         "msg": "http_request",
-        "method": request.method,
-        "path": request.url.path,
+        "method": scope["method"],
+        "path": scope["path"],
         "status": status,
         "elapsed_ms": round(elapsed_ms, 2),
         "request_id": correlation_id,

--- a/apps/analysis/app/services/image_analysis.py
+++ b/apps/analysis/app/services/image_analysis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -17,7 +18,6 @@ from app.models.analysis import (
     FindingCategory,
     FindingSeverity,
 )
-from app.services.image_comparison import compare_images
 from app.services.prompts import SYSTEM_PROMPT, build_analysis_prompt
 from app.services.scoring import compute_health_score
 from app.services.storage import (
@@ -32,6 +32,10 @@ logger = logging.getLogger(__name__)
 MODEL_NAME = "gpt-4o"
 MODEL_VERSION = "gpt-4o-2024-08-06"
 FALLBACK_MODEL_VERSION = "phenosage-fallback-0.1"
+JSON_CODE_BLOCK_RE = re.compile(
+    r"```(?:json)?\s*(?P<body>[\s\S]*?)\s*```",
+    re.IGNORECASE,
+)
 
 
 class AnalysisError(RuntimeError):
@@ -86,6 +90,8 @@ async def run_analysis(request: AnalyzeRequest) -> AnalyzeResponse:
     comparison_summary: str | None = None
     if request.previous_image_id and request.previous_storage_path:
         try:
+            from app.services.image_comparison import compare_images
+
             text = await compare_images(
                 request.image_id,
                 request.storage_path,
@@ -140,14 +146,43 @@ async def _call_vision(data_url: str, user_prompt: str) -> dict[str, Any]:
     if not content:
         raise AnalysisError("OpenAI returned an empty response")
 
-    try:
-        parsed = json.loads(content)
-    except json.JSONDecodeError as exc:
-        raise AnalysisError(f"OpenAI response was not valid JSON: {exc}") from exc
+    return _parse_json_object(content)
 
-    if not isinstance(parsed, dict):
-        raise AnalysisError("OpenAI response was not a JSON object")
-    return parsed
+
+def _parse_json_object(content: str) -> dict[str, Any]:
+    candidates: list[str] = []
+    stripped = content.strip()
+    if stripped:
+        candidates.append(stripped)
+
+    if match := JSON_CODE_BLOCK_RE.search(content):
+        fenced = match.group("body").strip()
+        if fenced:
+            candidates.append(fenced)
+
+    start = stripped.find("{")
+    end = stripped.rfind("}")
+    if 0 <= start < end:
+        candidates.append(stripped[start : end + 1].strip())
+
+    seen: set[str] = set()
+    last_error: json.JSONDecodeError | None = None
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            parsed = json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            last_error = exc
+            continue
+        if not isinstance(parsed, dict):
+            raise AnalysisError("OpenAI response was not a JSON object")
+        return parsed
+
+    if last_error is not None:
+        raise AnalysisError(f"OpenAI response was not valid JSON: {last_error}") from last_error
+    raise AnalysisError("OpenAI response was not valid JSON")
 
 
 def _parse_findings(parsed: dict[str, Any]) -> list[AnalysisFinding]:

--- a/apps/analysis/app/services/storage.py
+++ b/apps/analysis/app/services/storage.py
@@ -8,6 +8,7 @@ through ``httpx`` (already a direct dependency) — no supabase-py needed.
 from __future__ import annotations
 
 import base64
+import re
 from urllib.parse import quote
 
 import httpx
@@ -15,10 +16,49 @@ import httpx
 from app.config import settings
 
 BUCKET = "plant-images"
+_VALID_PATH_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+_http_client: httpx.AsyncClient | None = None
 
 
 class StorageFetchError(RuntimeError):
     """Raised when fetching a private object from Supabase Storage fails."""
+
+
+def _normalize_storage_path(storage_path: str) -> str:
+    clean_path = storage_path.strip().lstrip("/")
+    if clean_path.startswith(f"{BUCKET}/"):
+        clean_path = clean_path[len(BUCKET) + 1 :]
+
+    if not clean_path:
+        raise StorageFetchError("storage path is empty")
+    if "://" in clean_path or clean_path.startswith(("http:", "https:")):
+        raise StorageFetchError("storage path must be relative")
+    if "\\" in clean_path or clean_path.startswith("/"):
+        raise StorageFetchError("storage path is invalid")
+    if not _VALID_PATH_RE.fullmatch(clean_path):
+        raise StorageFetchError("storage path contains invalid characters")
+
+    parts = clean_path.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise StorageFetchError("storage path is invalid")
+
+    return clean_path
+
+
+def get_http_client(timeout_s: float = 20.0) -> httpx.AsyncClient:
+    global _http_client
+    if _http_client is None or _http_client.is_closed:
+        _http_client = httpx.AsyncClient(timeout=timeout_s)
+    else:
+        _http_client.timeout = httpx.Timeout(timeout_s)
+    return _http_client
+
+
+async def close_http_client() -> None:
+    global _http_client
+    if _http_client is not None and not _http_client.is_closed:
+        await _http_client.aclose()
+    _http_client = None
 
 
 async def fetch_image_bytes(storage_path: str, timeout_s: float = 20.0) -> bytes:
@@ -29,10 +69,7 @@ async def fetch_image_bytes(storage_path: str, timeout_s: float = 20.0) -> bytes
     if not settings.supabase_url or not settings.supabase_service_role_key:
         raise StorageFetchError("Supabase credentials not configured")
 
-    # Strip a leading bucket prefix if the caller passed one.
-    clean_path = storage_path.lstrip("/")
-    if clean_path.startswith(f"{BUCKET}/"):
-        clean_path = clean_path[len(BUCKET) + 1 :]
+    clean_path = _normalize_storage_path(storage_path)
 
     base = settings.supabase_url.rstrip("/")
     url = f"{base}/storage/v1/object/{BUCKET}/{quote(clean_path, safe='/')}"
@@ -41,8 +78,8 @@ async def fetch_image_bytes(storage_path: str, timeout_s: float = 20.0) -> bytes
         "apikey": settings.supabase_service_role_key,
     }
     try:
-        async with httpx.AsyncClient(timeout=timeout_s) as client:
-            response = await client.get(url, headers=headers)
+        client = get_http_client(timeout_s)
+        response = await client.get(url, headers=headers)
     except httpx.HTTPError as exc:
         raise StorageFetchError(f"storage network error: {exc}") from exc
 

--- a/apps/analysis/tests/test_api.py
+++ b/apps/analysis/tests/test_api.py
@@ -76,6 +76,17 @@ async def test_health_does_not_require_auth() -> None:
 
 
 @pytest.mark.asyncio
+async def test_health_preserves_inbound_request_id() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get("/health", headers={"x-request-id": "req-123"})
+
+    assert response.status_code == 200
+    assert response.headers["x-request-id"] == "req-123"
+
+
+@pytest.mark.asyncio
 async def test_analyze_rejects_wrong_bearer_token() -> None:
     """A syntactically-valid but incorrect token must be rejected."""
     async with AsyncClient(

--- a/apps/analysis/tests/test_image_analysis.py
+++ b/apps/analysis/tests/test_image_analysis.py
@@ -164,6 +164,30 @@ async def test_run_analysis_malformed_json_returns_fallback(
 
 
 @pytest.mark.asyncio
+async def test_run_analysis_accepts_fenced_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch(path: str, timeout_s: float = 20.0) -> bytes:
+        return b"bytes"
+
+    monkeypatch.setattr(image_analysis, "fetch_image_bytes", fake_fetch)
+    monkeypatch.setattr(
+        image_analysis,
+        "get_openai_client",
+        lambda: _FakeClient(
+            """```json
+{"overall_health_score": 82, "summary": "Stable canopy.", "findings": []}
+```"""
+        ),
+    )
+
+    response = await image_analysis.run_analysis(_request())
+
+    assert response.model_version == image_analysis.MODEL_VERSION
+    assert response.summary == "Stable canopy."
+
+
+@pytest.mark.asyncio
 async def test_run_analysis_coerces_unknown_category(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/apps/analysis/tests/test_storage.py
+++ b/apps/analysis/tests/test_storage.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services import storage
+
+
+@pytest.mark.parametrize(
+    ("storage_path", "expected"),
+    [
+        ("plant-images/grow-1/plant-1/image.jpg", "grow-1/plant-1/image.jpg"),
+        ("grow-1/plant-1/image.jpg", "grow-1/plant-1/image.jpg"),
+    ],
+)
+def test_normalize_storage_path_accepts_expected_paths(
+    storage_path: str, expected: str
+) -> None:
+    assert storage._normalize_storage_path(storage_path) == expected
+
+
+@pytest.mark.parametrize(
+    "storage_path",
+    [
+        "",
+        "../etc/passwd",
+        "grow-1/../plant-1/image.jpg",
+        "https://evil.example/object.jpg",
+        "grow-1\\plant-1\\image.jpg",
+        "grow-1/plant 1/image.jpg",
+    ],
+)
+def test_normalize_storage_path_rejects_untrusted_input(storage_path: str) -> None:
+    with pytest.raises(storage.StorageFetchError):
+        storage._normalize_storage_path(storage_path)

--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -39,6 +39,11 @@ vi.mock("@/lib/server/db", () => ({
 
 import { POST } from "../route";
 
+const USER_ID = "11111111-1111-1111-1111-111111111111";
+const THREAD_ID = "22222222-2222-2222-2222-222222222222";
+const GROW_ID = "33333333-3333-3333-3333-333333333333";
+const OTHER_GROW_ID = "44444444-4444-4444-4444-444444444444";
+
 function req(body: unknown): Request {
   return new Request("http://localhost/api/chat", {
     method: "POST",
@@ -65,21 +70,23 @@ describe("POST /api/chat", () => {
   });
 
   it("returns 400 when message missing", async () => {
-    getServerUser.mockResolvedValue({ id: "u1" });
+    getServerUser.mockResolvedValue({ id: USER_ID });
     const res = await POST(
       req({ message: "" }) as unknown as import("next/server").NextRequest,
     );
     expect(res.status).toBe(400);
   });
 
-  it("creates a thread, persists messages, and returns the assistant reply", async () => {
-    getServerUser.mockResolvedValue({ id: "u1" });
+  it("loads the newest thread messages in descending order and replays them oldest-first", async () => {
+    getServerUser.mockResolvedValue({ id: USER_ID });
 
-    const threadInsert = vi.fn().mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        single: vi.fn().mockResolvedValue({
-          data: { id: "t1", grow_id: null },
-          error: null,
+    const threadSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { id: THREAD_ID, user_id: USER_ID, grow_id: null },
+            error: null,
+          }),
         }),
       }),
     });
@@ -106,12 +113,18 @@ describe("POST /api/chat", () => {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
-      limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+      limit: vi.fn().mockResolvedValue({
+        data: [
+          { role: "user", content: "newest user message" },
+          { role: "assistant", content: "older assistant reply" },
+        ],
+        error: null,
+      }),
     };
 
     let messageInsertCalls = 0;
     tableHandlers["chat_threads"] = () => ({
-      insert: threadInsert,
+      select: threadSelect,
       update: threadUpdate,
     });
     tableHandlers["chat_messages"] = () => {
@@ -131,34 +144,49 @@ describe("POST /api/chat", () => {
     });
 
     const res = await POST(
-      req({ message: "hey" }) as unknown as import("next/server").NextRequest,
+      req({
+        message: "hey",
+        threadId: THREAD_ID,
+      }) as unknown as import("next/server").NextRequest,
     );
     expect(res.status).toBe(201);
     const body = (await res.json()) as {
       threadId: string;
       message: { role: string; content: string };
     };
-    expect(body.threadId).toBe("t1");
+    expect(body.threadId).toBe(THREAD_ID);
     expect(body.message.content).toBe("hello there");
-    expect(threadInsert).toHaveBeenCalled();
+    expect(historyBuilder.order).toHaveBeenCalledWith("created_at", {
+      ascending: false,
+    });
     expect(openaiCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         model: "gpt-4o",
-        messages: expect.arrayContaining([
+        messages: [
           expect.objectContaining({ role: "system" }),
-        ]),
+          expect.objectContaining({
+            role: "assistant",
+            content: "older assistant reply",
+          }),
+          expect.objectContaining({
+            role: "user",
+            content: "newest user message",
+          }),
+        ],
       }),
     );
   });
 
   it("returns 404 when threadId does not belong to the user", async () => {
-    getServerUser.mockResolvedValue({ id: "u1" });
+    getServerUser.mockResolvedValue({ id: USER_ID });
 
     const threadSelect = vi.fn().mockReturnValue({
       eq: vi.fn().mockReturnValue({
-        maybeSingle: vi.fn().mockResolvedValue({
-          data: { id: "t-other", user_id: "u2", grow_id: null },
-          error: null,
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: null,
+            error: null,
+          }),
         }),
       }),
     });
@@ -167,20 +195,45 @@ describe("POST /api/chat", () => {
     const res = await POST(
       req({
         message: "hey",
-        threadId: "t-other",
+        threadId: THREAD_ID,
       }) as unknown as import("next/server").NextRequest,
     );
     expect(res.status).toBe(404);
   });
 
+  it("rejects a growId override on an existing thread", async () => {
+    getServerUser.mockResolvedValue({ id: USER_ID });
+
+    const threadSelect = vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: { id: THREAD_ID, user_id: USER_ID, grow_id: GROW_ID },
+            error: null,
+          }),
+        }),
+      }),
+    });
+    tableHandlers["chat_threads"] = () => ({ select: threadSelect });
+
+    const res = await POST(
+      req({
+        message: "hey",
+        threadId: THREAD_ID,
+        growId: OTHER_GROW_ID,
+      }) as unknown as import("next/server").NextRequest,
+    );
+    expect(res.status).toBe(400);
+  });
+
   it("returns 502 when the OpenAI call fails", async () => {
-    getServerUser.mockResolvedValue({ id: "u1" });
+    getServerUser.mockResolvedValue({ id: USER_ID });
 
     tableHandlers["chat_threads"] = () => ({
       insert: vi.fn().mockReturnValue({
         select: vi.fn().mockReturnValue({
           single: vi.fn().mockResolvedValue({
-            data: { id: "t2", grow_id: null },
+            data: { id: THREAD_ID, grow_id: null },
             error: null,
           }),
         }),

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -13,6 +13,8 @@ const MAX_MESSAGE_LEN = 4_000;
 const MAX_HISTORY_MESSAGES = 20;
 const MAX_CONTEXT_PLANTS = 8;
 const MAX_CONTEXT_FINDINGS = 20;
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 interface ChatBody {
   message: unknown;
@@ -81,12 +83,19 @@ export async function POST(request: NextRequest) {
 
   const threadIdIn =
     typeof body.threadId === "string" && body.threadId.length > 0
-      ? body.threadId
+      ? body.threadId.trim()
       : null;
   const growIdIn =
     typeof body.growId === "string" && body.growId.length > 0
-      ? body.growId
+      ? body.growId.trim()
       : null;
+
+  if (threadIdIn && !UUID_RE.test(threadIdIn)) {
+    return errJson("threadId must be a uuid", 400, requestId);
+  }
+  if (growIdIn && !UUID_RE.test(growIdIn)) {
+    return errJson("growId must be a uuid", 400, requestId);
+  }
 
   const db = getDbClient();
 
@@ -98,13 +107,23 @@ export async function POST(request: NextRequest) {
       .from("chat_threads")
       .select("id, user_id, grow_id")
       .eq("id", threadIdIn)
+      .eq("user_id", user.id)
       .maybeSingle();
     if (error || !thread) return errJson("Thread not found", 404, requestId);
-    if (thread.user_id !== user.id) {
-      return errJson("Thread not found", 404, requestId);
-    }
     threadId = thread.id as string;
     threadGrowId = (thread.grow_id as string | null) ?? null;
+    if (
+      growIdIn &&
+      ((threadGrowId && growIdIn !== threadGrowId) ||
+        (!threadGrowId && growIdIn))
+    ) {
+      return errJson("growId does not match thread", 400, requestId);
+    }
+    if (threadGrowId) {
+      const grow = await authorizeGrowAccess(user.id, threadGrowId);
+      if (!grow) return errJson("Grow not found", 404, requestId);
+      threadGrowId = grow.growId;
+    }
   } else {
     let boundGrowId: string | null = null;
     if (growIdIn) {
@@ -239,9 +258,9 @@ async function loadThreadHistory(
     .from("chat_messages")
     .select("role, content, created_at")
     .eq("thread_id", threadId)
-    .order("created_at", { ascending: true })
+    .order("created_at", { ascending: false })
     .limit(MAX_HISTORY_MESSAGES);
-  return (data ?? []).map((m) => ({
+  return [...(data ?? [])].reverse().map((m) => ({
     role: m.role as string,
     content: m.content as string,
   }));


### PR DESCRIPTION
## Summary
- fix chat thread history ordering so the newest rows are fetched first and replayed oldest-first
- harden chat thread and grow authorization checks against user-controlled overrides
- eliminate analysis storage path trust issues and move to a shared AsyncClient lifecycle
- remove the analysis/comparison import cycle, tolerate fenced JSON responses, and replace BaseHTTPMiddleware with pure ASGI middleware

## Verification
- pnpm --filter web test -- src/app/api/chat/__tests__/route.test.ts
- pnpm --filter web type-check
- pnpm --filter web lint
- python -m pytest tests/test_image_analysis.py tests/test_storage.py tests/test_api.py
- python -m ruff check app tests
- python -m mypy app/

## Scope note
This PR is intentionally targeted at the unresolved correctness/security findings on top of #45. It does not make #45 mergeable to main; the feature branch still needs to be split or replaced with narrower PRs before release.