### PR TITLE
fix(web): sanitize API route error responses and keep diagnostics in logs

### DIFF
--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,6 +4,20 @@ Handoff log between sessions. Keep entries short. Newest at top.
 
 ---
 
+## 2026-05-08 — API error-response hardening in route handlers (GPT-5.3-Codex)
+
+**Landed on `work`**
+
+- `fix(web)` — sanitized server-error JSON payloads in API route handlers so 500 responses return stable generic messages plus `requestId`, never raw exception text. Updated routes: `plants/[plantId]/analyze`, `plants/[plantId]/timeline`, `plants/[plantId]/analysis/latest`, `plants/[plantId]/images` (GET+POST), and `uploads/sign`.
+- `fix(web)` — preserved full diagnostics in logs only by emitting `errorMessage` and `errorStack` alongside existing route context (`plantId`, `imageId`, `requestId`).
+- `test(web)` — extended route tests to assert thrown raw error strings are not included in HTTP response bodies.
+
+1. What landed (with commit SHA): `000949b`
+2. What's in-flight (branch name + PR link if any): `work`, PR not opened yet.
+3. Dead ends: none.
+
+---
+
 ## 2026-05-08 — UX walkthrough: signed-out CTAs + auth copy + alert focus (Claude Opus 4.7)
 
 **Landed on `main`**

--- a/apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analysis/latest/__tests__/route.test.ts
@@ -57,4 +57,17 @@ describe("GET /api/plants/[plantId]/analysis/latest", () => {
     expect(body.plantId).toBe("plant-xyz");
     expect(body.analysis).toEqual({ score: 0.87 });
   });
+
+  it("does not leak thrown error details", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    getLatestPlantAnalysis.mockRejectedValue(
+      new Error("provider timeout raw details"),
+    );
+    const res = await GET(makeRequest(), makeParams("p1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to load latest analysis");
+    expect(JSON.stringify(body)).not.toContain("provider timeout raw details");
+    expect(body.requestId).toBeTypeOf("string");
+  });
 });

--- a/apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analysis/latest/route.ts
@@ -46,15 +46,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     logServerEvent("error", "latest plant analysis fetch failed", {
       requestId,
       plantId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      errorMessage: error instanceof Error ? error.message : "unknown_error",
+      errorStack: error instanceof Error ? error.stack : undefined,
     });
     return attachRequestId(
       NextResponse.json(
         {
-          error:
-            error instanceof Error
-              ? error.message
-              : "Failed to load latest analysis",
+          error: "Failed to load latest analysis",
           requestId,
         },
         { status: 500 },

--- a/apps/web/src/app/api/plants/[plantId]/analyze/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/analyze/route.ts
@@ -80,13 +80,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       requestId,
       plantId,
       imageId: body.imageId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      errorMessage: error instanceof Error ? error.message : "unknown_error",
+      errorStack: error instanceof Error ? error.stack : undefined,
     });
     return attachRequestId(
       NextResponse.json(
         {
-          error:
-            error instanceof Error ? error.message : "Plant analysis failed",
+          error: "Plant analysis failed",
           requestId,
         },
         { status: 500 },

--- a/apps/web/src/app/api/plants/[plantId]/images/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/images/route.ts
@@ -45,15 +45,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     logServerEvent("error", "plant image listing failed", {
       requestId,
       plantId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      errorMessage: error instanceof Error ? error.message : "unknown_error",
+      errorStack: error instanceof Error ? error.stack : undefined,
     });
     return attachRequestId(
       NextResponse.json(
         {
-          error:
-            error instanceof Error
-              ? error.message
-              : "Failed to load plant images",
+          error: "Failed to load plant images",
           requestId,
         },
         { status: 500 },
@@ -139,13 +137,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     logServerEvent("error", "plant image finalize failed", {
       requestId,
       plantId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      errorMessage: error instanceof Error ? error.message : "unknown_error",
+      errorStack: error instanceof Error ? error.stack : undefined,
     });
     return attachRequestId(
       NextResponse.json(
         {
-          error:
-            error instanceof Error ? error.message : "Image persistence failed",
+          error: "Image persistence failed",
           requestId,
         },
         { status: 500 },

--- a/apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/timeline/__tests__/route.test.ts
@@ -46,4 +46,17 @@ describe("GET /api/plants/[plantId]/timeline", () => {
     expect(Array.isArray(body.items)).toBe(true);
     expect(getPlantTimeline).toHaveBeenCalledWith("plant-xyz");
   });
+
+  it("does not expose thrown error details", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    getPlantTimeline.mockRejectedValue(
+      new Error("database exploded raw message"),
+    );
+    const res = await GET(makeRequest(), makeParams("p1"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Failed to load timeline");
+    expect(JSON.stringify(body)).not.toContain("database exploded raw message");
+    expect(body.requestId).toBeTypeOf("string");
+  });
 });

--- a/apps/web/src/app/api/plants/[plantId]/timeline/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/timeline/route.ts
@@ -45,13 +45,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     logServerEvent("error", "plant timeline fetch failed", {
       requestId,
       plantId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      errorMessage: error instanceof Error ? error.message : "unknown_error",
+      errorStack: error instanceof Error ? error.stack : undefined,
     });
     return attachRequestId(
       NextResponse.json(
         {
-          error:
-            error instanceof Error ? error.message : "Failed to load timeline",
+          error: "Failed to load timeline",
           requestId,
         },
         { status: 500 },

--- a/apps/web/src/app/api/uploads/sign/__tests__/route.test.ts
+++ b/apps/web/src/app/api/uploads/sign/__tests__/route.test.ts
@@ -133,4 +133,23 @@ describe("POST /api/uploads/sign", () => {
     );
     expect(res.status).toBe(404);
   });
+
+  it("does not return thrown error details to clients", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    preparePlantImageUpload.mockRejectedValue(
+      new Error("supabase secret failure"),
+    );
+    const res = await POST(
+      jsonRequest({
+        plantId: "p1",
+        fileName: "shot.png",
+        contentType: "image/png",
+      }),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Upload signing failed");
+    expect(JSON.stringify(body)).not.toContain("supabase secret failure");
+    expect(body.requestId).toBeTypeOf("string");
+  });
 });

--- a/apps/web/src/app/api/uploads/sign/route.ts
+++ b/apps/web/src/app/api/uploads/sign/route.ts
@@ -98,13 +98,13 @@ export async function POST(request: NextRequest) {
     logServerEvent("error", "upload signing failed", {
       requestId,
       plantId: body.plantId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      errorMessage: error instanceof Error ? error.message : "unknown_error",
+      errorStack: error instanceof Error ? error.stack : undefined,
     });
     return attachRequestId(
       NextResponse.json(
         {
-          error:
-            error instanceof Error ? error.message : "Upload signing failed",
+          error: "Upload signing failed",
           requestId,
         },
         { status: 500 },


### PR DESCRIPTION
### Motivation
- Prevent leaking raw exception text to clients by returning stable, generic `error` messages plus a `requestId` on 500 responses from route handlers. 
- Preserve full debugging detail in server-side logs only so operators can triage with `requestId` without exposing secrets or internal stack traces to users. 
- Add tests to assert thrown error strings are not returned in HTTP JSON bodies.

### Description
- Replaced client-facing `error` payloads that echoed `error.message` with fixed messages and `requestId` in the following route handlers: `apps/web/src/app/api/plants/[plantId]/analyze/route.ts`, `plants/[plantId]/timeline/route.ts`, `plants/[plantId]/analysis/latest/route.ts`, `plants/[plantId]/images/route.ts` (GET + POST), and `apps/web/src/app/api/uploads/sign/route.ts`.
- Kept full diagnostics in `logServerEvent` by emitting structured fields `errorMessage` and `errorStack` (when available) alongside existing context (`requestId`, `plantId`, `imageId`).
- Extended route test suites to assert thrown/raw error text is not present in responses and that `requestId` is present on 500 responses by adding checks to `timeline/__tests__/route.test.ts`, `analysis/latest/__tests__/route.test.ts`, and `uploads/sign/__tests__/route.test.ts`.
- Note on sensitive paths: this PR touches `apps/web/src/app/api/**/route.ts` files but does not change authentication boundary, public API contract, security headers, or environment handling; the edits only harden error disclosure behavior so a separate contract-guardian review was not required.

### Testing
- Ran platform validation with `pnpm run validate` and `pnpm run security:routes`, both succeeded. 
- Ran the full web suite with `pnpm turbo run type-check lint test`, and all tests passed (web tests: 18 files, 107 tests; shared tests passed). 
- Verified the new/modified route tests (timeline, analysis/latest, uploads/sign) assert that raw thrown messages are not returned and that `requestId` is present; these tests passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2cce9da8832cb7e4105f990c6c7a)