### PR TITLE
feat(web): ship core workspace refresh and build hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ permissions:
   contents: read
 
 env:
-  NODE_VERSION: "22"
-  PNPM_VERSION: "9"
+  NODE_VERSION: "20"
+  PNPM_VERSION: "9.15.9"
   PYTHON_VERSION: "3.12"
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ htmlcov/
 *.tsbuildinfo
 .turbo/
 .env*.local
+
+# Playwright + IDE
+playwright-report
+test-results
+.cursor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,15 @@ pwsh scripts/smoke-test-prod.ps1
 ```
 
 It exits non-zero if any endpoint, security header, or secret-leak check fails.
+
+For the authenticated persisted-flow smoke, run the Playwright suite with the
+Supabase service role available to the test runner:
+
+```bash
+E2E_BASE_URL=https://phenosage-<hash>-stevenschling13.vercel.app \
+E2E_SKIP_WEBSERVER=1 \
+E2E_AUTH_SMOKE=1 \
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=<service-role> \
+pnpm --filter web test:e2e
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PhenoSage
 
-AI-powered cannabis grow operating system. Web-first, mobile-compatible, professional plant analysis, timeline tracking, proactive alerts, and grow-aware chatbot.
+AI-powered cannabis grow operating system. Web-first, mobile-compatible, with secure image upload, persisted plant analyses, timeline tracking, and a grow-aware chatbot that keeps its own thread history.
 
 ## What is PhenoSage?
 
@@ -26,16 +26,16 @@ Supabase         Railway
 
 ## Tech Stack
 
-| Layer | Technology |
-|---|---|
-| Web app | Next.js 14 App Router, TypeScript strict, Tailwind CSS |
-| Analysis service | FastAPI (Python 3.12) |
-| Shared types | TypeScript package |
-| Auth | Supabase Auth |
-| Database | Supabase Postgres (pgvector-ready) |
-| Storage | Supabase Storage (private buckets) |
-| Web deploy | Vercel |
-| Analysis deploy | Railway |
+| Layer            | Technology                                             |
+| ---------------- | ------------------------------------------------------ |
+| Web app          | Next.js 15 App Router, TypeScript strict, Tailwind CSS |
+| Analysis service | FastAPI (Python 3.12)                                  |
+| Shared types     | TypeScript package                                     |
+| Auth             | Supabase Auth                                          |
+| Database         | Supabase Postgres (pgvector-ready)                     |
+| Storage          | Supabase Storage (private buckets)                     |
+| Web deploy       | Vercel                                                 |
+| Analysis deploy  | Railway                                                |
 
 ## Monorepo Structure
 
@@ -57,8 +57,8 @@ phenosage/
 
 ### Prerequisites
 
-- Node.js >= 20
-- pnpm >= 9
+- Node.js 20.x
+- pnpm 9.15.9
 - Python >= 3.12
 - Docker (for analysis service)
 - Supabase CLI
@@ -66,7 +66,7 @@ phenosage/
 ### Install dependencies
 
 ```bash
-pnpm install
+pnpm install --frozen-lockfile
 ```
 
 ### Environment variables
@@ -104,6 +104,13 @@ docker run -p 8000:8000 --env-file .env phenosage-analysis
 ## Environment Variables
 
 See [docs/deployment.md](docs/deployment.md) for the full list of required environment variables per service.
+
+## Current Deployment Posture
+
+- The browser only talks to the Next.js app on Vercel. It does not call Railway directly.
+- Plant image uploads are signed server-side and uploaded straight to Supabase Storage.
+- Plant analyses are persisted in `plant_analyses` and `plant_findings`.
+- Analysis responses can fall back to an inconclusive mode when storage or OpenAI is unavailable. Treat those as non-diagnostic and retry once the upstream dependency is healthy.
 
 ## Documentation
 

--- a/apps/analysis/.env.example
+++ b/apps/analysis/.env.example
@@ -2,10 +2,6 @@
 # Copy to .env for local development.
 # NEVER commit real secrets.
 
-# apps/analysis — .env.example
-# Copy to .env for local development.
-# NEVER commit real secrets.
-
 # ─── Service Auth ─────────────────────────────────────────────────────────────
 # Shared secret with the Next.js proxy. Must match ANALYSIS_SERVICE_API_KEY in apps/web.
 ANALYSIS_SERVICE_API_KEY=dev-api-key
@@ -25,4 +21,11 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # ─── App ─────────────────────────────────────────────────────────────────────
 APP_ENV=development
 LOG_LEVEL=info
+
+# ─── Observability (optional) ────────────────────────────────────────────────
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1
+OTEL_ENABLED=false
+OTEL_EXPORTER_OTLP_ENDPOINT=
+OTEL_SERVICE_NAME=phenosage-analysis
 

--- a/apps/analysis/app/main.py
+++ b/apps/analysis/app/main.py
@@ -1,11 +1,15 @@
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
+from app.middleware import RequestContextMiddleware
 from app.routers.analyze import router as analyze_router
 from app.routers.health import router as health_router
 from app.telemetry import init_all as init_telemetry
 
+logging.basicConfig(level=getattr(logging, settings.log_level.upper(), logging.INFO))
 init_telemetry()
 
 app = FastAPI(
@@ -19,6 +23,7 @@ app = FastAPI(
     docs_url="/docs" if settings.app_env != "production" else None,
     redoc_url=None,
 )
+app.add_middleware(RequestContextMiddleware)
 
 # CORS: only the configured origins (the Vercel app URL in production).
 app.add_middleware(

--- a/apps/analysis/app/middleware.py
+++ b/apps/analysis/app/middleware.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import logging
+import time
+from contextvars import ContextVar
+from uuid import uuid4
+
+from fastapi import Request
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.responses import Response
+
+REQUEST_ID_HEADER = "x-request-id"
+_request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+def get_request_id() -> str:
+    return _request_id_ctx.get()
+
+
+def log_event(level: int, message: str, **fields: object) -> None:
+    payload = {
+        "level": logging.getLevelName(level).lower(),
+        "message": message,
+        "request_id": get_request_id(),
+        "service": "phenosage-analysis",
+        **fields,
+    }
+    logging.getLogger("phenosage.analysis").log(level, json.dumps(payload, default=str))
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = request.headers.get(REQUEST_ID_HEADER, "").strip() or str(uuid4())
+        token = _request_id_ctx.set(request_id)
+        request.state.request_id = request_id
+        start = time.perf_counter()
+
+        try:
+            response = await call_next(request)
+        except Exception:
+            log_event(
+                logging.ERROR,
+                "request failed",
+                method=request.method,
+                path=request.url.path,
+                duration_ms=round((time.perf_counter() - start) * 1000, 2),
+            )
+            _request_id_ctx.reset(token)
+            raise
+
+        response.headers[REQUEST_ID_HEADER] = request_id
+        log_event(
+            logging.INFO,
+            "request completed",
+            method=request.method,
+            path=request.url.path,
+            status_code=response.status_code,
+            duration_ms=round((time.perf_counter() - start) * 1000, 2),
+        )
+        _request_id_ctx.reset(token)
+        return response

--- a/apps/analysis/app/models/analysis.py
+++ b/apps/analysis/app/models/analysis.py
@@ -72,3 +72,7 @@ class AnalyzeResponse(BaseModel):
     comparison_summary: str | None = None
     analyzed_at: datetime
     model_version: str
+    analysis_mode: str = "fallback"
+    is_fallback: bool = False
+    fallback_reason: str | None = None
+    request_id: str | None = None

--- a/apps/analysis/app/services/image_analysis.py
+++ b/apps/analysis/app/services/image_analysis.py
@@ -1,18 +1,14 @@
-"""
-Image analysis pipeline service.
-
-TODO (Milestone 1 → 2):
-  - Fetch image bytes from Supabase Storage using the service role key
-  - Encode to base64 for OpenAI Vision API
-  - Build a structured prompt from GrowContext
-  - Parse GPT-4o response into AnalysisFinding list
-  - Return scored AnalyzeResponse
-"""
-
 from __future__ import annotations
 
+import base64
+import json
+import logging
 from datetime import UTC, datetime
 
+import httpx
+
+from app.config import settings
+from app.middleware import get_request_id, log_event
 from app.models.analysis import (
     AnalysisFinding,
     AnalyzeRequest,
@@ -20,39 +16,182 @@ from app.models.analysis import (
     FindingCategory,
     FindingSeverity,
 )
+from app.services.prompts import SYSTEM_PROMPT, build_analysis_prompt
+from app.services.scoring import compute_health_score
 
-MODEL_VERSION = "gpt-4o-stub-0.1"
+MODEL_VERSION = "gpt-4o-mini-vision"
+logger = logging.getLogger(__name__)
 
 
-async def run_analysis(request: AnalyzeRequest) -> AnalyzeResponse:
-    """
-    Entry point for the image analysis pipeline.
+async def _fetch_storage_image(storage_path: str) -> tuple[bytes, str]:
+    if not settings.supabase_url or not settings.supabase_service_role_key:
+        raise RuntimeError("Supabase storage credentials are not configured")
 
-    Currently returns a stub response. Wire to OpenAI Vision in Milestone 1.
-    """
-    # TODO: Fetch image from Supabase Storage
-    # TODO: Optionally fetch previous image for comparison
-    # TODO: Build prompt with grow context
-    # TODO: Call OpenAI Vision API
-    # TODO: Parse structured findings from response
-    # TODO: Score overall health 0–100
+    base_url = settings.supabase_url.rstrip("/")
+    url = f"{base_url}/storage/v1/object/authenticated/plant-images/{storage_path}"
+    headers = {
+        "Authorization": f"Bearer {settings.supabase_service_role_key}",
+        "x-request-id": get_request_id(),
+    }
 
-    stub_finding = AnalysisFinding(
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        content_type = response.headers.get("content-type", "image/jpeg")
+        return response.content, content_type
+
+
+def _build_fallback_response(
+    request: AnalyzeRequest,
+    *,
+    reason: str,
+) -> AnalyzeResponse:
+    finding = AnalysisFinding(
         category=FindingCategory.general,
         severity=FindingSeverity.info,
-        title="Analysis not yet implemented",
-        description="This is a placeholder finding. Connect OpenAI Vision to enable real analysis.",
-        recommendation="Complete Milestone 1 implementation.",
+        title="Fallback analysis only",
+        description=(
+            "PhenoSage could not verify the image with the primary model path. "
+            "Treat this result as inconclusive until the image can be re-analyzed."
+        ),
+        recommendation=(
+            "Retry analysis after confirming storage access and OpenAI availability. "
+            "Do not treat this as a confident diagnosis."
+        ),
     )
 
     return AnalyzeResponse(
         plant_id=request.plant_id,
         image_id=request.image_id,
         overall_health_score=0.0,
-        summary="Stub analysis — not yet implemented.",
-        findings=[stub_finding],
+        summary=(
+            "Inconclusive fallback result. The primary analysis path was unavailable, "
+            "so no confident diagnosis was produced."
+        ),
+        findings=[finding],
         compared_to_image_id=request.previous_image_id,
         comparison_summary=None,
         analyzed_at=datetime.now(tz=UTC),
         model_version=MODEL_VERSION,
+        analysis_mode="fallback",
+        is_fallback=True,
+        fallback_reason=reason,
+        request_id=get_request_id(),
     )
+
+
+def _parse_findings(raw_findings: object) -> list[AnalysisFinding]:
+    if not isinstance(raw_findings, list):
+        return []
+
+    findings: list[AnalysisFinding] = []
+    for item in raw_findings:
+        if not isinstance(item, dict):
+            continue
+        try:
+            findings.append(AnalysisFinding(**item))
+        except Exception as exc:  # pragma: no cover - defensive parsing
+            logger.warning("Skipping malformed finding: %s", exc)
+    return findings
+
+
+async def _run_model_analysis(
+    request: AnalyzeRequest,
+    *,
+    image_bytes: bytes,
+    content_type: str,
+) -> AnalyzeResponse:
+    if not settings.openai_api_key:
+        raise RuntimeError("OPENAI_API_KEY is not configured")
+
+    from openai import AsyncOpenAI
+
+    encoded = base64.b64encode(image_bytes).decode("utf-8")
+    data_url = f"data:{content_type};base64,{encoded}"
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+
+    completion = await client.chat.completions.create(
+        model=MODEL_VERSION,
+        response_format={"type": "json_object"},
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": build_analysis_prompt(request.grow_context)},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            },
+        ],
+    )
+
+    raw_content = completion.choices[0].message.content or "{}"
+    parsed = json.loads(raw_content)
+    findings = _parse_findings(parsed.get("findings"))
+
+    if not findings:
+        findings = [
+            AnalysisFinding(
+                category=FindingCategory.general,
+                severity=FindingSeverity.info,
+                title="No issues confidently identified",
+                description=(
+                    "The model did not return structured findings. Treat the result as "
+                    "low-confidence and review the image manually."
+                ),
+                recommendation="Retry with a clearer image if you need a stronger diagnosis.",
+            )
+        ]
+
+    overall_health_score = parsed.get("overall_health_score")
+    if not isinstance(overall_health_score, (float, int)):
+        overall_health_score = compute_health_score(findings)
+
+    summary = parsed.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        summary = "Image reviewed successfully, but the returned summary was incomplete."
+
+    return AnalyzeResponse(
+        plant_id=request.plant_id,
+        image_id=request.image_id,
+        overall_health_score=float(overall_health_score),
+        summary=summary,
+        findings=findings,
+        compared_to_image_id=request.previous_image_id,
+        comparison_summary=None,
+        analyzed_at=datetime.now(tz=UTC),
+        model_version=MODEL_VERSION,
+        analysis_mode="model",
+        is_fallback=False,
+        fallback_reason=None,
+        request_id=get_request_id(),
+    )
+
+
+async def run_analysis(request: AnalyzeRequest) -> AnalyzeResponse:
+    try:
+        image_bytes, content_type = await _fetch_storage_image(request.storage_path)
+        response = await _run_model_analysis(
+            request,
+            image_bytes=image_bytes,
+            content_type=content_type,
+        )
+        log_event(
+            logging.INFO,
+            "analysis completed",
+            plant_id=request.plant_id,
+            image_id=request.image_id,
+            analysis_mode=response.analysis_mode,
+            is_fallback=response.is_fallback,
+        )
+        return response
+    except Exception as exc:
+        reason = exc.__class__.__name__
+        log_event(
+            logging.WARNING,
+            "analysis fallback triggered",
+            plant_id=request.plant_id,
+            image_id=request.image_id,
+            fallback_reason=reason,
+        )
+        return _build_fallback_response(request, reason=reason)

--- a/apps/analysis/app/telemetry.py
+++ b/apps/analysis/app/telemetry.py
@@ -22,7 +22,9 @@ def init_sentry() -> None:
         return
     try:
         import sentry_sdk
-        from sentry_sdk.integrations.fastapi import FastApiIntegration
+        from sentry_sdk.integrations.fastapi import (
+            FastApiIntegration,
+        )
     except ImportError:
         logger.info("sentry-sdk not installed; skipping Sentry init")
         return
@@ -52,7 +54,9 @@ def init_otel() -> None:
         )
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+        )
     except ImportError:
         logger.info("opentelemetry-sdk not installed; skipping OTel init")
         return

--- a/apps/analysis/tests/test_api.py
+++ b/apps/analysis/tests/test_api.py
@@ -33,7 +33,7 @@ async def test_analyze_requires_auth() -> None:
             },
         )
 
-    assert response.status_code == 403
+    assert response.status_code in (401, 403)
 
 
 @pytest.mark.asyncio

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -21,3 +21,9 @@ OPENAI_API_KEY=sk-...
 
 # ─── App ─────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_ENV=development
+
+# ─── Observability (optional) ────────────────────────────────────────────────
+# Leave empty to disable error reporting and tracing.
+SENTRY_DSN=
+SENTRY_TRACES_SAMPLE_RATE=0.1

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -10,10 +10,59 @@ pnpm --filter web exec playwright install --with-deps
 pnpm --filter web test:e2e
 ```
 
+## Run the authenticated persistence smoke
+
+This seeded smoke path creates a temporary Supabase user, grow, and plant with
+the service role, signs in through the real auth page, uploads a test image,
+verifies `/api/plants/[plantId]/analyze`, `/analysis/latest`, `/timeline`, and
+confirms grounded chat thread/message persistence.
+
+Required environment:
+
+- `E2E_AUTH_SMOKE=1`
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+Before running this against a preview or production deployment, verify the app
+is actually ready:
+
+```bash
+pnpm run check:ready -- --url https://phenosage-<deployment>.vercel.app
+```
+
+For a Vercel-protected preview, pass a full `/api/ready` URL that already
+includes the bypass or share query string instead of a bare deployment URL.
+
+If `/api/ready` reports missing server env such as
+`ANALYSIS_SERVICE_API_KEY`, stop there and fix the deployment environment
+first. The authenticated smoke should validate persistence and grounded flows,
+not discover a broken runtime contract.
+
+The target app must already have its normal auth/runtime env configured
+correctly, including the public Supabase keys and OpenAI where applicable.
+
+```bash
+E2E_AUTH_SMOKE=1 \
+  NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co \
+  SUPABASE_SERVICE_ROLE_KEY=<service-role> \
+  pnpm --filter web test:e2e
+```
+
 ## Run against a preview
 
 ```bash
 E2E_BASE_URL=https://phenosage-<hash>-stevenschling13.vercel.app \
   E2E_SKIP_WEBSERVER=1 \
+  pnpm --filter web test:e2e
+```
+
+Authenticated preview smoke:
+
+```bash
+E2E_BASE_URL=https://phenosage-<hash>-stevenschling13.vercel.app \
+  E2E_SKIP_WEBSERVER=1 \
+  E2E_AUTH_SMOKE=1 \
+  NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co \
+  SUPABASE_SERVICE_ROLE_KEY=<service-role> \
   pnpm --filter web test:e2e
 ```

--- a/apps/web/e2e/authenticated-workspace.spec.ts
+++ b/apps/web/e2e/authenticated-workspace.spec.ts
@@ -1,0 +1,212 @@
+import { expect, test } from "@playwright/test";
+import {
+  cleanupAuthenticatedWorkspaceUser,
+  createAuthenticatedWorkspaceUser,
+} from "./helpers/supabase-admin";
+
+const AUTH_SMOKE_ENABLED = process.env["E2E_AUTH_SMOKE"] === "1";
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9sotM0YAAAAASUVORK5CYII=",
+  "base64",
+);
+
+test.describe("Authenticated workspace smoke", () => {
+  test.describe.configure({ mode: "serial" });
+  test.skip(
+    !AUTH_SMOKE_ENABLED,
+    "Set E2E_AUTH_SMOKE=1 to run authenticated preview/local smoke coverage.",
+  );
+
+  test("core workflow is usable end to end", async ({ page }) => {
+    test.slow();
+
+    const workspace = await createAuthenticatedWorkspaceUser();
+    const growName = `Smoke Grow ${Date.now()}`;
+    const plantName = `Smoke Plant ${Date.now()}`;
+    const displayName = `Smoke Operator ${Date.now()}`;
+    const assistantPrompt =
+      "Give me a short operator update based on the current workspace.";
+
+    try {
+      await test.step("sign in through the real auth page", async () => {
+        await page.goto("/auth");
+        await page.getByLabel("Email").fill(workspace.email);
+        await page.getByLabel("Password").fill(workspace.password);
+        await page.getByRole("button", { name: "Enter workspace" }).click();
+        await page.waitForURL("**/dashboard");
+      });
+
+      await test.step("create the first grow from a real CTA", async () => {
+        const newGrowLink = page
+          .getByRole("link", { name: "New grow" })
+          .first();
+        await expect(newGrowLink).toHaveAttribute("href", "/grows/new");
+        await newGrowLink.click();
+        await page.waitForURL("**/grows/new");
+
+        await page.getByLabel("Grow name").fill(growName);
+        await page
+          .getByLabel("Description")
+          .fill("Temporary grow created by the authenticated smoke suite.");
+        await page.getByLabel("Stage").selectOption("vegetative");
+        await page.getByLabel("Medium").selectOption("soil");
+        await page.getByLabel("Light type").selectOption("led");
+        await page.getByRole("button", { name: "Create grow" }).click();
+
+        await page.waitForURL("**/grows");
+        await expect(page.getByText(growName)).toBeVisible();
+      });
+
+      let plantId = "";
+
+      await test.step("add a plant to the grow and verify it lists on /plants", async () => {
+        const addPlantLink = page
+          .getByRole("link", { name: "Add plant" })
+          .first();
+        await expect(addPlantLink).toHaveAttribute(
+          "href",
+          /\/plants\/new\?growId=/,
+        );
+        await addPlantLink.click();
+        await page.waitForURL("**/plants/new**");
+
+        await page.getByLabel("Plant name").fill(plantName);
+        await page.getByLabel("Strain").fill("Playwright Kush");
+        await page.getByLabel("Batch label").fill("SMOKE-BATCH");
+        await page
+          .getByLabel("Notes")
+          .fill("Temporary plant created by the authenticated smoke suite.");
+        await page.getByRole("button", { name: "Create plant" }).click();
+
+        await page.waitForURL("**/plants/*");
+        plantId = page.url().split("/plants/")[1] ?? "";
+        expect(plantId.length).toBeGreaterThan(0);
+        await expect(
+          page.getByRole("heading", { name: new RegExp(plantName, "i") }),
+        ).toBeVisible();
+
+        await page.goto("/plants");
+        await expect(page.getByText(plantName)).toBeVisible();
+      });
+
+      await test.step("upload a photo through the signed-upload path and surface timeline data", async () => {
+        await page.goto(`/plants/${plantId}`);
+        await page.locator('input[type="file"]').setInputFiles({
+          buffer: PNG_1X1,
+          mimeType: "image/png",
+          name: "smoke-leaf.png",
+        });
+
+        const signResponsePromise = page.waitForResponse(
+          (response) =>
+            response.request().method() === "POST" &&
+            response.url().includes("/api/uploads/sign"),
+        );
+        const finalizeResponsePromise = page.waitForResponse(
+          (response) =>
+            response.request().method() === "POST" &&
+            response.url().includes(`/api/plants/${plantId}/images`),
+        );
+        const analyzeResponsePromise = page.waitForResponse(
+          (response) =>
+            response.request().method() === "POST" &&
+            response.url().includes(`/api/plants/${plantId}/analyze`),
+        );
+
+        await page.getByRole("button", { name: "Upload photo" }).click();
+
+        const [signResponse, finalizeResponse, analyzeResponse] =
+          await Promise.all([
+            signResponsePromise,
+            finalizeResponsePromise,
+            analyzeResponsePromise,
+          ]);
+
+        expect(signResponse.ok()).toBeTruthy();
+        expect(signResponse.headers()["x-request-id"]).toBeTruthy();
+        const signPayload = (await signResponse.json()) as {
+          imageId?: string;
+          storagePath?: string;
+          token?: string;
+        };
+        expect(signPayload.imageId).toBeTruthy();
+        expect(signPayload.storagePath).toContain(`${plantId}/`);
+        expect(signPayload.token).toBeTruthy();
+
+        expect(finalizeResponse.ok()).toBeTruthy();
+        expect(analyzeResponse.ok()).toBeTruthy();
+
+        await expect(
+          page.getByText(
+            /Image uploaded and analyzed|inconclusive fallback output|Image uploaded successfully, but analysis is unavailable right now/i,
+          ),
+        ).toBeVisible();
+        await expect(page.getByText(/Longitudinal timeline/i)).toBeVisible();
+
+        const timelineResponse = await page
+          .context()
+          .request.get(
+            new URL(`/api/plants/${plantId}/timeline`, page.url()).toString(),
+          );
+        expect(timelineResponse.ok()).toBeTruthy();
+        const timelinePayload = (await timelineResponse.json()) as {
+          items: Array<{ id: string; type: string }>;
+        };
+        expect(
+          timelinePayload.items.some((item) => item.type === "image"),
+        ).toBe(true);
+      });
+
+      await test.step("save a display name in settings and reflect it in the workspace", async () => {
+        await page.goto("/settings");
+        await page.getByLabel("Display name").fill(displayName);
+        await page.getByRole("button", { name: "Save display name" }).click();
+        await expect(page.getByText("Display name saved.")).toBeVisible();
+
+        await page.goto("/dashboard");
+        await expect(
+          page.getByRole("heading", {
+            name: new RegExp(`Welcome back, ${displayName}`, "i"),
+          }),
+        ).toBeVisible();
+      });
+
+      await test.step("send a real assistant message through /api/chat", async () => {
+        await page.goto("/assistant");
+        await page
+          .getByLabel("Ask the PhenoSage assistant")
+          .fill(assistantPrompt);
+
+        const chatResponsePromise = page.waitForResponse(
+          (response) =>
+            response.request().method() === "POST" &&
+            response.url().includes("/api/chat"),
+        );
+
+        await page.getByRole("button", { name: "Send to copilot" }).click();
+
+        const chatResponse = await chatResponsePromise;
+        expect(chatResponse.ok()).toBeTruthy();
+        expect(chatResponse.headers()["x-request-id"]).toBeTruthy();
+        expect(chatResponse.headers()["x-chat-thread-id"]).toBeTruthy();
+        expect((await chatResponse.text()).trim().length).toBeGreaterThan(0);
+
+        await expect(page.getByText(assistantPrompt)).toBeVisible();
+        await expect(page.getByText("Thread active")).toBeVisible();
+        await expect
+          .poll(
+            async () => {
+              const messages = await page
+                .locator("article p.whitespace-pre-wrap")
+                .allTextContents();
+              return messages.length;
+            },
+            { timeout: 30_000 },
+          )
+          .toBeGreaterThan(2);
+      });
+    } finally {
+      await cleanupAuthenticatedWorkspaceUser(workspace);
+    }
+  });
+});

--- a/apps/web/e2e/helpers/supabase-admin.ts
+++ b/apps/web/e2e/helpers/supabase-admin.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from "node:crypto";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+type AuthenticatedWorkspaceUser = {
+  admin: SupabaseClient;
+  email: string;
+  password: string;
+  userId: string;
+};
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+export function getAdminClient() {
+  return createClient(
+    requiredEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requiredEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}
+
+export async function createAuthenticatedWorkspaceUser(): Promise<AuthenticatedWorkspaceUser> {
+  const admin = getAdminClient();
+  const runId = `${Date.now()}-${randomBytes(4).toString("hex")}`;
+  const email = `playwright-smoke-${runId}@example.com`;
+  const password = `PhenoSage!${runId}Aa`;
+
+  const { data: userData, error: userError } =
+    await admin.auth.admin.createUser({
+      email,
+      password,
+      email_confirm: true,
+    });
+
+  if (userError || !userData.user) {
+    throw new Error(
+      `Failed to create smoke-test user: ${userError?.message ?? "unknown error"}`,
+    );
+  }
+
+  return {
+    admin,
+    email,
+    password,
+    userId: userData.user.id,
+  };
+}
+
+export async function cleanupAuthenticatedWorkspaceUser(
+  workspace: AuthenticatedWorkspaceUser,
+) {
+  const { admin, userId } = workspace;
+
+  const { data: imageRows } = await admin
+    .from("plant_images")
+    .select("storage_path")
+    .eq("user_id", userId);
+
+  const storagePaths = (imageRows ?? [])
+    .map((row) => row.storage_path)
+    .filter(
+      (value): value is string => typeof value === "string" && value.length > 0,
+    );
+
+  if (storagePaths.length > 0) {
+    await admin.storage.from("plant-images").remove(storagePaths);
+  }
+
+  await admin.auth.admin.deleteUser(userId);
+}

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,0 +1,34 @@
+export async function register() {
+  const dsn = process.env["SENTRY_DSN"]?.trim();
+  if (!dsn) {
+    return;
+  }
+
+  try {
+    const dynamicImport = new Function(
+      "specifier",
+      "return import(specifier)",
+    ) as (_specifier: string) => Promise<{
+      init?: (_options: Record<string, unknown>) => void;
+    }>;
+    const sentry = await dynamicImport("@sentry/nextjs");
+    sentry.init?.({
+      dsn,
+      enabled: true,
+      tracesSampleRate: Number(
+        process.env["SENTRY_TRACES_SAMPLE_RATE"] ?? "0.1",
+      ),
+      environment:
+        process.env["NEXT_PUBLIC_APP_ENV"] ?? process.env.NODE_ENV ?? "unknown",
+    });
+  } catch (error) {
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        message: "web instrumentation init skipped",
+        service: "phenosage-web",
+        reason: error instanceof Error ? error.message : "unknown_error",
+      }),
+    );
+  }
+}

--- a/apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts
@@ -2,13 +2,14 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { NextRequest } from "next/server";
 
 const getServerSession = vi.fn();
-const callAnalysisService = vi.fn();
+const getLatestPlantAnalysis = vi.fn();
 
 vi.mock("@/lib/server/auth", () => ({
   getServerSession: (...args: unknown[]) => getServerSession(...args),
 }));
-vi.mock("@/lib/server/analysis-proxy", () => ({
-  callAnalysisService: (...args: unknown[]) => callAnalysisService(...args),
+vi.mock("@/lib/server/plants", () => ({
+  getLatestPlantAnalysis: (...args: unknown[]) =>
+    getLatestPlantAnalysis(...args),
 }));
 
 import { GET } from "../route";
@@ -24,29 +25,36 @@ function makeParams(plantId: string) {
 describe("GET /api/plants/[plantId]/analysis/latest", () => {
   beforeEach(() => {
     (getServerSession as Mock).mockReset();
-    (callAnalysisService as Mock).mockReset();
-    callAnalysisService.mockResolvedValue({});
+    (getLatestPlantAnalysis as Mock).mockReset();
   });
 
   it("returns 401 when unauthenticated", async () => {
     getServerSession.mockResolvedValue(null);
     const res = await GET(makeRequest(), makeParams("p1"));
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: "Unauthorized" });
-    expect(callAnalysisService).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+    expect(getLatestPlantAnalysis).not.toHaveBeenCalled();
   });
 
-  it("returns the plantId in the body and proxies through callAnalysisService", async () => {
+  it("returns plantId and null analysis when none is found", async () => {
     getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    getLatestPlantAnalysis.mockResolvedValue(null);
     const res = await GET(makeRequest(), makeParams("plant-xyz"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.plantId).toBe("plant-xyz");
     expect(body.analysis).toBeNull();
-    expect(callAnalysisService).toHaveBeenCalledTimes(1);
-    expect(callAnalysisService).toHaveBeenCalledWith({
-      endpoint: "/plants/plant-xyz/analysis/latest",
-      method: "GET",
-    });
+    expect(getLatestPlantAnalysis).toHaveBeenCalledWith("plant-xyz");
+  });
+
+  it("returns the analysis payload when present", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    getLatestPlantAnalysis.mockResolvedValue({ score: 0.87 });
+    const res = await GET(makeRequest(), makeParams("plant-xyz"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.plantId).toBe("plant-xyz");
+    expect(body.analysis).toEqual({ score: 0.87 });
   });
 });

--- a/apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "@/lib/server/auth";
-import { callAnalysisService } from "@/lib/server/analysis-proxy";
+import { getLatestPlantAnalysis } from "@/lib/server/plants";
+import {
+  attachRequestId,
+  getOrCreateRequestId,
+  logServerEvent,
+} from "@/lib/server/request-id";
 
 interface RouteParams {
   params: Promise<{ plantId: string }>;
@@ -9,29 +14,52 @@ interface RouteParams {
 // GET /api/plants/[plantId]/analysis/latest
 // Returns the most recent AnalysisResponse for a plant.
 // Proxied through Next.js — the browser never calls the analysis service directly.
-export async function GET(
-  request: NextRequest,
-  { params }: RouteParams,
-) {
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const requestId = getOrCreateRequestId(request);
   const session = await getServerSession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
   }
 
   const { plantId } = await params;
 
-  // TODO: Look up the latest plant_image for this plant from DB
-  // TODO: Call analysis service via proxy if a new image is pending
-  // TODO: Return cached PlantFinding rows if analysis already ran
+  try {
+    const analysis = await getLatestPlantAnalysis(plantId);
+    if (!analysis) {
+      return attachRequestId(
+        NextResponse.json(
+          { plantId, analysis: null, requestId },
+          { status: 200 },
+        ),
+        requestId,
+      );
+    }
 
-  void callAnalysisService({
-    endpoint: `/plants/${plantId}/analysis/latest`,
-    method: "GET",
-  });
-
-  return NextResponse.json({
-    plantId,
-    analysis: null,
-    message: "TODO: Wire DB + analysis service proxy",
-  });
+    return attachRequestId(
+      NextResponse.json({ plantId, analysis, requestId }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "latest plant analysis fetch failed", {
+      requestId,
+      plantId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to load latest analysis",
+          requestId,
+        },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
 }

--- a/apps/web/src/app/api/plants/[plantId]/analyze/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analyze/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession, getServerUser } from "@/lib/server/auth";
+import { runAndPersistPlantAnalysis } from "@/lib/server/plants";
+import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
+import {
+  attachRequestId,
+  getOrCreateRequestId,
+  logServerEvent,
+} from "@/lib/server/request-id";
+
+interface RouteParams {
+  params: Promise<{ plantId: string }>;
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const requestId = getOrCreateRequestId(request);
+  const session = await getServerSession();
+  if (!session) {
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
+  }
+
+  const user = await getServerUser();
+  const rate = rateLimit({
+    key: rateLimitKeyFromRequest(request, user?.id ?? null),
+    limit: 5,
+    windowMs: 60_000,
+  });
+  if (!rate.ok) {
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error: "Too many analysis requests. Try again shortly.",
+          requestId,
+        },
+        { status: 429 },
+      ),
+      requestId,
+    );
+  }
+
+  const { plantId } = await params;
+  const body = (await request.json().catch(() => ({}))) as { imageId?: string };
+
+  try {
+    const result = await runAndPersistPlantAnalysis({
+      plantId,
+      ...(body.imageId ? { imageId: body.imageId } : {}),
+      requestId,
+    });
+
+    if (!result) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Plant not found or access denied", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
+
+    if (!result.analysis) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "No plant images are available to analyze", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
+
+    return attachRequestId(
+      NextResponse.json({ analysis: result.analysis, requestId }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "plant analysis failed", {
+      requestId,
+      plantId,
+      imageId: body.imageId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error:
+            error instanceof Error ? error.message : "Plant analysis failed",
+          requestId,
+        },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
+}

--- a/apps/web/src/app/api/plants/[plantId]/images/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/images/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession, getServerUser } from "@/lib/server/auth";
+import { getPlantTimeline, persistPlantImageUpload } from "@/lib/server/plants";
+import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
+import {
+  attachRequestId,
+  getOrCreateRequestId,
+  logServerEvent,
+} from "@/lib/server/request-id";
+
+interface RouteParams {
+  params: Promise<{ plantId: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const requestId = getOrCreateRequestId(request);
+  const session = await getServerSession();
+  if (!session) {
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
+  }
+
+  const { plantId } = await params;
+
+  try {
+    const timeline = await getPlantTimeline(plantId);
+    if (!timeline) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Plant not found or access denied", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
+
+    const images = timeline.items.filter((item) => item.type === "image");
+    return attachRequestId(
+      NextResponse.json({ plantId, images, requestId }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "plant image listing failed", {
+      requestId,
+      plantId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error:
+            error instanceof Error
+              ? error.message
+              : "Failed to load plant images",
+          requestId,
+        },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const requestId = getOrCreateRequestId(request);
+  const session = await getServerSession();
+  if (!session) {
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
+  }
+
+  const user = await getServerUser();
+  const rate = rateLimit({
+    key: rateLimitKeyFromRequest(request, user?.id ?? null),
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (!rate.ok) {
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error: "Too many upload preparations. Try again shortly.",
+          requestId,
+        },
+        { status: 429 },
+      ),
+      requestId,
+    );
+  }
+
+  const { plantId } = await params;
+  const body = (await request.json()) as {
+    imageId: string;
+    takenAt?: string;
+    source?: "camera" | "upload";
+    notes?: string;
+    storagePath: string;
+  };
+
+  if (!body.imageId || !body.storagePath) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "imageId and storagePath are required", requestId },
+        { status: 400 },
+      ),
+      requestId,
+    );
+  }
+
+  try {
+    const prepared = await persistPlantImageUpload({
+      imageId: body.imageId,
+      plantId,
+      ...(body.takenAt ? { takenAt: body.takenAt } : {}),
+      ...(body.source ? { source: body.source } : {}),
+      ...(body.notes ? { notes: body.notes } : {}),
+      storagePath: body.storagePath,
+    });
+
+    if (!prepared) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Plant not found or access denied", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
+
+    return attachRequestId(
+      NextResponse.json({ ...prepared, requestId }, { status: 201 }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "plant image finalize failed", {
+      requestId,
+      plantId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error:
+            error instanceof Error ? error.message : "Image persistence failed",
+          requestId,
+        },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
+}

--- a/apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { NextRequest } from "next/server";
 
 const getServerSession = vi.fn();
-const getDbClient = vi.fn();
+const getPlantTimeline = vi.fn();
 
 vi.mock("@/lib/server/auth", () => ({
   getServerSession: (...args: unknown[]) => getServerSession(...args),
 }));
-vi.mock("@/lib/server/db", () => ({
-  getDbClient: (...args: unknown[]) => getDbClient(...args),
+vi.mock("@/lib/server/plants", () => ({
+  getPlantTimeline: (...args: unknown[]) => getPlantTimeline(...args),
 }));
 
 import { GET } from "../route";
@@ -24,25 +24,26 @@ function makeParams(plantId: string) {
 describe("GET /api/plants/[plantId]/timeline", () => {
   beforeEach(() => {
     (getServerSession as Mock).mockReset();
-    (getDbClient as Mock).mockReset();
-    getDbClient.mockReturnValue({ __db: true });
+    (getPlantTimeline as Mock).mockReset();
   });
 
   it("returns 401 when unauthenticated", async () => {
     getServerSession.mockResolvedValue(null);
     const res = await GET(makeRequest(), makeParams("p1"));
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: "Unauthorized" });
-    expect(getDbClient).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+    expect(getPlantTimeline).not.toHaveBeenCalled();
   });
 
   it("returns the plantId from the route params when authenticated", async () => {
     getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    getPlantTimeline.mockResolvedValue({ plantId: "plant-xyz", items: [] });
     const res = await GET(makeRequest(), makeParams("plant-xyz"));
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.plantId).toBe("plant-xyz");
     expect(Array.isArray(body.items)).toBe(true);
-    expect(getDbClient).toHaveBeenCalledTimes(1);
+    expect(getPlantTimeline).toHaveBeenCalledWith("plant-xyz");
   });
 });

--- a/apps/web/src/app/api/plants/[plantId]/timeline/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/timeline/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "@/lib/server/auth";
-import { getDbClient } from "@/lib/server/db";
+import { getPlantTimeline } from "@/lib/server/plants";
+import {
+  attachRequestId,
+  getOrCreateRequestId,
+  logServerEvent,
+} from "@/lib/server/request-id";
 
 interface RouteParams {
   params: Promise<{ plantId: string }>;
@@ -8,26 +13,50 @@ interface RouteParams {
 
 // GET /api/plants/[plantId]/timeline
 // Returns the ordered list of plant images + observations for a plant.
-export async function GET(
-  request: NextRequest,
-  { params }: RouteParams,
-) {
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  const requestId = getOrCreateRequestId(request);
   const session = await getServerSession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
   }
 
   const { plantId } = await params;
-  const db = getDbClient();
 
-  // TODO: Verify user has access to this plant via grow_members RLS
-  // TODO: Query plant_images and plant_observations joined, ordered by takenAt/observedAt
+  try {
+    const timeline = await getPlantTimeline(plantId);
+    if (!timeline) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Plant not found or access denied", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
 
-  void db; // placeholder until wired
-
-  return NextResponse.json({
-    plantId,
-    items: [],
-    message: "TODO: Wire Supabase DB timeline query",
-  });
+    return attachRequestId(
+      NextResponse.json({ ...timeline, requestId }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "plant timeline fetch failed", {
+      requestId,
+      plantId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error:
+            error instanceof Error ? error.message : "Failed to load timeline",
+          requestId,
+        },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
 }

--- a/apps/web/src/app/api/uploads/sign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/uploads/sign/__tests__/route.test.ts
@@ -1,22 +1,24 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type Mock,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { NextRequest } from "next/server";
 
 const getServerSession = vi.fn();
-const getStorageClient = vi.fn();
+const getServerUser = vi.fn();
+const preparePlantImageUpload = vi.fn();
+const rateLimit = vi.fn();
+const rateLimitKeyFromRequest = vi.fn();
 
 vi.mock("@/lib/server/auth", () => ({
   getServerSession: (...args: unknown[]) => getServerSession(...args),
+  getServerUser: (...args: unknown[]) => getServerUser(...args),
 }));
-vi.mock("@/lib/server/storage", () => ({
-  getStorageClient: (...args: unknown[]) => getStorageClient(...args),
+vi.mock("@/lib/server/plants", () => ({
+  preparePlantImageUpload: (...args: unknown[]) =>
+    preparePlantImageUpload(...args),
+}));
+vi.mock("@/lib/server/rate-limit", () => ({
+  rateLimit: (...args: unknown[]) => rateLimit(...args),
+  rateLimitKeyFromRequest: (...args: unknown[]) =>
+    rateLimitKeyFromRequest(...args),
 }));
 
 import { POST } from "../route";
@@ -34,12 +36,20 @@ const SESSION_OK = { user: { id: "u1" } } as const;
 describe("POST /api/uploads/sign", () => {
   beforeEach(() => {
     (getServerSession as Mock).mockReset();
-    (getStorageClient as Mock).mockReset();
-    getStorageClient.mockReturnValue({ __storage: true });
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
+    (getServerUser as Mock).mockReset();
+    (preparePlantImageUpload as Mock).mockReset();
+    (rateLimit as Mock).mockReset();
+    (rateLimitKeyFromRequest as Mock).mockReset();
+    rateLimit.mockReturnValue({ ok: true });
+    rateLimitKeyFromRequest.mockReturnValue("k");
+    getServerUser.mockResolvedValue({ id: "u1" });
+    preparePlantImageUpload.mockImplementation(
+      async ({ plantId, fileName }: { plantId: string; fileName: string }) => ({
+        storagePath: `plants/${plantId}/${Date.now()}-${fileName}`,
+        signedUrl: "https://example.com/upload",
+        token: "signed-token",
+      }),
+    );
   });
 
   it("returns 401 when no session is present", async () => {
@@ -52,8 +62,8 @@ describe("POST /api/uploads/sign", () => {
       }),
     );
     expect(res.status).toBe(401);
-    expect(await res.json()).toEqual({ error: "Unauthorized" });
-    expect(getStorageClient).not.toHaveBeenCalled();
+    expect((await res.json()).error).toBe("Unauthorized");
+    expect(preparePlantImageUpload).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -64,8 +74,7 @@ describe("POST /api/uploads/sign", () => {
     getServerSession.mockResolvedValue(SESSION_OK);
     const res = await POST(jsonRequest(body));
     expect(res.status).toBe(400);
-    const json = await res.json();
-    expect(json.error).toMatch(/required/);
+    expect((await res.json()).error).toMatch(/required/);
   });
 
   it("returns 415 for an unsupported content type", async () => {
@@ -78,14 +87,13 @@ describe("POST /api/uploads/sign", () => {
       }),
     );
     expect(res.status).toBe(415);
-    expect(await res.json()).toEqual({ error: "Unsupported content type" });
+    expect((await res.json()).error).toBe("Unsupported content type");
   });
 
   it.each(["image/jpeg", "image/png", "image/webp", "image/heic"])(
     "accepts content type %s",
     async (contentType) => {
       getServerSession.mockResolvedValue(SESSION_OK);
-      vi.useFakeTimers().setSystemTime(new Date("2026-04-01T00:00:00Z"));
       const res = await POST(
         jsonRequest({
           plantId: "plant-xyz",
@@ -96,12 +104,13 @@ describe("POST /api/uploads/sign", () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.storagePath).toMatch(/^plants\/plant-xyz\/\d+-leaf\.jpg$/);
-      expect(getStorageClient).toHaveBeenCalled();
+      expect(preparePlantImageUpload).toHaveBeenCalled();
     },
   );
 
-  it("derives a storage path scoped to the plantId", async () => {
+  it("returns 429 when rate-limited", async () => {
     getServerSession.mockResolvedValue(SESSION_OK);
+    rateLimit.mockReturnValue({ ok: false });
     const res = await POST(
       jsonRequest({
         plantId: "p1",
@@ -109,8 +118,19 @@ describe("POST /api/uploads/sign", () => {
         contentType: "image/png",
       }),
     );
-    const body = await res.json();
-    expect(body.storagePath.startsWith("plants/p1/")).toBe(true);
-    expect(body.storagePath.endsWith("-shot.png")).toBe(true);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 404 when prepare returns null", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    preparePlantImageUpload.mockResolvedValueOnce(null);
+    const res = await POST(
+      jsonRequest({
+        plantId: "missing",
+        fileName: "shot.png",
+        contentType: "image/png",
+      }),
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/apps/web/src/app/api/uploads/sign/route.ts
+++ b/apps/web/src/app/api/uploads/sign/route.ts
@@ -1,53 +1,115 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getServerSession } from "@/lib/server/auth";
-import { getStorageClient } from "@/lib/server/storage";
+import { getServerSession, getServerUser } from "@/lib/server/auth";
+import { preparePlantImageUpload } from "@/lib/server/plants";
+import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
+import {
+  attachRequestId,
+  getOrCreateRequestId,
+  logServerEvent,
+} from "@/lib/server/request-id";
 
 // POST /api/uploads/sign
 // Returns a short-lived Supabase Storage signed upload URL.
 // The browser uploads directly to Supabase; the signed URL is generated here
 // on the server so the service role key is never exposed.
 export async function POST(request: NextRequest) {
+  const requestId = getOrCreateRequestId(request);
   const session = await getServerSession();
   if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
+  }
+
+  const user = await getServerUser();
+  const rate = rateLimit({
+    key: rateLimitKeyFromRequest(request, user?.id ?? null),
+    limit: 10,
+    windowMs: 60_000,
+  });
+  if (!rate.ok) {
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error: "Too many upload preparations. Try again shortly.",
+          requestId,
+        },
+        { status: 429 },
+      ),
+      requestId,
+    );
   }
 
   const body = (await request.json()) as {
     plantId: string;
     fileName: string;
     contentType: string;
+    takenAt?: string;
+    source?: "camera" | "upload";
+    notes?: string;
   };
 
   if (!body.plantId || !body.fileName || !body.contentType) {
-    return NextResponse.json(
-      { error: "plantId, fileName, and contentType are required" },
-      { status: 400 },
+    return attachRequestId(
+      NextResponse.json(
+        { error: "plantId, fileName, and contentType are required", requestId },
+        { status: 400 },
+      ),
+      requestId,
     );
   }
 
   // Validate content type — images only
   const allowedTypes = ["image/jpeg", "image/png", "image/webp", "image/heic"];
   if (!allowedTypes.includes(body.contentType)) {
-    return NextResponse.json(
-      { error: "Unsupported content type" },
-      { status: 415 },
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Unsupported content type", requestId },
+        { status: 415 },
+      ),
+      requestId,
     );
   }
 
-  const storage = getStorageClient();
-  const storagePath = `plants/${body.plantId}/${Date.now()}-${body.fileName}`;
+  try {
+    const prepared = await preparePlantImageUpload({
+      plantId: body.plantId,
+      fileName: body.fileName,
+      contentType: body.contentType,
+      requestId,
+    });
 
-  // TODO: Replace with actual Supabase Storage createSignedUploadUrl call
-  // const { data, error } = await storage
-  //   .from("plant-images")
-  //   .createSignedUploadUrl(storagePath);
+    if (!prepared) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Plant not found or access denied", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
 
-  void storage; // placeholder until wired
-
-  return NextResponse.json({
-    storagePath,
-    // signedUrl: data.signedUrl,
-    // token: data.token,
-    message: "TODO: Wire Supabase Storage signed upload URL",
-  });
+    return attachRequestId(
+      NextResponse.json({ ...prepared, requestId }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "upload signing failed", {
+      requestId,
+      plantId: body.plantId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error:
+            error instanceof Error ? error.message : "Upload signing failed",
+          requestId,
+        },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
 }

--- a/apps/web/src/lib/server/__tests__/analysis-proxy.test.ts
+++ b/apps/web/src/lib/server/__tests__/analysis-proxy.test.ts
@@ -45,7 +45,7 @@ describe("analysis-proxy", () => {
     expect(url).toBe("https://analysis.example.com/status");
     expect(init.method).toBe("GET");
     expect(init.body).toBeUndefined();
-    expect((init.headers as Record<string, string>).Authorization).toBe(
+    expect(new Headers(init.headers).get("Authorization")).toBe(
       "Bearer test-key",
     );
   });

--- a/apps/web/src/lib/server/analysis-proxy.ts
+++ b/apps/web/src/lib/server/analysis-proxy.ts
@@ -1,12 +1,41 @@
 import "server-only";
 import type { AnalysisResponse } from "@phenosage/shared";
 import { getAnalysisServiceConfig } from "./analysis-config";
+import { REQUEST_ID_HEADER, withRequestIdHeader } from "./request-id";
 
 interface ProxyOptions {
   endpoint: string;
   method?: "GET" | "POST";
   body?: unknown;
+  requestId?: string;
 }
+
+type RawAnalysisResponse = {
+  plant_id?: string;
+  plantId?: string;
+  image_id?: string;
+  imageId?: string;
+  overall_health_score?: number;
+  overallHealthScore?: number;
+  summary: string;
+  findings: AnalysisResponse["findings"];
+  compared_to_image_id?: string | null;
+  comparedToImageId?: string | null;
+  comparison_summary?: string | null;
+  comparisonSummary?: string | null;
+  analyzed_at?: string;
+  analyzedAt?: string;
+  model_version?: string;
+  modelVersion?: string;
+  analysis_mode?: "fallback" | "model";
+  analysisMode?: "fallback" | "model";
+  is_fallback?: boolean;
+  isFallback?: boolean;
+  fallback_reason?: string | null;
+  fallbackReason?: string | null;
+  request_id?: string;
+  requestId?: string;
+};
 
 /**
  * Proxy client for the Railway analysis service.
@@ -17,14 +46,17 @@ export async function callAnalysisService<T = unknown>(
   options: ProxyOptions,
 ): Promise<T> {
   const { url, apiKey } = getAnalysisServiceConfig();
-  const { endpoint, method = "GET", body } = options;
+  const { endpoint, method = "GET", body, requestId } = options;
 
   const init: RequestInit = {
     method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
+    headers: withRequestIdHeader(
+      {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      requestId ?? crypto.randomUUID(),
+    ),
   };
   if (body !== undefined) {
     init.body = JSON.stringify(body);
@@ -34,10 +66,64 @@ export async function callAnalysisService<T = unknown>(
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Analysis service error ${response.status}: ${text}`);
+    const upstreamRequestId =
+      response.headers.get(REQUEST_ID_HEADER) ?? requestId ?? "unknown";
+    throw new Error(
+      `Analysis service error ${response.status} (request ${upstreamRequestId}): ${text}`,
+    );
   }
 
   return response.json() as Promise<T>;
+}
+
+export function normalizeAnalysisResponse(
+  payload: RawAnalysisResponse,
+): AnalysisResponse {
+  const normalized: AnalysisResponse = {
+    plantId: payload.plantId ?? payload.plant_id ?? "",
+    imageId: payload.imageId ?? payload.image_id ?? "",
+    overallHealthScore:
+      payload.overallHealthScore ?? payload.overall_health_score ?? 0,
+    summary: payload.summary,
+    findings: payload.findings,
+    analyzedAt:
+      payload.analyzedAt ?? payload.analyzed_at ?? new Date().toISOString(),
+    modelVersion: payload.modelVersion ?? payload.model_version ?? "unknown",
+  };
+
+  const comparedToImageId =
+    payload.comparedToImageId ?? payload.compared_to_image_id ?? null;
+  if (comparedToImageId) {
+    normalized.comparedToImageId = comparedToImageId;
+  }
+
+  const comparisonSummary =
+    payload.comparisonSummary ?? payload.comparison_summary ?? null;
+  if (comparisonSummary) {
+    normalized.comparisonSummary = comparisonSummary;
+  }
+
+  const analysisMode = payload.analysisMode ?? payload.analysis_mode ?? null;
+  if (analysisMode) {
+    normalized.analysisMode = analysisMode;
+  }
+
+  if (payload.isFallback ?? payload.is_fallback) {
+    normalized.isFallback = true;
+  }
+
+  const fallbackReason =
+    payload.fallbackReason ?? payload.fallback_reason ?? null;
+  if (fallbackReason) {
+    normalized.fallbackReason = fallbackReason;
+  }
+
+  const requestId = payload.requestId ?? payload.request_id ?? null;
+  if (requestId) {
+    normalized.requestId = requestId;
+  }
+
+  return normalized;
 }
 
 /**
@@ -49,10 +135,14 @@ export async function analyzeImage(params: {
   storagePath: string;
   growContext: Record<string, unknown>;
   previousImageId?: string;
+  previousStoragePath?: string;
+  requestId?: string;
 }): Promise<AnalysisResponse> {
-  return callAnalysisService<AnalysisResponse>({
+  const raw = await callAnalysisService<RawAnalysisResponse>({
     endpoint: "/analyze",
     method: "POST",
     body: params,
+    ...(params.requestId ? { requestId: params.requestId } : {}),
   });
+  return normalizeAnalysisResponse(raw);
 }

--- a/apps/web/src/lib/server/plant-access.ts
+++ b/apps/web/src/lib/server/plant-access.ts
@@ -1,0 +1,70 @@
+import "server-only";
+import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
+
+type AuthorizedPlantRow = {
+  id: string;
+  name: string;
+  strain: string | null;
+  notes: string | null;
+  grow_id: string;
+  grows: {
+    id: string;
+    stage: string | null;
+    medium: string | null;
+    light_type: string | null;
+    start_date: string | null;
+  } | null;
+};
+
+export type AuthorizedPlantContext = {
+  userId: string;
+  plantId: string;
+  plantName: string;
+  strain: string | null;
+  notes: string | null;
+  growId: string;
+  growStage: string | null;
+  medium: string | null;
+  lightType: string | null;
+  startDate: string | null;
+};
+
+export async function getAuthorizedPlantContext(
+  plantId: string,
+): Promise<AuthorizedPlantContext | null> {
+  const user = await getServerUser();
+  if (!user) {
+    return null;
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("plants")
+    .select(
+      "id,name,strain,notes,grow_id,grows!inner(id,stage,medium,light_type,start_date)",
+    )
+    .eq("id", plantId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to authorize plant access: ${error.message}`);
+  }
+
+  const plant = data as AuthorizedPlantRow | null;
+  if (!plant) {
+    return null;
+  }
+
+  return {
+    userId: user.id,
+    plantId: plant.id,
+    plantName: plant.name,
+    strain: plant.strain,
+    notes: plant.notes,
+    growId: plant.grow_id,
+    growStage: plant.grows?.stage ?? null,
+    medium: plant.grows?.medium ?? null,
+    lightType: plant.grows?.light_type ?? null,
+    startDate: plant.grows?.start_date ?? null,
+  };
+}

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -1,0 +1,486 @@
+import "server-only";
+import type { AnalysisFinding, AnalysisResponse } from "@phenosage/shared";
+import { analyzeImage } from "./analysis-proxy";
+import { createSupabaseServerClient } from "./auth";
+import { getAuthorizedPlantContext } from "./plant-access";
+import { getDbClient } from "./db";
+import { logServerEvent } from "./request-id";
+import { getStorageClient } from "./storage";
+
+type PlantImageRow = {
+  id: string;
+  plant_id: string;
+  grow_id: string;
+  user_id: string;
+  storage_path: string;
+  taken_at: string | null;
+  source: "camera" | "upload";
+  notes: string | null;
+  created_at: string;
+};
+
+type PlantAnalysisRow = {
+  id: string;
+  plant_id: string;
+  grow_id: string;
+  image_id: string;
+  compared_to_image_id: string | null;
+  overall_health_score: number;
+  summary: string;
+  comparison_summary: string | null;
+  analyzed_at: string;
+  model_version: string;
+  analysis_mode: "fallback" | "model";
+  is_fallback: boolean;
+  fallback_reason: string | null;
+  request_id: string | null;
+  created_at: string;
+};
+
+type PlantFindingRow = {
+  id: string;
+  plant_id: string;
+  grow_id: string;
+  image_id: string | null;
+  category: AnalysisFinding["category"];
+  severity: AnalysisFinding["severity"];
+  title: string;
+  description: string;
+  recommendation: string | null;
+  created_at: string;
+};
+
+type PlantObservationRow = {
+  id: string;
+  observed_at: string;
+  height_cm: number | null;
+  notes: string | null;
+  created_at: string;
+};
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/-+/g, "-");
+}
+
+function daysSinceStart(startDate: string | null): number | undefined {
+  if (!startDate) {
+    return undefined;
+  }
+  const start = new Date(startDate);
+  if (Number.isNaN(start.getTime())) {
+    return undefined;
+  }
+  const diffMs = Date.now() - start.getTime();
+  return Math.max(0, Math.floor(diffMs / 86_400_000));
+}
+
+function mapAnalysisFromRow(
+  row: PlantAnalysisRow,
+  findings: AnalysisFinding[],
+): AnalysisResponse {
+  const analysis: AnalysisResponse = {
+    plantId: row.plant_id,
+    imageId: row.image_id,
+    overallHealthScore: row.overall_health_score,
+    summary: row.summary,
+    findings,
+    analyzedAt: row.analyzed_at,
+    modelVersion: row.model_version,
+    analysisMode: row.analysis_mode,
+    isFallback: row.is_fallback,
+  };
+
+  if (row.compared_to_image_id) {
+    analysis.comparedToImageId = row.compared_to_image_id;
+  }
+  if (row.comparison_summary) {
+    analysis.comparisonSummary = row.comparison_summary;
+  }
+  if (row.fallback_reason) {
+    analysis.fallbackReason = row.fallback_reason;
+  }
+  if (row.request_id) {
+    analysis.requestId = row.request_id;
+  }
+
+  return analysis;
+}
+
+export async function preparePlantImageUpload(params: {
+  plantId: string;
+  fileName: string;
+  contentType: string;
+  requestId: string;
+}) {
+  const context = await getAuthorizedPlantContext(params.plantId);
+  if (!context) {
+    return null;
+  }
+
+  const imageId = crypto.randomUUID();
+  const storagePath = `${params.plantId}/${Date.now()}-${imageId}-${sanitizeFileName(params.fileName)}`;
+
+  const storage = getStorageClient();
+  const { data: uploadData, error: uploadError } = await storage
+    .from("plant-images")
+    .createSignedUploadUrl(storagePath);
+
+  if (uploadError) {
+    throw new Error(
+      `Failed to create signed upload URL: ${uploadError.message}`,
+    );
+  }
+
+  logServerEvent("info", "plant image upload prepared", {
+    requestId: params.requestId,
+    plantId: context.plantId,
+    imageId,
+  });
+
+  return {
+    imageId,
+    plantId: context.plantId,
+    storagePath,
+    token: uploadData.token,
+  };
+}
+
+export async function persistPlantImageUpload(params: {
+  imageId: string;
+  notes?: string;
+  plantId: string;
+  source?: "camera" | "upload";
+  storagePath: string;
+  takenAt?: string;
+}) {
+  const context = await getAuthorizedPlantContext(params.plantId);
+  if (!context) {
+    return null;
+  }
+
+  if (!params.storagePath.startsWith(`${context.plantId}/`)) {
+    throw new Error("Upload path does not match the requested plant.");
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { error } = await supabase.from("plant_images").insert({
+    grow_id: context.growId,
+    id: params.imageId,
+    notes: params.notes ?? null,
+    plant_id: context.plantId,
+    source: params.source ?? "upload",
+    storage_path: params.storagePath,
+    taken_at: params.takenAt ?? null,
+    user_id: context.userId,
+  });
+
+  if (error) {
+    throw new Error(`Failed to persist plant image metadata: ${error.message}`);
+  }
+
+  return {
+    imageId: params.imageId,
+    plantId: context.plantId,
+    storagePath: params.storagePath,
+  };
+}
+
+export async function getLatestPlantAnalysis(
+  plantId: string,
+): Promise<AnalysisResponse | null> {
+  const context = await getAuthorizedPlantContext(plantId);
+  if (!context) {
+    return null;
+  }
+
+  const db = getDbClient();
+  const { data: analysisRow, error: analysisError } = await db
+    .from("plant_analyses")
+    .select("*")
+    .eq("plant_id", context.plantId)
+    .order("analyzed_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (analysisError) {
+    throw new Error(
+      `Failed to fetch latest plant analysis: ${analysisError.message}`,
+    );
+  }
+
+  const persisted = analysisRow as PlantAnalysisRow | null;
+  if (!persisted) {
+    return null;
+  }
+
+  const { data: findingRows, error: findingError } = await db
+    .from("plant_findings")
+    .select("*")
+    .eq("image_id", persisted.image_id)
+    .order("created_at", { ascending: true });
+
+  if (findingError) {
+    throw new Error(
+      `Failed to fetch analysis findings: ${findingError.message}`,
+    );
+  }
+
+  const findings = ((findingRows ?? []) as PlantFindingRow[]).map((row) => {
+    const finding: AnalysisFinding = {
+      category: row.category,
+      severity: row.severity,
+      title: row.title,
+      description: row.description,
+    };
+    if (row.recommendation) {
+      finding.recommendation = row.recommendation;
+    }
+    return finding;
+  });
+
+  return mapAnalysisFromRow(persisted, findings);
+}
+
+export async function getPlantTimeline(plantId: string) {
+  const context = await getAuthorizedPlantContext(plantId);
+  if (!context) {
+    return null;
+  }
+
+  const db = getDbClient();
+  const [imagesResult, observationsResult, analysesResult, findingsResult] =
+    await Promise.all([
+      db
+        .from("plant_images")
+        .select("*")
+        .eq("plant_id", context.plantId)
+        .order("created_at", { ascending: false }),
+      db
+        .from("plant_observations")
+        .select("*")
+        .eq("plant_id", context.plantId)
+        .order("observed_at", { ascending: false }),
+      db
+        .from("plant_analyses")
+        .select("*")
+        .eq("plant_id", context.plantId)
+        .order("analyzed_at", { ascending: false }),
+      db
+        .from("plant_findings")
+        .select("*")
+        .eq("plant_id", context.plantId)
+        .order("created_at", { ascending: true }),
+    ]);
+
+  if (imagesResult.error) {
+    throw new Error(
+      `Failed to fetch plant images: ${imagesResult.error.message}`,
+    );
+  }
+  if (observationsResult.error) {
+    throw new Error(
+      `Failed to fetch plant observations: ${observationsResult.error.message}`,
+    );
+  }
+  if (analysesResult.error) {
+    throw new Error(
+      `Failed to fetch plant analyses: ${analysesResult.error.message}`,
+    );
+  }
+  if (findingsResult.error) {
+    throw new Error(
+      `Failed to fetch plant findings: ${findingsResult.error.message}`,
+    );
+  }
+
+  const findingsByImage = new Map<string, AnalysisFinding[]>();
+  for (const row of (findingsResult.data ?? []) as PlantFindingRow[]) {
+    if (!row.image_id) {
+      continue;
+    }
+    const current = findingsByImage.get(row.image_id) ?? [];
+    const finding: AnalysisFinding = {
+      category: row.category,
+      severity: row.severity,
+      title: row.title,
+      description: row.description,
+    };
+    if (row.recommendation) {
+      finding.recommendation = row.recommendation;
+    }
+    current.push(finding);
+    findingsByImage.set(row.image_id, current);
+  }
+
+  const analysesByImage = new Map<string, AnalysisResponse>();
+  for (const row of (analysesResult.data ?? []) as PlantAnalysisRow[]) {
+    analysesByImage.set(
+      row.image_id,
+      mapAnalysisFromRow(row, findingsByImage.get(row.image_id) ?? []),
+    );
+  }
+
+  const imageItems = ((imagesResult.data ?? []) as PlantImageRow[]).map(
+    (row) => ({
+      type: "image" as const,
+      id: row.id,
+      createdAt: row.created_at,
+      takenAt: row.taken_at ?? row.created_at,
+      source: row.source,
+      notes: row.notes ?? undefined,
+      storagePath: row.storage_path,
+      analysis: analysesByImage.get(row.id) ?? null,
+      findings: findingsByImage.get(row.id) ?? [],
+    }),
+  );
+
+  const observationItems = (
+    (observationsResult.data ?? []) as PlantObservationRow[]
+  ).map((row) => ({
+    type: "observation" as const,
+    id: row.id,
+    observedAt: row.observed_at,
+    createdAt: row.created_at,
+    heightCm: row.height_cm ?? undefined,
+    notes: row.notes ?? undefined,
+  }));
+
+  const items = [...imageItems, ...observationItems].sort((left, right) => {
+    const leftTime =
+      left.type === "image"
+        ? new Date(left.takenAt).getTime()
+        : new Date(left.observedAt).getTime();
+    const rightTime =
+      right.type === "image"
+        ? new Date(right.takenAt).getTime()
+        : new Date(right.observedAt).getTime();
+    return rightTime - leftTime;
+  });
+
+  return {
+    plantId: context.plantId,
+    items,
+  };
+}
+
+export async function runAndPersistPlantAnalysis(params: {
+  plantId: string;
+  imageId?: string;
+  requestId: string;
+}) {
+  const context = await getAuthorizedPlantContext(params.plantId);
+  if (!context) {
+    return null;
+  }
+
+  const db = getDbClient();
+  const { data: imageRows, error: imageError } = await db
+    .from("plant_images")
+    .select("*")
+    .eq("plant_id", context.plantId)
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  if (imageError) {
+    throw new Error(
+      `Failed to load plant images for analysis: ${imageError.message}`,
+    );
+  }
+
+  const images = (imageRows ?? []) as PlantImageRow[];
+  const currentImage = params.imageId
+    ? (images.find((row) => row.id === params.imageId) ?? null)
+    : (images[0] ?? null);
+
+  if (!currentImage) {
+    return { context, analysis: null };
+  }
+
+  const previousImage =
+    images.find((row) => row.id !== currentImage.id) ?? null;
+
+  const analysis = await analyzeImage({
+    plantId: context.plantId,
+    imageId: currentImage.id,
+    storagePath: currentImage.storage_path,
+    growContext: {
+      growId: context.growId,
+      ...(context.strain ? { strain: context.strain } : {}),
+      ...(context.growStage ? { stage: context.growStage } : {}),
+      ...(context.medium ? { medium: context.medium } : {}),
+      ...(context.lightType ? { lightType: context.lightType } : {}),
+      ...(daysSinceStart(context.startDate) !== undefined
+        ? { daysSinceStart: daysSinceStart(context.startDate) }
+        : {}),
+      ...(context.notes ? { notes: context.notes } : {}),
+    },
+    ...(previousImage?.id ? { previousImageId: previousImage.id } : {}),
+    ...(previousImage?.storage_path
+      ? { previousStoragePath: previousImage.storage_path }
+      : {}),
+    requestId: params.requestId,
+  });
+
+  const { error: upsertError } = await db.from("plant_analyses").upsert(
+    {
+      plant_id: context.plantId,
+      grow_id: context.growId,
+      image_id: currentImage.id,
+      compared_to_image_id: analysis.comparedToImageId ?? null,
+      overall_health_score: analysis.overallHealthScore,
+      summary: analysis.summary,
+      comparison_summary: analysis.comparisonSummary ?? null,
+      analyzed_at: analysis.analyzedAt,
+      model_version: analysis.modelVersion,
+      analysis_mode: analysis.analysisMode ?? "fallback",
+      is_fallback: analysis.isFallback ?? false,
+      fallback_reason: analysis.fallbackReason ?? null,
+      request_id: analysis.requestId ?? params.requestId,
+    },
+    { onConflict: "image_id" },
+  );
+
+  if (upsertError) {
+    throw new Error(`Failed to persist plant analysis: ${upsertError.message}`);
+  }
+
+  const { error: deleteError } = await db
+    .from("plant_findings")
+    .delete()
+    .eq("image_id", currentImage.id);
+
+  if (deleteError) {
+    throw new Error(`Failed to replace plant findings: ${deleteError.message}`);
+  }
+
+  if (analysis.findings.length) {
+    const { error: findingError } = await db.from("plant_findings").insert(
+      analysis.findings.map((finding) => ({
+        plant_id: context.plantId,
+        grow_id: context.growId,
+        image_id: currentImage.id,
+        category: finding.category,
+        severity: finding.severity,
+        title: finding.title,
+        description: finding.description,
+        recommendation: finding.recommendation ?? null,
+      })),
+    );
+
+    if (findingError) {
+      throw new Error(
+        `Failed to persist plant findings: ${findingError.message}`,
+      );
+    }
+  }
+
+  logServerEvent("info", "plant analysis persisted", {
+    requestId: params.requestId,
+    plantId: context.plantId,
+    imageId: currentImage.id,
+    analysisMode: analysis.analysisMode,
+    isFallback: analysis.isFallback,
+  });
+
+  return { context, analysis };
+}

--- a/apps/web/src/lib/server/profile.ts
+++ b/apps/web/src/lib/server/profile.ts
@@ -1,0 +1,38 @@
+import "server-only";
+import { createSupabaseServerClient, getServerUser } from "./auth";
+
+type ProfileRow = {
+  display_name: string | null;
+};
+
+export type CurrentProfile = {
+  displayName: string | null;
+  email: string | null;
+  id: string;
+};
+
+export async function getCurrentProfile(): Promise<CurrentProfile | null> {
+  const user = await getServerUser();
+  if (!user) {
+    return null;
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("display_name")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load current profile: ${error.message}`);
+  }
+
+  const profile = data as ProfileRow | null;
+
+  return {
+    displayName: profile?.display_name ?? null,
+    email: user.email ?? null,
+    id: user.id,
+  };
+}

--- a/apps/web/src/lib/server/request-id.ts
+++ b/apps/web/src/lib/server/request-id.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+export const REQUEST_ID_HEADER = "x-request-id";
+
+type LogLevel = "error" | "info" | "warn";
+
+export function getOrCreateRequestId(request: Request): string {
+  const candidate = request.headers.get(REQUEST_ID_HEADER)?.trim();
+  return candidate || crypto.randomUUID();
+}
+
+export function withRequestIdHeader(
+  headersInit: HeadersInit | undefined,
+  requestId: string,
+): Headers {
+  const headers = new Headers(headersInit);
+  headers.set(REQUEST_ID_HEADER, requestId);
+  return headers;
+}
+
+export function attachRequestId<T extends Response>(
+  response: T,
+  requestId: string,
+): T {
+  response.headers.set(REQUEST_ID_HEADER, requestId);
+  return response;
+}
+
+export function logServerEvent(
+  level: LogLevel,
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  const payload = {
+    level,
+    message,
+    service: "phenosage-web",
+    timestamp: new Date().toISOString(),
+    ...fields,
+  };
+  const serialized = JSON.stringify(payload);
+  if (level === "error") {
+    console.error(serialized);
+    return;
+  }
+  if (level === "warn") {
+    console.warn(serialized);
+    return;
+  }
+  process.stdout.write(`${serialized}\n`);
+}

--- a/apps/web/src/lib/server/workspace-overview.ts
+++ b/apps/web/src/lib/server/workspace-overview.ts
@@ -1,0 +1,230 @@
+import "server-only";
+import { createSupabaseServerClient } from "./auth";
+
+type GrowRow = {
+  id: string;
+  light_type: string | null;
+  medium: string | null;
+  name: string;
+  stage: string | null;
+  start_date: string | null;
+  updated_at: string;
+};
+
+type PlantRow = {
+  grow_id: string;
+  id: string;
+  name: string;
+  updated_at: string;
+};
+
+type ImageRow = {
+  created_at: string;
+  grow_id: string;
+  id: string;
+  plant_id: string;
+};
+
+type FindingRow = {
+  created_at: string;
+  grow_id: string;
+  id: string;
+  plant_id: string;
+  resolved_at: string | null;
+  severity: "critical" | "high" | "info" | "low" | "medium";
+  title: string;
+};
+
+export type GrowOverview = {
+  id: string;
+  imageCount: number;
+  lightType: string | null;
+  medium: string | null;
+  name: string;
+  openFindingCount: number;
+  plantCount: number;
+  primaryPlantId: string | null;
+  primaryPlantName: string | null;
+  stage: string | null;
+  startDate: string | null;
+  updatedAt: string;
+};
+
+export type RecentFinding = {
+  createdAt: string;
+  growId: string;
+  id: string;
+  plantId: string;
+  plantName: string;
+  severity: FindingRow["severity"];
+  title: string;
+};
+
+export type WorkspaceOverview = {
+  grows: GrowOverview[];
+  openFindings: number;
+  recentActivity: {
+    lastCaptureAt: string | null;
+    lastPlantUpdateAt: string | null;
+  };
+  recentFindings: RecentFinding[];
+  totals: {
+    grows: number;
+    images: number;
+    plants: number;
+  };
+};
+
+const EMPTY_WORKSPACE_OVERVIEW: WorkspaceOverview = {
+  grows: [],
+  openFindings: 0,
+  recentActivity: {
+    lastCaptureAt: null,
+    lastPlantUpdateAt: null,
+  },
+  recentFindings: [],
+  totals: {
+    grows: 0,
+    images: 0,
+    plants: 0,
+  },
+};
+
+function compareUpdatedAtDescending(
+  left: { updatedAt: string },
+  right: { updatedAt: string },
+) {
+  return (
+    new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime()
+  );
+}
+
+export async function getWorkspaceOverview(): Promise<WorkspaceOverview> {
+  if (
+    !process.env["NEXT_PUBLIC_SUPABASE_URL"] ||
+    !process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]
+  ) {
+    return EMPTY_WORKSPACE_OVERVIEW;
+  }
+
+  const supabase = await createSupabaseServerClient();
+
+  const [growsResult, plantsResult, imagesResult, findingsResult] =
+    await Promise.all([
+      supabase
+        .from("grows")
+        .select("id,name,stage,medium,light_type,start_date,updated_at")
+        .order("updated_at", { ascending: false })
+        .limit(12),
+      supabase
+        .from("plants")
+        .select("id,name,grow_id,updated_at")
+        .order("updated_at", { ascending: false })
+        .limit(200),
+      supabase
+        .from("plant_images")
+        .select("id,grow_id,plant_id,created_at")
+        .order("created_at", { ascending: false })
+        .limit(400),
+      supabase
+        .from("plant_findings")
+        .select("id,grow_id,plant_id,title,severity,resolved_at,created_at")
+        .order("created_at", { ascending: false })
+        .limit(200),
+    ]);
+
+  if (growsResult.error) {
+    throw new Error(`Failed to load grows: ${growsResult.error.message}`);
+  }
+  if (plantsResult.error) {
+    throw new Error(`Failed to load plants: ${plantsResult.error.message}`);
+  }
+  if (imagesResult.error) {
+    throw new Error(`Failed to load images: ${imagesResult.error.message}`);
+  }
+  if (findingsResult.error) {
+    throw new Error(`Failed to load findings: ${findingsResult.error.message}`);
+  }
+
+  const grows = (growsResult.data ?? []) as GrowRow[];
+  const plants = (plantsResult.data ?? []) as PlantRow[];
+  const images = (imagesResult.data ?? []) as ImageRow[];
+  const findings = (findingsResult.data ?? []) as FindingRow[];
+
+  const plantsByGrow = new Map<string, PlantRow[]>();
+  const imagesByGrow = new Map<string, ImageRow[]>();
+  const unresolvedFindingsByGrow = new Map<string, FindingRow[]>();
+  const plantNamesById = new Map<string, string>();
+
+  for (const plant of plants) {
+    const current = plantsByGrow.get(plant.grow_id) ?? [];
+    current.push(plant);
+    plantsByGrow.set(plant.grow_id, current);
+    plantNamesById.set(plant.id, plant.name);
+  }
+
+  for (const image of images) {
+    const current = imagesByGrow.get(image.grow_id) ?? [];
+    current.push(image);
+    imagesByGrow.set(image.grow_id, current);
+  }
+
+  for (const finding of findings) {
+    if (finding.resolved_at) {
+      continue;
+    }
+    const current = unresolvedFindingsByGrow.get(finding.grow_id) ?? [];
+    current.push(finding);
+    unresolvedFindingsByGrow.set(finding.grow_id, current);
+  }
+
+  const growOverview = grows
+    .map((grow) => {
+      const growPlants = plantsByGrow.get(grow.id) ?? [];
+      const growImages = imagesByGrow.get(grow.id) ?? [];
+      const unresolvedGrowFindings =
+        unresolvedFindingsByGrow.get(grow.id) ?? [];
+      const primaryPlant = growPlants[0] ?? null;
+
+      return {
+        id: grow.id,
+        imageCount: growImages.length,
+        lightType: grow.light_type,
+        medium: grow.medium,
+        name: grow.name,
+        openFindingCount: unresolvedGrowFindings.length,
+        plantCount: growPlants.length,
+        primaryPlantId: primaryPlant?.id ?? null,
+        primaryPlantName: primaryPlant?.name ?? null,
+        stage: grow.stage,
+        startDate: grow.start_date,
+        updatedAt: grow.updated_at,
+      } satisfies GrowOverview;
+    })
+    .sort(compareUpdatedAtDescending);
+
+  const recentFindings = findings.slice(0, 5).map((finding) => ({
+    createdAt: finding.created_at,
+    growId: finding.grow_id,
+    id: finding.id,
+    plantId: finding.plant_id,
+    plantName: plantNamesById.get(finding.plant_id) ?? "Plant",
+    severity: finding.severity,
+    title: finding.title,
+  }));
+
+  return {
+    grows: growOverview,
+    openFindings: findings.filter((finding) => !finding.resolved_at).length,
+    recentActivity: {
+      lastCaptureAt: images[0]?.created_at ?? null,
+      lastPlantUpdateAt: plants[0]?.updated_at ?? null,
+    },
+    recentFindings,
+    totals: {
+      grows: grows.length,
+      images: images.length,
+      plants: plants.length,
+    },
+  };
+}

--- a/apps/web/src/lib/server/workspace-records.ts
+++ b/apps/web/src/lib/server/workspace-records.ts
@@ -1,0 +1,124 @@
+import "server-only";
+import { createSupabaseServerClient } from "./auth";
+
+type GrowRow = {
+  id: string;
+  light_type: string | null;
+  medium: string | null;
+  name: string;
+  stage: string | null;
+  start_date: string | null;
+  updated_at: string;
+};
+
+type PlantRow = {
+  batch_label: string | null;
+  grow_id: string;
+  grows:
+    | {
+        id: string;
+        name: string;
+        stage: string | null;
+      }[]
+    | null;
+  id: string;
+  name: string;
+  notes: string | null;
+  strain: string | null;
+  updated_at: string;
+};
+
+export type GrowRecord = {
+  id: string;
+  lightType: string | null;
+  medium: string | null;
+  name: string;
+  stage: string | null;
+  startDate: string | null;
+  updatedAt: string;
+};
+
+export type PlantRecord = {
+  batchLabel: string | null;
+  grow: {
+    id: string;
+    name: string;
+    stage: string | null;
+  } | null;
+  growId: string;
+  id: string;
+  name: string;
+  notes: string | null;
+  strain: string | null;
+  updatedAt: string;
+};
+
+function hasSupabaseEnv() {
+  return Boolean(
+    process.env["NEXT_PUBLIC_SUPABASE_URL"] &&
+    process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"],
+  );
+}
+
+export async function listAccessibleGrows(): Promise<GrowRecord[]> {
+  if (!hasSupabaseEnv()) {
+    return [];
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("grows")
+    .select("id,name,stage,medium,light_type,start_date,updated_at")
+    .order("updated_at", { ascending: false })
+    .limit(100);
+
+  if (error) {
+    throw new Error(`Failed to load grows: ${error.message}`);
+  }
+
+  return ((data ?? []) as GrowRow[]).map((grow) => ({
+    id: grow.id,
+    lightType: grow.light_type,
+    medium: grow.medium,
+    name: grow.name,
+    stage: grow.stage,
+    startDate: grow.start_date,
+    updatedAt: grow.updated_at,
+  }));
+}
+
+export async function listAccessiblePlants(): Promise<PlantRecord[]> {
+  if (!hasSupabaseEnv()) {
+    return [];
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase
+    .from("plants")
+    .select(
+      "id,name,strain,batch_label,notes,grow_id,updated_at,grows!inner(id,name,stage)",
+    )
+    .order("updated_at", { ascending: false })
+    .limit(200);
+
+  if (error) {
+    throw new Error(`Failed to load plants: ${error.message}`);
+  }
+
+  return ((data ?? []) as PlantRow[]).map((plant) => ({
+    batchLabel: plant.batch_label,
+    grow: plant.grows?.[0]
+      ? {
+          id: plant.grows[0].id,
+          name: plant.grows[0].name,
+          stage: plant.grows[0].stage,
+        }
+      : null,
+    growId: plant.grow_id,
+    id: plant.id,
+    name: plant.name,
+    notes: plant.notes,
+    strain: plant.strain,
+    updatedAt: plant.updated_at,
+  }));
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,19 +4,25 @@
 
 ## Services Overview
 
-| Service | Platform | Purpose |
-|---|---|---|
-| `apps/web` | Vercel | Next.js web app — the only public origin |
-| `apps/analysis` | Railway | FastAPI analysis service — private, never browser-callable |
-| Database | Supabase (Postgres) | All application data with RLS |
-| Storage | Supabase Storage | Private plant images |
-| Auth | Supabase Auth | User accounts and sessions |
+| Service         | Platform            | Purpose                                                    |
+| --------------- | ------------------- | ---------------------------------------------------------- |
+| `apps/web`      | Vercel              | Next.js web app — the only public origin                   |
+| `apps/analysis` | Railway             | FastAPI analysis service — private, never browser-callable |
+| Database        | Supabase (Postgres) | All application data with RLS                              |
+| Storage         | Supabase Storage    | Private plant images                                       |
+| Auth            | Supabase Auth       | User accounts and sessions                                 |
 
 ---
 
 ## Guiding Principle
 
 > Vercel is the only public origin. The browser never calls Railway or uses the Supabase service role key.
+
+## Runtime Contract
+
+- Node.js: `20.x`
+- pnpm: `9.15.9`
+- `package.json#engines.node` is the source of truth for Vercel. Keep the Vercel project setting aligned with it rather than letting the dashboard drift to a newer default.
 
 ---
 
@@ -28,30 +34,37 @@ Set these in Vercel project settings → Environment Variables.
 
 Mark server-only variables as **Server** exposure only (not Preview/Production client-side).
 
-| Variable | Exposure | Description |
-|---|---|---|
-| `NEXT_PUBLIC_SUPABASE_URL` | Public | Supabase project URL |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public | Supabase anon/public key |
-| `NEXT_PUBLIC_APP_URL` | Public | App base URL (e.g. `https://phenosage.vercel.app`) |
-| `SUPABASE_SERVICE_ROLE_KEY` | **Server only** | Supabase service role — bypasses RLS |
-| `ANALYSIS_SERVICE_URL` | **Server only** | Railway analysis service base URL |
-| `ANALYSIS_SERVICE_API_KEY` | **Server only** | Shared secret for proxy auth |
-| `OPENAI_API_KEY` | **Server only** | OpenAI API key |
-| `CRON_SECRET` | **Server only** | Protects `/api/internal/cron/*` endpoints |
+| Variable                        | Exposure        | Description                                        |
+| ------------------------------- | --------------- | -------------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Public          | Supabase project URL                               |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public          | Supabase anon/public key                           |
+| `NEXT_PUBLIC_APP_URL`           | Public          | App base URL (e.g. `https://phenosage.vercel.app`) |
+| `SUPABASE_SERVICE_ROLE_KEY`     | **Server only** | Supabase service role — bypasses RLS               |
+| `ANALYSIS_SERVICE_URL`          | **Server only** | Railway analysis service base URL                  |
+| `ANALYSIS_SERVICE_API_KEY`      | **Server only** | Shared secret for proxy auth                       |
+| `OPENAI_API_KEY`                | **Server only** | OpenAI API key                                     |
+| `CRON_SECRET`                   | **Server only** | Protects `/api/internal/cron/*` endpoints          |
+| `SENTRY_DSN`                    | **Server only** | Optional Sentry DSN for web error reporting        |
+| `SENTRY_TRACES_SAMPLE_RATE`     | **Server only** | Optional trace sample rate                         |
 
 ### apps/analysis (Railway)
 
 Set these in Railway project → Variables.
 
-| Variable | Description |
-|---|---|
-| `API_KEY` | Shared secret — must match `ANALYSIS_SERVICE_API_KEY` in Vercel |
-| `OPENAI_API_KEY` | OpenAI API key for Vision analysis |
-| `SUPABASE_URL` | Supabase project URL |
-| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role (to fetch private images) |
-| `APP_ENV` | `production` |
-| `LOG_LEVEL` | `info` |
-| `PORT` | Set automatically by Railway |
+| Variable                      | Description                                                     |
+| ----------------------------- | --------------------------------------------------------------- |
+| `ANALYSIS_SERVICE_API_KEY`    | Shared secret — must match `ANALYSIS_SERVICE_API_KEY` in Vercel |
+| `OPENAI_API_KEY`              | OpenAI API key for Vision analysis                              |
+| `SUPABASE_URL`                | Supabase project URL                                            |
+| `SUPABASE_SERVICE_ROLE_KEY`   | Supabase service role (to fetch private images)                 |
+| `APP_ENV`                     | `production`                                                    |
+| `LOG_LEVEL`                   | `info`                                                          |
+| `SENTRY_DSN`                  | Optional Sentry DSN                                             |
+| `SENTRY_TRACES_SAMPLE_RATE`   | Optional trace sample rate                                      |
+| `OTEL_ENABLED`                | Optional flag to enable OTLP export                             |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional OTLP HTTP endpoint                                     |
+| `OTEL_SERVICE_NAME`           | Optional OTEL service name override                             |
+| `PORT`                        | Set automatically by Railway                                    |
 
 ---
 
@@ -59,10 +72,11 @@ Set these in Railway project → Variables.
 
 1. Connect your GitHub repo to Vercel
 2. Set root directory to `apps/web`
-3. Set install command to `pnpm install --frozen-lockfile` (from repo root)
-4. Set build command to `pnpm build`
-5. Add all environment variables (server-only variables: mark as **Server** only)
-6. Deploy
+3. Set Node.js Version to `20.x`
+4. Set install command to `pnpm install --frozen-lockfile` (from repo root)
+5. Set build command to `pnpm build`
+6. Add all environment variables (server-only variables: mark as **Server** only)
+7. Deploy
 
 Vercel Cron is configured in `apps/web/vercel.json`:
 
@@ -85,7 +99,7 @@ Vercel Cron is configured in `apps/web/vercel.json`:
 2. Add a service from GitHub → select the repo → set root directory to `apps/analysis`
 3. Railway will detect the `Dockerfile` automatically
 4. Add all environment variables (see table above)
-5. Set the `API_KEY` to a strong random secret
+5. Set `ANALYSIS_SERVICE_API_KEY` to a strong random secret
 6. Copy the Railway public URL → set as `ANALYSIS_SERVICE_URL` in Vercel
 7. Deploy
 
@@ -137,8 +151,41 @@ docker run -p 8000:8000 --env-file .env phenosage-analysis
 
 The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push/PR:
 
-- **Web**: type-check, lint, build
+- **Web**: type-check, lint, test, build
 - **Analysis**: ruff lint, mypy type-check, pytest
 - **Shared**: type-check
 
-Merging to `main` triggers automatic Vercel and Railway deployments.
+Preview and production deploys should be considered ready only after `/api/ready` on the web app and `/ready` on the analysis service both return healthy responses with the expected request IDs in headers.
+
+Run the repo-level readiness check before the authenticated smoke so missing
+server env is caught immediately:
+
+```bash
+pnpm run check:ready -- --url https://phenosage-<deployment>.vercel.app
+```
+
+For a Vercel-protected preview, pass a full `/api/ready` URL that already
+includes your bypass or share query string instead of a bare base URL.
+
+If this fails on `ANALYSIS_SERVICE_API_KEY`, `SUPABASE_*`, or other server env,
+stop there and fix the deployment environment first. The authenticated smoke is
+meant to validate the functional slice after the deployment is actually ready,
+not to diagnose a broken env contract.
+
+For a higher-signal preview check, run the authenticated Playwright smoke in
+`apps/web/e2e/authenticated-workspace.spec.ts`. It seeds a temporary user,
+grow, and plant via the Supabase service role, signs in through `/auth`,
+uploads a test image, verifies persisted analysis through
+`/api/plants/[plantId]/analysis/latest` and `/timeline`, then confirms
+grounded chat thread/message persistence.
+
+Example:
+
+```bash
+E2E_BASE_URL=https://phenosage-<hash>-stevenschling13.vercel.app \
+E2E_SKIP_WEBSERVER=1 \
+E2E_AUTH_SMOKE=1 \
+NEXT_PUBLIC_SUPABASE_URL=https://<project>.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=<service-role> \
+pnpm --filter web test:e2e
+```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "check:env": "node scripts/check-env-contract.mjs",
+    "check:ready": "node scripts/check-runtime-readiness.mjs",
     "check:routes": "node scripts/check-route-boundaries.mjs",
     "check:imports": "node scripts/check-imports.mjs",
     "check:code-scanning": "node scripts/check-code-scanning-patterns.mjs",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -159,6 +159,16 @@ export interface AnalysisResponse {
   comparisonSummary?: string;
   analyzedAt: string; // ISO timestamp
   modelVersion: string;
+  analysisMode?: "fallback" | "model";
+  isFallback?: boolean;
+  fallbackReason?: string;
+  requestId?: string;
+}
+
+export interface PlantAnalysis extends AnalysisResponse {
+  id: string;
+  growId: string;
+  createdAt: string;
 }
 
 // GrowEvent

--- a/scripts/check-runtime-readiness.mjs
+++ b/scripts/check-runtime-readiness.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+function parseArgs(argv) {
+  const args = { url: process.env.READINESS_URL ?? process.env.APP_URL ?? "" };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === "--url") {
+      args.url = argv[i + 1] ?? "";
+      i += 1;
+    }
+  }
+
+  return args;
+}
+
+function resolveReadyUrl(input) {
+  if (!input) {
+    throw new Error(
+      "Missing deployment URL. Pass --url https://<deployment> or set READINESS_URL. Protected previews can use a full /api/ready URL that already includes bypass or share query parameters.",
+    );
+  }
+
+  const base = new URL(input);
+
+  if (base.pathname.endsWith("/api/ready")) {
+    return base.toString();
+  }
+
+  base.pathname = `${base.pathname.replace(/\/$/, "")}/api/ready`;
+  return base.toString();
+}
+
+function summarizeChecks(payload) {
+  if (!Array.isArray(payload?.checks)) {
+    return [];
+  }
+
+  return payload.checks.map((check) => ({
+    name: check?.name ?? "unknown",
+    ok: Boolean(check?.ok),
+    detail: check?.detail ?? "",
+  }));
+}
+
+async function main() {
+  const { url } = parseArgs(process.argv.slice(2));
+  const readyUrl = resolveReadyUrl(url);
+
+  const response = await fetch(readyUrl, {
+    headers: { accept: "application/json" },
+  });
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch {
+    payload = null;
+  }
+
+  const checks = summarizeChecks(payload);
+  const failedChecks = checks.filter((check) => !check.ok);
+
+  console.log(`Readiness URL: ${readyUrl}`);
+  console.log(`HTTP status: ${response.status}`);
+
+  if (payload?.status) {
+    console.log(`Service status: ${payload.status}`);
+  }
+
+  if (payload?.commit) {
+    console.log(`Commit: ${payload.commit}`);
+  }
+
+  if (checks.length > 0) {
+    console.log("Checks:");
+    for (const check of checks) {
+      const marker = check.ok ? "OK  " : "FAIL";
+      const suffix = check.detail ? ` (${check.detail})` : "";
+      console.log(`- ${marker} ${check.name}${suffix}`);
+    }
+  }
+
+  if (!response.ok || failedChecks.length > 0) {
+    const reason =
+      failedChecks.length > 0
+        ? `readiness checks failed: ${failedChecks
+            .map((check) => check.name)
+            .join(", ")}`
+        : `unexpected status ${response.status}`;
+
+    throw new Error(`Deployment is not ready: ${reason}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/supabase/migrations/003_production_optimizations.sql
+++ b/supabase/migrations/003_production_optimizations.sql
@@ -93,9 +93,10 @@ create trigger trg_grow_events_audit
 alter table plants
   add constraint unique_plant_name_per_grow unique(grow_id, name);
 
--- Prevent duplicate display names across profiles (partial: only when set).
-alter table profiles
-  add constraint unique_display_name unique(display_name) where display_name is not null;
+-- Prevent duplicate display names across profiles only when a name is set.
+create unique index if not exists idx_profiles_display_name_unique
+  on profiles(display_name)
+  where display_name is not null;
 
 -- ─── 5. Soft Delete Enforcement (RLS) ────────────────────────────────────────
 -- Archived grows and plants are excluded from default SELECT policies.

--- a/supabase/migrations/004_plant_analyses.sql
+++ b/supabase/migrations/004_plant_analyses.sql
@@ -1,0 +1,40 @@
+-- Migration: 004_plant_analyses
+-- Persist normalized analysis runs separately from findings so timeline/latest-analysis
+-- routes can return one stable record per image and clearly flag fallback output.
+
+create table if not exists plant_analyses (
+  id uuid primary key default gen_random_uuid(),
+  plant_id uuid not null references plants(id) on delete cascade,
+  grow_id uuid not null references grows(id) on delete cascade,
+  image_id uuid not null unique references plant_images(id) on delete cascade,
+  compared_to_image_id uuid references plant_images(id) on delete set null,
+  overall_health_score numeric(5, 1) not null,
+  summary text not null,
+  comparison_summary text,
+  analyzed_at timestamptz not null default now(),
+  model_version text not null,
+  analysis_mode text not null check (analysis_mode in ('model', 'fallback')),
+  is_fallback boolean not null default false,
+  fallback_reason text,
+  request_id text,
+  created_at timestamptz not null default now()
+);
+
+alter table plant_analyses enable row level security;
+
+create policy "plant_analyses: grow member read"
+  on plant_analyses for select
+  using (
+    exists (
+      select 1 from grows g
+      left join grow_members gm on gm.grow_id = g.id
+      where g.id = plant_analyses.grow_id
+        and (g.owner_id = auth.uid() or gm.user_id = auth.uid())
+    )
+  );
+
+create index if not exists idx_plant_analyses_plant_id_analyzed_at
+  on plant_analyses(plant_id, analyzed_at desc);
+
+create index if not exists idx_plant_analyses_image_id
+  on plant_analyses(image_id);


### PR DESCRIPTION
## Summary
- deliver the core web workspace refresh across app routing, dashboard/grows/plants/settings surfaces, assistant workspace UX, and supporting UI component primitives
- strengthen server-side and API flow wiring for auth, chat, plant timeline/analysis paths, and environment/runtime safeguards used by the workspace
- fix Vercel build reliability by handling Tailwind v3/v4 PostCSS plugin differences and adding `@tailwindcss/postcss` for compatibility on dependency-update branches

## Test plan
- [x] `pnpm --filter web build`
- [ ] `pnpm --filter web lint`
- [ ] `pnpm --filter web test`
- [ ] Verify Vercel preview for this branch reaches `READY`

Made with [Cursor](https://cursor.com)