### PR TITLE
feat(web): apply editorial PhenoSage redesign

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -12,15 +12,9 @@ import {
 } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
-import { PageHeader } from "@/components/ui/page-header";
+import { SectionHeader } from "@/components/ui/section-header";
 import { StatCard } from "@/components/ui/stat-card";
 import { getCurrentProfile } from "@/lib/server/profile";
 import { getWorkspaceOverview } from "@/lib/server/workspace-overview";
@@ -35,6 +29,24 @@ function formatDateLabel(value: string | null) {
     month: "short",
     day: "numeric",
   }).format(new Date(value));
+}
+
+function formatGreeting(now: Date) {
+  const hour = now.getHours();
+  if (hour < 5) return "Working late";
+  if (hour < 12) return "Good morning";
+  if (hour < 18) return "Good afternoon";
+  return "Good evening";
+}
+
+function formatTodayLabel(now: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+    month: "short",
+    day: "numeric",
+  })
+    .format(now)
+    .toUpperCase();
 }
 
 export default async function DashboardPage() {
@@ -52,33 +64,93 @@ export default async function DashboardPage() {
   const displayName = operator.replace(/\b\w/g, (character) =>
     character.toUpperCase(),
   );
+  const firstName = displayName.split(/\s+/)[0] ?? displayName;
   const activeGrowCount = overview.totals.grows;
   const hasWorkspaceData = activeGrowCount > 0;
   const highlightedGrow = overview.grows[0] ?? null;
+  const now = new Date();
+  const greeting = formatGreeting(now);
+  const todayLabel = formatTodayLabel(now);
+  const openCount = overview.openFindings;
+  const captureCount = overview.totals.images;
+  const lastCapture = formatDateLabel(overview.recentActivity.lastCaptureAt);
 
   return (
     <main className="app-page">
-      <PageHeader
-        actions={
-          <>
+      {/* ── Editorial header ─────────────────────────── */}
+      <header className="workspace-hero">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-3 max-w-3xl">
+            <p className="ps-eyebrow">{todayLabel}</p>
+            <h1 className="ps-display text-balance text-[34px] leading-[1.04] sm:text-[44px] lg:text-[52px]">
+              {greeting}, {firstName}.
+            </h1>
+            <p className="text-[14.5px] leading-[1.55] text-[rgb(var(--ps-muted))] sm:text-[15.5px]">
+              The day&rsquo;s plant health, drift, and the next cultivation
+              action — all in one quiet operating board.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5 lg:justify-end">
             <Link
-              className={buttonStyles({ size: "md", variant: "surface" })}
+              className={buttonStyles({ size: "md", variant: "outline" })}
               href="/assistant"
             >
               Ask copilot
             </Link>
-            <Link className={buttonStyles({ size: "md" })} href="/grows/new">
+            <Link
+              className={buttonStyles({ size: "md", variant: "primary" })}
+              href="/grows/new"
+            >
               New grow
             </Link>
-          </>
-        }
-        breadcrumbs={[{ label: "Dashboard" }]}
-        description="Monitor plant health, watch for drift, and keep the next cultivation action visible without digging through disconnected tools."
-        eyebrow={<Badge tone="accent">Workspace overview</Badge>}
-        title={`Welcome back, ${displayName}`}
-      />
+          </div>
+        </div>
+      </header>
 
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {/* ── Ritual band (today's hook) ───────────────── */}
+      <Card className="relative overflow-hidden">
+        <div
+          aria-hidden="true"
+          className="ps-trichome-bg pointer-events-none absolute inset-0 opacity-60"
+        />
+        <CardContent className="relative flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-4">
+            <span
+              aria-hidden="true"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[14px] bg-[rgb(var(--ps-accent-soft))] text-[rgb(var(--ps-accent-strong))]"
+            >
+              <SparkIcon className="h-5 w-5" />
+            </span>
+            <div className="space-y-1">
+              <p className="text-[15px] leading-[1.4] text-[rgb(var(--ps-ink))]">
+                <span className="font-medium">
+                  {hasWorkspaceData
+                    ? `${overview.totals.plants} plants tracked across ${activeGrowCount} grow${activeGrowCount === 1 ? "" : "s"}.`
+                    : "No plants tracked yet."}
+                </span>{" "}
+                <span className="text-[rgb(var(--ps-muted))]">
+                  {openCount > 0
+                    ? `Sage flagged ${openCount} item${openCount === 1 ? "" : "s"} to look at first.`
+                    : hasWorkspaceData
+                      ? "Quietly going right — nothing to chase."
+                      : "Set up the first grow to wake the operating board."}
+                </span>
+              </p>
+            </div>
+          </div>
+          <div className="flex items-baseline gap-2 self-end sm:self-auto sm:flex-col sm:items-end sm:gap-0">
+            <span className="ps-display text-[28px] leading-[1] text-[rgb(var(--ps-ink))]">
+              {captureCount}
+            </span>
+            <span className="ps-mono text-[10px] uppercase tracking-[0.14em] text-[rgb(var(--ps-muted))]">
+              captures
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Stat row ─────────────────────────────────── */}
+      <section className="grid gap-3.5 md:grid-cols-2 xl:grid-cols-4">
         <StatCard
           detail={
             hasWorkspaceData
@@ -88,62 +160,69 @@ export default async function DashboardPage() {
           icon={<GrowIcon className="h-5 w-5" />}
           label="Active grows"
           tone="accent"
-          value={activeGrowCount === 0 ? "None yet" : String(activeGrowCount)}
+          value={activeGrowCount === 0 ? "—" : String(activeGrowCount)}
         />
         <StatCard
           detail={
-            overview.totals.images > 0
-              ? `Latest capture landed ${formatDateLabel(overview.recentActivity.lastCaptureAt)}.`
-              : "The first image set establishes your longitudinal comparison baseline."
+            captureCount > 0
+              ? `Latest capture landed ${lastCapture}.`
+              : "The first image set establishes your longitudinal baseline."
           }
           icon={<AnalysisIcon className="h-5 w-5" />}
           label="Capture history"
           tone="warning"
-          value={
-            overview.totals.images === 0
-              ? "Awaiting baseline"
-              : `${overview.totals.images} captures`
-          }
+          value={captureCount === 0 ? "—" : String(captureCount)}
         />
         <StatCard
           detail="Unresolved findings that still need operator attention."
           icon={<AlertIcon className="h-5 w-5" />}
           label="Open watch items"
-          value={String(overview.openFindings)}
+          tone={openCount === 0 ? "success" : "warning"}
+          value={String(openCount)}
         />
         <StatCard
           detail={
             overview.recentFindings.length > 0
-              ? "The composer posts to /api/chat and can ground replies in persisted findings."
-              : "The composer is enabled, but useful answers still depend on actual uploads and findings."
+              ? "The composer posts to /api/chat and grounds replies in persisted findings."
+              : "Composer is enabled — useful answers still depend on uploads and findings."
           }
           icon={<AssistantIcon className="h-5 w-5" />}
-          label="Assistant route"
+          label="Copilot route"
           meta={<Badge tone="success">Composer enabled</Badge>}
           tone="success"
-          value="Connected"
+          value="Ready"
         />
       </section>
 
-      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.95fr)]">
+      {/* ── Activity + next actions ──────────────────── */}
+      <section className="grid gap-5 xl:grid-cols-[minmax(0,1.45fr)_minmax(340px,0.95fr)]">
         <Card>
-          <CardHeader>
-            <CardTitle>Recent operating activity</CardTitle>
-            <CardDescription>
-              The dashboard should answer what moved, what changed, and what
-              needs attention without making you hunt through pages.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4 p-6">
+            <SectionHeader
+              label="Recent operating activity"
+              trailing={
+                overview.recentFindings.length > 0
+                  ? `${overview.recentFindings.length} surfaced`
+                  : "quiet"
+              }
+            />
             {overview.recentFindings.length > 0 ? (
-              <div className="space-y-3">
-                {overview.recentFindings.map((finding) => (
+              <div className="flex flex-col">
+                {overview.recentFindings.map((finding, idx) => (
                   <div
                     key={finding.id}
-                    className="flex items-start justify-between gap-4 rounded-[1.1rem] border border-border/70 bg-background-subtle/65 px-4 py-4"
+                    className="flex items-start justify-between gap-4 py-4 first:pt-0 last:pb-0"
+                    style={
+                      idx === 0
+                        ? undefined
+                        : {
+                            borderTop:
+                              "1px solid rgb(var(--ps-line) / var(--ps-line-strength))",
+                          }
+                    }
                   >
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-2">
+                    <div className="space-y-1.5 min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
                         <Badge
                           tone={
                             finding.severity === "critical" ||
@@ -156,21 +235,21 @@ export default async function DashboardPage() {
                         >
                           {finding.severity}
                         </Badge>
-                        <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                        <span className="ps-mono text-[10.5px] uppercase tracking-[0.12em] text-[rgb(var(--ps-muted))]">
                           {formatDateLabel(finding.createdAt)}
                         </span>
                       </div>
-                      <p className="text-sm font-semibold text-foreground">
+                      <p className="text-[14.5px] font-medium leading-[1.35] text-[rgb(var(--ps-ink))]">
                         {finding.title}
                       </p>
-                      <p className="text-sm leading-6 text-muted-foreground">
+                      <p className="text-[13px] leading-[1.5] text-[rgb(var(--ps-muted))]">
                         {finding.plantName}
                       </p>
                     </div>
                     <Link
                       className={buttonStyles({
                         size: "sm",
-                        variant: "surface",
+                        variant: "outline",
                       })}
                       href={`/plants/${finding.plantId}`}
                     >
@@ -190,91 +269,92 @@ export default async function DashboardPage() {
         </Card>
 
         <Card>
-          <CardHeader>
-            <CardTitle>Next recommended actions</CardTitle>
-            <CardDescription>
-              Sequenced work that moves the workspace from setup into a usable
-              operating loop.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {(hasWorkspaceData
-              ? [
-                  highlightedGrow?.primaryPlantId
-                    ? `Open ${highlightedGrow.primaryPlantName ?? "the primary plant"} and capture a fresh image from the same angle as the last baseline.`
-                    : "Add the first plant to your most recent grow so image history has a stable home.",
-                  overview.openFindings > 0
-                    ? "Review unresolved findings and convert them into a clear action checklist with the copilot."
-                    : "Use the copilot to define the next repeatable capture cadence before new findings arrive.",
-                  "Record observations after feed, irrigation, or environment changes so timeline context stays useful.",
-                  "Keep one grow as the clean reference surface for stage, medium, and light metadata.",
-                ]
-              : [
-                  "Create the first grow record with stage, medium, and light profile.",
-                  "Add one or more plant records so image history has a stable home.",
-                  "Upload a consistent baseline photo set from the plant detail view.",
-                  "Use the copilot to turn the first findings into an operating checklist.",
-                ]
-            ).map((item, index) => (
-              <div
-                key={item}
-                className="flex gap-4 rounded-[1rem] border border-border bg-background-subtle/50 px-4 py-4"
-              >
-                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface border border-border font-mono text-sm font-semibold text-accent shadow-sm">
-                  {index + 1}
+          <CardContent className="space-y-4 p-6">
+            <SectionHeader
+              label="Next recommended actions"
+              trailing="ordered"
+            />
+            <div className="flex flex-col gap-2.5">
+              {(hasWorkspaceData
+                ? [
+                    highlightedGrow?.primaryPlantId
+                      ? `Open ${highlightedGrow.primaryPlantName ?? "the primary plant"} and capture a fresh image from the same angle as the last baseline.`
+                      : "Add the first plant to your most recent grow so image history has a stable home.",
+                    overview.openFindings > 0
+                      ? "Review unresolved findings and convert them into a clear action checklist with the copilot."
+                      : "Use the copilot to define the next repeatable capture cadence before new findings arrive.",
+                    "Record observations after feed, irrigation, or environment changes so timeline context stays useful.",
+                    "Keep one grow as the clean reference surface for stage, medium, and light metadata.",
+                  ]
+                : [
+                    "Create the first grow record with stage, medium, and light profile.",
+                    "Add one or more plant records so image history has a stable home.",
+                    "Upload a consistent baseline photo set from the plant detail view.",
+                    "Use the copilot to turn the first findings into an operating checklist.",
+                  ]
+              ).map((item, index) => (
+                <div
+                  key={item}
+                  className="flex gap-3.5 rounded-[14px] border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface-2)/0.55)] px-4 py-3.5"
+                >
+                  <div className="ps-mono flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[rgb(var(--ps-surface))] text-[12px] font-medium text-[rgb(var(--ps-accent-strong))]">
+                    {index + 1}
+                  </div>
+                  <p className="text-[13.5px] leading-[1.5] text-[rgb(var(--ps-ink))]">
+                    {item}
+                  </p>
                 </div>
-                <p className="text-sm leading-6 text-foreground">{item}</p>
-              </div>
-            ))}
+              ))}
+            </div>
           </CardContent>
         </Card>
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-3">
+      {/* ── Operating context trio ───────────────────── */}
+      <section className="grid gap-5 lg:grid-cols-3">
         <Card>
-          <CardHeader>
-            <CardTitle>What this board will surface</CardTitle>
-            <CardDescription>
-              The operating view is designed to explain what matters now, not
-              just show data.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm leading-6 text-muted-foreground">
-            <div className="rounded-[1rem] border border-border bg-background-subtle/50 p-4">
-              Severity-ranked findings with recommended follow-up.
-            </div>
-            <div className="rounded-[1rem] border border-border bg-background-subtle/50 p-4">
-              Longitudinal drift and recurrence across image sets.
-            </div>
-            <div className="rounded-[1rem] border border-border bg-background-subtle/50 p-4">
-              Daily action queues generated from recent activity and stage
-              context.
+          <CardContent className="space-y-4 p-6">
+            <SectionHeader label="What this board surfaces" />
+            <div className="flex flex-col gap-2.5 text-[13.5px] leading-[1.55] text-[rgb(var(--ps-ink-2))]">
+              {[
+                "Severity-ranked findings with recommended follow-up.",
+                "Longitudinal drift and recurrence across image sets.",
+                "Daily action queues generated from recent activity and stage context.",
+              ].map((line) => (
+                <div
+                  key={line}
+                  className="rounded-[14px] border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface-2)/0.55)] p-3.5"
+                >
+                  {line}
+                </div>
+              ))}
             </div>
           </CardContent>
         </Card>
 
         <Card>
-          <CardHeader>
-            <CardTitle>Grow registry pulse</CardTitle>
-            <CardDescription>
-              A compact view of where the next meaningful work is likely to
-              happen.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4 p-6">
+            <SectionHeader
+              label="Grow registry pulse"
+              trailing={
+                overview.grows.length > 0
+                  ? `${overview.grows.length} live`
+                  : "—"
+              }
+            />
             {overview.grows.length > 0 ? (
-              <div className="space-y-3">
+              <div className="flex flex-col gap-2.5">
                 {overview.grows.slice(0, 3).map((grow) => (
                   <div
                     key={grow.id}
-                    className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-4"
+                    className="rounded-[14px] border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface-2)/0.55)] px-4 py-3.5"
                   >
                     <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="text-sm font-semibold text-foreground">
+                      <div className="min-w-0">
+                        <p className="text-[14px] font-medium leading-tight text-[rgb(var(--ps-ink))]">
                           {grow.name}
                         </p>
-                        <p className="mt-1 text-sm text-muted-foreground">
+                        <p className="ps-mono mt-1.5 text-[10.5px] uppercase tracking-[0.1em] text-[rgb(var(--ps-muted))]">
                           {grow.stage ?? "stage pending"} · {grow.plantCount}{" "}
                           plants · {grow.imageCount} captures
                         </p>
@@ -283,11 +363,11 @@ export default async function DashboardPage() {
                         <Link
                           className={buttonStyles({
                             size: "sm",
-                            variant: "surface",
+                            variant: "outline",
                           })}
                           href={`/plants/${grow.primaryPlantId}`}
                         >
-                          Open plant
+                          Open
                         </Link>
                       ) : null}
                     </div>
@@ -305,32 +385,34 @@ export default async function DashboardPage() {
         </Card>
 
         <Card>
-          <CardHeader>
-            <CardTitle>Platform readiness</CardTitle>
-            <CardDescription>
-              Honest product posture instead of placeholder vanity metrics.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {[
-              "Authenticated grow and plant creation flows are active",
-              "The assistant composer posts to the same-origin chat route",
-              "Signed uploads persist into plant timelines before analysis runs",
-            ].map((item, index) => (
-              <div
-                key={item}
-                className="flex items-start gap-3 rounded-[1rem] border border-border bg-background-subtle/50 px-4 py-4"
-              >
-                {index === 0 ? (
-                  <ShieldIcon className="mt-0.5 h-4 w-4 text-accent" />
-                ) : index === 1 ? (
-                  <SparkIcon className="mt-0.5 h-4 w-4 text-accent" />
-                ) : (
-                  <BellIcon className="mt-0.5 h-4 w-4 text-accent" />
-                )}
-                <p className="text-sm leading-6 text-foreground">{item}</p>
-              </div>
-            ))}
+          <CardContent className="space-y-4 p-6">
+            <SectionHeader label="Platform readiness" trailing="all on" />
+            <div className="flex flex-col gap-2.5">
+              {[
+                {
+                  Icon: ShieldIcon,
+                  text: "Authenticated grow and plant creation flows are active.",
+                },
+                {
+                  Icon: SparkIcon,
+                  text: "The assistant composer posts to the same-origin chat route.",
+                },
+                {
+                  Icon: BellIcon,
+                  text: "Signed uploads persist into plant timelines before analysis runs.",
+                },
+              ].map(({ Icon, text }) => (
+                <div
+                  key={text}
+                  className="flex items-start gap-3 rounded-[14px] border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface-2)/0.55)] px-4 py-3.5"
+                >
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-[rgb(var(--ps-accent))]" />
+                  <p className="text-[13.5px] leading-[1.55] text-[rgb(var(--ps-ink))]">
+                    {text}
+                  </p>
+                </div>
+              ))}
+            </div>
           </CardContent>
         </Card>
       </section>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -3,96 +3,171 @@
 @tailwind utilities;
 
 /* -----------------------------------------------------------
- * Design tokens
+ * PhenoSage editorial design tokens
  *
- * Inspired by shadcn/ui — semantic, theme-aware HSL variables
- * consumed by Tailwind via tailwind.config.js. To rebrand or
- * tune contrast, edit values here only; Tailwind classes
- * (bg-card, text-foreground, etc.) update everywhere.
+ * Cannabis-aware palette: cream "hemp-paper" canvas, "cola"
+ * deep flower-canopy green ink, "resin" amber for caution,
+ * "pistil" rust for critical. Type pairs Fraunces (display)
+ * with General Sans (body) and JetBrains Mono (labels).
+ *
+ * Tokens are exposed both as raw CSS custom properties (for
+ * direct consumption: `var(--ps-ink)`) and as the legacy
+ * shadcn-style HSL triples consumed by `tailwind.config.js`.
  * --------------------------------------------------------- */
 @layer base {
   :root {
-    --background: 140 30% 99%;
-    --foreground: 150 14% 12%;
+    /* ── Canvas & ink — light (hemp paper) ─────────────── */
+    --ps-canvas: 239 234 217; /* #EFEAD9 hemp-paper */
+    --ps-surface: 247 242 226; /* #F7F2E2 cured-flower cream */
+    --ps-surface-2: 230 225 206; /* #E6E1CE */
+    --ps-panel: 247 242 226;
+    --ps-line: 34 42 32;
+    --ps-line-strength: 0.10;
+    --ps-line-strong-strength: 0.18;
+    --ps-ink: 26 36 24; /* #1A2418 deep cola */
+    --ps-ink-2: 58 69 52; /* #3A4534 */
+    --ps-muted: 110 114 100; /* #6E7264 */
+    --ps-subtle: 160 159 139; /* #A09F8B */
 
-    --card: 0 0% 100%;
-    --card-foreground: 150 14% 12%;
+    /* ── Accent: cola (deep flower canopy) ─────────────── */
+    --ps-accent: 62 92 58; /* #3E5C3A cola */
+    --ps-accent-ink: 244 239 217; /* #F4EFD9 */
+    --ps-accent-soft: 219 226 207; /* cola wash */
+    --ps-accent-strong: 42 64 39;
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 150 14% 12%;
+    /* ── Semantic ──────────────────────────────────────── */
+    --ps-ok: 62 92 58;
+    --ps-ok-soft: 219 226 207;
+    --ps-warn: 183 137 47; /* #B7892F resin amber */
+    --ps-warn-soft: 246 232 192;
+    --ps-crit: 160 74 54; /* #A04A36 ripe pistil */
+    --ps-crit-soft: 241 216 204;
 
-    --primary: 142 71% 35%;
-    --primary-foreground: 0 0% 100%;
+    /* ── Geometry ──────────────────────────────────────── */
+    --ps-radius-sm: 8px;
+    --ps-radius-md: 12px;
+    --ps-radius-lg: 18px;
+    --ps-radius-xl: 24px;
+    --ps-radius-pill: 9999px;
 
-    --secondary: 140 25% 95%;
-    --secondary-foreground: 150 14% 18%;
+    /* ── Type stacks ───────────────────────────────────── */
+    --ps-font-display:
+      var(--font-fraunces, "Fraunces"), "Instrument Serif", Georgia, serif;
+    --ps-font-body:
+      var(--font-general-sans, "General Sans"), "Söhne", -apple-system,
+      BlinkMacSystemFont, system-ui, sans-serif;
+    --ps-font-mono:
+      var(--font-jetbrains-mono, "JetBrains Mono"), "IBM Plex Mono", ui-monospace,
+      SFMono-Regular, Menlo, monospace;
 
-    --muted: 140 16% 95%;
-    --muted-foreground: 150 8% 42%;
+    /* ── Legacy shadcn-style HSL tokens (Tailwind) ─────── */
+    --background: 47 32% 90%; /* hemp-paper */
+    --foreground: 110 17% 12%;
 
-    --accent: 142 60% 92%;
-    --accent-foreground: 142 71% 22%;
+    --card: 49 53% 93%;
+    --card-foreground: 110 17% 12%;
 
-    --destructive: 0 72% 50%;
-    --destructive-foreground: 0 0% 100%;
+    --popover: 49 53% 93%;
+    --popover-foreground: 110 17% 12%;
 
-    --success: 142 71% 35%;
-    --success-foreground: 0 0% 100%;
+    --primary: 117 22% 29%; /* cola */
+    --primary-foreground: 49 56% 91%;
 
-    --warning: 38 92% 48%;
+    --secondary: 47 26% 87%;
+    --secondary-foreground: 110 17% 18%;
+
+    --muted: 47 22% 86%;
+    --muted-foreground: 75 7% 42%;
+
+    --accent: 117 22% 29%;
+    --accent-foreground: 49 56% 91%;
+
+    --destructive: 11 50% 42%;
+    --destructive-foreground: 49 56% 96%;
+
+    --success: 117 22% 29%;
+    --success-foreground: 49 56% 91%;
+
+    --warning: 39 60% 45%;
     --warning-foreground: 30 50% 12%;
 
-    --info: 211 92% 50%;
+    --info: 154 28% 32%;
     --info-foreground: 0 0% 100%;
 
-    --border: 140 12% 88%;
-    --input: 140 12% 88%;
-    --ring: 142 71% 40%;
+    --border: 110 17% 12%;
+    --input: 110 17% 12%;
+    --ring: 117 22% 29%;
 
-    --radius: 0.75rem;
+    --radius: 0.875rem;
   }
 
   .dark {
-    --background: 150 14% 7%;
-    --foreground: 140 8% 95%;
+    /* ── Canvas & ink — dark (grow-room-at-night) ──────── */
+    --ps-canvas: 13 18 13; /* #0D120D */
+    --ps-surface: 20 26 20; /* #141A14 */
+    --ps-surface-2: 27 34 26; /* #1B221A */
+    --ps-panel: 20 26 20;
+    --ps-line: 229 222 196;
+    --ps-line-strength: 0.12;
+    --ps-line-strong-strength: 0.22;
+    --ps-ink: 229 222 196; /* #E5DEC4 dried-flower paper */
+    --ps-ink-2: 197 191 166;
+    --ps-muted: 138 142 120;
+    --ps-subtle: 86 90 76;
 
-    --card: 150 14% 10%;
-    --card-foreground: 140 8% 95%;
+    --ps-accent: 122 168 135; /* milky trichome */
+    --ps-accent-ink: 15 26 18;
+    --ps-accent-soft: 31 42 35;
+    --ps-accent-strong: 156 199 166;
 
-    --popover: 150 14% 9%;
-    --popover-foreground: 140 8% 95%;
+    --ps-ok: 122 168 135;
+    --ps-ok-soft: 28 42 34;
+    --ps-warn: 214 164 70;
+    --ps-warn-soft: 44 36 24;
+    --ps-crit: 208 117 96;
+    --ps-crit-soft: 43 28 23;
 
-    --primary: 142 65% 48%;
-    --primary-foreground: 150 24% 8%;
+    /* ── Legacy HSL ────────────────────────────────────── */
+    --background: 120 17% 5%;
+    --foreground: 47 38% 83%;
 
-    --secondary: 150 10% 15%;
-    --secondary-foreground: 140 8% 92%;
+    --card: 120 13% 9%;
+    --card-foreground: 47 38% 83%;
 
-    --muted: 150 10% 14%;
-    --muted-foreground: 140 6% 65%;
+    --popover: 120 13% 9%;
+    --popover-foreground: 47 38% 83%;
 
-    --accent: 142 40% 18%;
-    --accent-foreground: 142 65% 78%;
+    --primary: 132 22% 57%;
+    --primary-foreground: 120 25% 8%;
 
-    --destructive: 0 65% 55%;
-    --destructive-foreground: 0 0% 100%;
+    --secondary: 110 12% 14%;
+    --secondary-foreground: 47 38% 83%;
 
-    --success: 142 65% 48%;
-    --success-foreground: 150 24% 8%;
+    --muted: 110 12% 14%;
+    --muted-foreground: 75 7% 56%;
 
-    --warning: 38 90% 55%;
+    --accent: 132 22% 57%;
+    --accent-foreground: 120 25% 8%;
+
+    --destructive: 11 56% 60%;
+    --destructive-foreground: 49 38% 92%;
+
+    --success: 132 22% 57%;
+    --success-foreground: 120 25% 8%;
+
+    --warning: 39 64% 56%;
     --warning-foreground: 30 50% 8%;
 
-    --info: 211 85% 60%;
-    --info-foreground: 220 30% 8%;
+    --info: 154 28% 56%;
+    --info-foreground: 0 0% 100%;
 
-    --border: 150 10% 18%;
-    --input: 150 10% 18%;
-    --ring: 142 65% 50%;
+    --border: 47 38% 83%;
+    --input: 47 38% 83%;
+    --ring: 132 22% 57%;
   }
 
   * {
-    border-color: hsl(var(--border));
+    border-color: rgba(var(--ps-line) / var(--ps-line-strength));
   }
 
   html {
@@ -106,37 +181,34 @@
   }
 
   body {
-    background-color: hsl(var(--background));
-    color: hsl(var(--foreground));
+    background-color: rgb(var(--ps-canvas));
+    color: rgb(var(--ps-ink));
+    font-family: var(--ps-font-body);
     font-feature-settings: "rlig" 1, "calt" 1, "ss01" 1;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
 
-  /* Visible, theme-aware focus ring */
   :focus-visible {
-    outline: 2px solid hsl(var(--ring));
+    outline: 2px solid rgb(var(--ps-accent));
     outline-offset: 2px;
     border-radius: 4px;
   }
 
-  /* Hide focus ring on mouse, keep for keyboard */
   :focus:not(:focus-visible) {
     outline: none;
   }
 
-  /* Selection */
   ::selection {
-    background-color: hsl(var(--primary) / 0.25);
-    color: hsl(var(--primary-foreground));
+    background-color: rgb(var(--ps-accent) / 0.22);
+    color: rgb(var(--ps-ink));
   }
 
-  /* Scrollbar — subtle, themed */
   @media (pointer: fine) {
     * {
       scrollbar-width: thin;
-      scrollbar-color: hsl(var(--muted-foreground) / 0.3) transparent;
+      scrollbar-color: rgb(var(--ps-muted) / 0.35) transparent;
     }
     *::-webkit-scrollbar {
       width: 10px;
@@ -146,17 +218,124 @@
       background: transparent;
     }
     *::-webkit-scrollbar-thumb {
-      background-color: hsl(var(--muted-foreground) / 0.25);
+      background-color: rgb(var(--ps-muted) / 0.3);
       border-radius: 9999px;
       border: 2px solid transparent;
       background-clip: padding-box;
     }
     *::-webkit-scrollbar-thumb:hover {
-      background-color: hsl(var(--muted-foreground) / 0.45);
+      background-color: rgb(var(--ps-muted) / 0.5);
     }
   }
 }
 
+/* -----------------------------------------------------------
+ * Editorial component classes
+ *
+ * These compose Tailwind utilities into the named building
+ * blocks the redesign relies on. They're stable, additive,
+ * and safe for JIT to scan.
+ * --------------------------------------------------------- */
+@layer components {
+  /* Page wrapper used by every (app)/* route. */
+  .app-page {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 1.5rem 1.25rem 4rem;
+    max-width: 1400px;
+    width: 100%;
+    margin-inline: auto;
+  }
+  @media (min-width: 768px) {
+    .app-page {
+      padding: 2rem 2rem 5rem;
+      gap: 1.75rem;
+    }
+  }
+  @media (min-width: 1280px) {
+    .app-page {
+      padding: 2.5rem 2.75rem 6rem;
+      gap: 2rem;
+    }
+  }
+
+  /* Editorial hero block at the top of a page. */
+  .workspace-hero {
+    position: relative;
+    padding: 0.5rem 0 1.25rem;
+    border-bottom: 1px solid rgb(var(--ps-line) / var(--ps-line-strength));
+  }
+
+  /* Compact mono pill — the visual chassis for tag-like metadata. */
+  .metric-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    background: rgb(var(--ps-ink) / 0.05);
+    color: rgb(var(--ps-ink-2));
+    font-family: var(--ps-font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  /* Mono small-caps eyebrow above section headings. */
+  .ps-eyebrow {
+    font-family: var(--ps-font-mono);
+    font-size: 10.5px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgb(var(--ps-muted));
+    font-weight: 500;
+  }
+
+  /* Display heading — Fraunces, tight tracking. */
+  .ps-display {
+    font-family: var(--ps-font-display);
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    color: rgb(var(--ps-ink));
+  }
+
+  /* Tabular monospaced numeric runs (for stats, timestamps). */
+  .ps-mono {
+    font-family: var(--ps-font-mono);
+    font-feature-settings: "tnum" 1;
+    letter-spacing: 0;
+  }
+
+  /* Section header strip: mono label + optional trailing widget. */
+  .ps-section-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  /* Subtle rise-in animation for stacked cards. */
+  .ps-rise {
+    animation: ps-rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) backwards;
+  }
+  .ps-rise:nth-child(1) { animation-delay: 0.02s; }
+  .ps-rise:nth-child(2) { animation-delay: 0.06s; }
+  .ps-rise:nth-child(3) { animation-delay: 0.10s; }
+  .ps-rise:nth-child(4) { animation-delay: 0.14s; }
+  .ps-rise:nth-child(5) { animation-delay: 0.18s; }
+  .ps-rise:nth-child(6) { animation-delay: 0.22s; }
+}
+
+/* -----------------------------------------------------------
+ * Utility classes — color/surface helpers consumed across
+ * components. These mirror tokens the legacy code already
+ * referenced (bg-surface, bg-panel, bg-background-subtle,
+ * shadow-soft, border-strong) so existing markup keeps
+ * styling without churn.
+ * --------------------------------------------------------- */
 @layer utilities {
   /* Container helpers */
   .container-page {
@@ -166,19 +345,39 @@
     max-width: 80rem;
   }
 
-  /* Soft surface gradient for hero / empty regions */
+  /* Surfaces */
+  .bg-surface { background-color: rgb(var(--ps-surface)); }
+  .bg-surface-2 { background-color: rgb(var(--ps-surface-2)); }
+  .bg-panel { background-color: rgb(var(--ps-panel)); }
+  .bg-background-subtle { background-color: rgb(var(--ps-surface-2) / 0.55); }
+  .bg-background-subtle\/50 { background-color: rgb(var(--ps-surface-2) / 0.5); }
+  .bg-background-subtle\/60 { background-color: rgb(var(--ps-surface-2) / 0.6); }
+  .bg-background-subtle\/65 { background-color: rgb(var(--ps-surface-2) / 0.65); }
+  .bg-background-subtle\/70 { background-color: rgb(var(--ps-surface-2) / 0.7); }
+
+  /* Borders */
+  .border-strong { border-color: rgb(var(--ps-line) / var(--ps-line-strong-strength)); }
+  .border-border-strong { border-color: rgb(var(--ps-line) / var(--ps-line-strong-strength)); }
+  .border-border-strong\/70 { border-color: rgb(var(--ps-line) / 0.14); }
+  .border-border\/70 { border-color: rgb(var(--ps-line) / 0.07); }
+  .border-border\/80 { border-color: rgb(var(--ps-line) / 0.085); }
+
+  /* Accent helpers */
+  .text-accent-strong { color: rgb(var(--ps-accent-strong)); }
+  .bg-accent\/10 { background-color: rgb(var(--ps-accent) / 0.10); }
+
+  /* Soft shadow — used for cards and floating chrome. */
+  .shadow-soft {
+    box-shadow:
+      0 1px 0 rgb(var(--ps-line) / 0.04),
+      0 8px 28px -16px rgb(var(--ps-ink) / 0.18);
+  }
+
+  /* Soft hero gradient (used by /auth and signed-out home). */
   .bg-hero-gradient {
     background-image:
-      radial-gradient(
-        circle at 20% 10%,
-        hsl(var(--primary) / 0.12),
-        transparent 45%
-      ),
-      radial-gradient(
-        circle at 85% 0%,
-        hsl(var(--info) / 0.08),
-        transparent 50%
-      );
+      radial-gradient(circle at 18% 12%, rgb(var(--ps-accent) / 0.16), transparent 48%),
+      radial-gradient(circle at 88% -8%, rgb(var(--ps-warn) / 0.12), transparent 50%);
   }
 
   /* Skip-link visible only on focus */
@@ -189,11 +388,13 @@
     z-index: 100;
     padding: 0.5rem 0.875rem;
     border-radius: 0.5rem;
-    background-color: hsl(var(--primary));
-    color: hsl(var(--primary-foreground));
-    font-size: 0.875rem;
-    font-weight: 600;
-    box-shadow: 0 8px 20px hsl(var(--primary) / 0.25);
+    background-color: rgb(var(--ps-ink));
+    color: rgb(var(--ps-canvas));
+    font-family: var(--ps-font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    box-shadow: 0 8px 20px rgb(var(--ps-ink) / 0.25);
     transition: top 0.15s ease;
   }
   .skip-link:focus,
@@ -201,9 +402,26 @@
     top: 0.75rem;
     outline: none;
   }
+
+  /* Trichome-stipple watermark — used inside hero cards. */
+  .ps-trichome-bg {
+    background-image:
+      radial-gradient(circle at 8% 22%, rgb(var(--ps-accent) / 0.12) 0 1.4px, transparent 2px),
+      radial-gradient(circle at 24% 70%, rgb(var(--ps-accent) / 0.10) 0 1.2px, transparent 2px),
+      radial-gradient(circle at 60% 18%, rgb(var(--ps-accent) / 0.10) 0 1.6px, transparent 2px),
+      radial-gradient(circle at 78% 64%, rgb(var(--ps-accent) / 0.10) 0 1.2px, transparent 2px),
+      radial-gradient(circle at 92% 30%, rgb(var(--ps-accent) / 0.08) 0 1.2px, transparent 2px);
+  }
 }
 
-/* Respect users who prefer reduced motion */
+/* -----------------------------------------------------------
+ * Animations
+ * --------------------------------------------------------- */
+@keyframes ps-rise {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,24 @@
 import type { Metadata, Viewport } from "next";
+import { Fraunces, JetBrains_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { SkipLink } from "@/components/app-shell/skip-link";
 import { ThemeScript } from "@/components/app-shell/theme-script";
 import "./globals.css";
+
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
+  variable: "--font-fraunces",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500"],
+  display: "swap",
+  variable: "--font-jetbrains-mono",
+});
 
 export const metadata: Metadata = {
   title: {
@@ -21,8 +36,8 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#fafdf9" },
-    { media: "(prefers-color-scheme: dark)", color: "#0f1411" },
+    { media: "(prefers-color-scheme: light)", color: "#EFEAD9" },
+    { media: "(prefers-color-scheme: dark)", color: "#0D120D" },
   ],
 };
 
@@ -32,7 +47,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${fraunces.variable} ${jetbrainsMono.variable}`}
+    >
       <head>
         <ThemeScript />
       </head>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -10,9 +10,7 @@ import {
   LogoMark,
   PlantIcon,
   SettingsIcon,
-  SparkIcon,
 } from "@/components/icons";
-import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
 import { cn } from "@/lib/cn";
 
@@ -38,7 +36,7 @@ const navItems = [
   {
     href: "/assistant",
     icon: AssistantIcon,
-    label: "Assistant",
+    label: "Copilot",
     match: ["/assistant"],
   },
   {
@@ -65,8 +63,6 @@ export function AppShell({
   userEmail?: string | null;
 }) {
   const pathname = usePathname();
-  const activeItem =
-    navItems.find((item) => isActive(pathname, item.match)) ?? navItems[0]!;
   const operatorLabel =
     displayName?.trim() ||
     userEmail
@@ -77,100 +73,95 @@ export function AppShell({
   const resolvedDisplayLabel = operatorLabel.replace(/\b\w/g, (character) =>
     character.toUpperCase(),
   );
+  const initials = resolvedDisplayLabel
+    .split(/\s+/)
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
 
   return (
-    <div className="min-h-screen bg-transparent">
+    <div className="min-h-screen bg-[rgb(var(--ps-canvas))] text-[rgb(var(--ps-ink))]">
       <div className="mx-auto flex min-h-screen w-full max-w-[1680px]">
-        <aside className="hidden w-[18rem] shrink-0 flex-col border-r border-border/80 bg-panel/88 px-5 py-6 backdrop-blur-sm lg:flex">
-          <Link className="flex items-center gap-3" href="/dashboard">
-            <div className="flex h-11 w-11 items-center justify-center rounded-[1.1rem] bg-accent text-accent-foreground shadow-sm">
-              <LogoMark className="h-5 w-5" />
-            </div>
-            <div>
-              <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
-                PhenoSage
-              </p>
-              <p className="text-sm font-semibold text-foreground">
-                Cultivation control
-              </p>
-            </div>
+        {/* ── Sidebar — desktop ─────────────────────────── */}
+        <aside
+          aria-label="Sidebar"
+          className="sticky top-0 hidden h-screen w-[260px] shrink-0 flex-col border-r border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface)/0.6)] px-5 py-6 lg:flex"
+        >
+          <Link
+            className="flex items-center gap-2.5"
+            href="/dashboard"
+            aria-label="PhenoSage home"
+          >
+            <span
+              aria-hidden="true"
+              className="flex h-9 w-9 items-center justify-center rounded-full bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
+            >
+              <LogoMark className="h-4 w-4" />
+            </span>
+            <span className="ps-display text-[20px] leading-none">
+              PhenoSage
+            </span>
           </Link>
 
-          <div className="mt-8 rounded-[1.25rem] border border-border/80 bg-surface/90 p-4 shadow-sm">
-            <div className="flex items-start justify-between gap-3">
-              <div className="space-y-1.5">
-                <p className="text-sm font-semibold text-foreground">
-                  Workspace posture
-                </p>
-                <p className="text-xs leading-5 text-muted-foreground">
-                  Private images, same-origin AI routes, and operator-scoped
-                  context.
-                </p>
-              </div>
-              <SparkIcon className="h-4 w-4 text-accent" />
-            </div>
-            <div className="mt-4 grid gap-2">
-              <div className="metric-chip w-fit">Secure upload path</div>
-              <div className="metric-chip w-fit">Persisted findings</div>
-            </div>
-          </div>
-
-          <nav aria-label="Primary" className="mt-8 flex flex-1 flex-col gap-1">
+          <p className="ps-eyebrow mt-8">Workspace</p>
+          <nav
+            aria-label="Primary"
+            className="mt-3 flex flex-1 flex-col gap-0.5"
+          >
             {navItems.map((item) => {
               const active = isActive(pathname, item.match);
               const Icon = item.icon;
-
               return (
                 <Link
                   key={item.href}
-                  className={cn(
-                    "group flex items-center justify-between rounded-[0.95rem] px-3 py-3 text-sm font-medium transition-colors",
-                    active
-                      ? "bg-accent/10 text-accent-strong shadow-[inset_0_1px_0_rgba(255,255,255,0.35)]"
-                      : "text-muted-foreground hover:bg-muted/80 hover:text-foreground",
-                  )}
                   href={item.href}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "group flex items-center gap-3 rounded-full px-3.5 py-2.5 text-[14px] font-medium transition-colors",
+                    active
+                      ? "bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
+                      : "text-[rgb(var(--ps-ink-2))] hover:bg-[rgb(var(--ps-ink)/0.06)] hover:text-[rgb(var(--ps-ink))]",
+                  )}
                 >
-                  <span className="flex items-center gap-3">
-                    <Icon
-                      className={cn(
-                        "h-5 w-5",
-                        active
-                          ? "text-accent"
-                          : "text-muted-foreground group-hover:text-foreground",
-                      )}
-                    />
-                    {item.label}
-                  </span>
+                  <Icon
+                    className={cn(
+                      "h-[17px] w-[17px] transition-colors",
+                      active
+                        ? "text-[rgb(var(--ps-canvas))]"
+                        : "text-[rgb(var(--ps-muted))] group-hover:text-[rgb(var(--ps-ink))]",
+                    )}
+                  />
+                  <span>{item.label}</span>
                 </Link>
               );
             })}
           </nav>
 
-          <div className="space-y-4 rounded-[1.2rem] border border-border/80 bg-surface/92 p-4 shadow-sm">
-            <div className="space-y-2">
-              <Badge tone="accent" className="text-[10px]">
-                Authenticated
-              </Badge>
-              <div>
-                <p className="text-sm font-semibold text-foreground">
+          <div className="mt-6 rounded-[18px] border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface))] p-4">
+            <div className="flex items-center gap-3">
+              <span
+                aria-hidden="true"
+                className="flex h-9 w-9 items-center justify-center rounded-full bg-[rgb(var(--ps-accent-soft))] text-[rgb(var(--ps-accent-strong))] ps-mono text-[12px] font-medium"
+              >
+                {initials || "OP"}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[13.5px] font-medium leading-tight">
                   {resolvedDisplayLabel}
                 </p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {userEmail ?? "Connected operator"}{" "}
-                </p>
-                <p className="mt-2 text-xs leading-5 text-muted-foreground">
-                  Signed in to a private cultivation workspace with route-scoped
-                  analysis and chat persistence.
+                <p className="ps-mono mt-0.5 truncate text-[10.5px] uppercase tracking-[0.08em] text-[rgb(var(--ps-muted))]">
+                  {userEmail ?? "signed in"}
                 </p>
               </div>
             </div>
-            <form action="/auth/signout" method="post">
+            <form action="/auth/signout" className="mt-3" method="post">
               <button
                 className={buttonStyles({
                   className: "w-full justify-center",
                   size: "sm",
-                  variant: "surface",
+                  variant: "outline",
                 })}
                 type="submit"
               >
@@ -178,44 +169,41 @@ export function AppShell({
               </button>
             </form>
           </div>
+
+          <p className="ps-mono mt-4 text-[10px] uppercase tracking-[0.16em] text-[rgb(var(--ps-subtle))]">
+            v0.1 · operator preview
+          </p>
         </aside>
 
+        {/* ── Main column ───────────────────────────────── */}
         <div className="flex min-h-screen min-w-0 flex-1 flex-col">
-          <header className="sticky top-0 z-20 border-b border-border/80 bg-background/78 backdrop-blur-md">
+          <header className="sticky top-0 z-20 border-b border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-canvas)/0.85)] backdrop-blur-md">
             <div className="flex h-14 items-center justify-between px-4 sm:px-6 lg:px-8">
-              <div className="flex items-center gap-4">
-                <Link
-                  className="flex items-center gap-3 lg:hidden"
-                  href="/dashboard"
+              {/* Mobile brand */}
+              <Link
+                className="flex items-center gap-2 lg:hidden"
+                href="/dashboard"
+              >
+                <span
+                  aria-hidden="true"
+                  className="flex h-7 w-7 items-center justify-center rounded-full bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
                 >
-                  <div className="flex h-8 w-8 items-center justify-center rounded-[0.75rem] bg-accent text-accent-foreground shadow-sm">
-                    <LogoMark className="h-4 w-4" />
-                  </div>
-                  <div>
-                    <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-muted-foreground">
-                      PhenoSage
-                    </p>
-                    <p className="text-sm font-semibold text-foreground">
-                      {activeItem.label}
-                    </p>
-                  </div>
-                </Link>
-                <div className="hidden lg:flex lg:items-center lg:gap-3">
-                  <div className="flex items-center gap-3 text-sm text-muted-foreground">
-                    <span className="metric-chip">{activeItem.label}</span>
-                    <span className="text-xs uppercase tracking-[0.15em] text-muted-foreground">
-                      Advanced operating view
-                    </span>
-                  </div>
-                </div>
+                  <LogoMark className="h-3.5 w-3.5" />
+                </span>
+                <span className="ps-display text-[16px] leading-none">
+                  PhenoSage
+                </span>
+              </Link>
+
+              <div className="hidden items-center gap-3 lg:flex">
+                <span className="ps-mono text-[11px] uppercase tracking-[0.14em] text-[rgb(var(--ps-muted))]">
+                  Operator workspace
+                </span>
               </div>
 
-              <div className="flex items-center gap-3">
-                <Badge className="hidden sm:inline-flex" tone="accent">
-                  Private by design
-                </Badge>
+              <div className="flex items-center gap-2">
                 <Link
-                  className={buttonStyles({ size: "sm", variant: "surface" })}
+                  className={buttonStyles({ size: "sm", variant: "outline" })}
                   href="/assistant"
                 >
                   Ask copilot
@@ -224,32 +212,33 @@ export function AppShell({
             </div>
           </header>
 
-          <div className="flex-1 pb-24 lg:pb-8">{children}</div>
+          <div className="flex-1 pb-28 lg:pb-12">{children}</div>
 
+          {/* ── Mobile bottom nav (floating pill) ──────── */}
           <nav
             aria-label="Mobile primary"
-            className="fixed bottom-4 left-4 right-4 z-30 rounded-[1.25rem] border border-border bg-surface/95 p-2 shadow-md backdrop-blur-md lg:hidden"
+            className="fixed bottom-3 left-3 right-3 z-30 lg:hidden"
+            style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
           >
-            <ul className="grid grid-cols-5 gap-1">
+            <ul className="grid grid-cols-5 gap-1 rounded-full border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface))] p-1.5 shadow-soft">
               {navItems.map((item) => {
                 const active = isActive(pathname, item.match);
                 const Icon = item.icon;
-
                 return (
                   <li key={item.href}>
                     <Link
+                      aria-current={active ? "page" : undefined}
+                      aria-label={item.label}
                       className={cn(
-                        "flex flex-col items-center gap-1.5 rounded-[0.75rem] px-3 py-2 text-[10px] font-semibold transition",
+                        "flex h-10 flex-col items-center justify-center gap-0.5 rounded-full px-1 text-[10px] font-medium transition-colors",
                         active
-                          ? "bg-accent/10 text-accent-strong"
-                          : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                          ? "bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
+                          : "text-[rgb(var(--ps-muted))] hover:text-[rgb(var(--ps-ink))]",
                       )}
                       href={item.href}
                     >
-                      <Icon
-                        className={cn("h-5 w-5", active ? "text-accent" : "")}
-                      />
-                      {item.label}
+                      <Icon className="h-[18px] w-[18px]" />
+                      <span className="leading-none">{item.label}</span>
                     </Link>
                   </li>
                 );

--- a/apps/web/src/components/app-shell/app-shell.tsx
+++ b/apps/web/src/components/app-shell/app-shell.tsx
@@ -17,46 +17,52 @@ interface AppShellProps {
  */
 export function AppShell({ user, children }: AppShellProps) {
   return (
-    <div className="min-h-screen bg-background text-foreground">
+    <div className="min-h-screen bg-[rgb(var(--ps-canvas))] text-[rgb(var(--ps-ink))]">
       <div className="flex">
         {/* Sidebar — desktop */}
         <aside
           aria-label="Sidebar"
-          className="sticky top-0 hidden h-screen w-60 shrink-0 border-r border-border bg-card md:flex md:flex-col"
+          className="sticky top-0 hidden h-screen w-60 shrink-0 flex-col border-r border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface)/0.6)] md:flex"
         >
           <Link
             href="/dashboard"
-            className="flex h-16 items-center gap-2 border-b border-border px-5 font-semibold tracking-tight"
+            className="flex h-16 items-center gap-2.5 border-b border-[rgb(var(--ps-line)/var(--ps-line-strength))] px-5"
           >
             <span
               aria-hidden="true"
-              className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground"
+              className="flex h-9 w-9 items-center justify-center rounded-full bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
             >
-              <LeafIcon width={18} height={18} />
+              <LeafIcon width={16} height={16} />
             </span>
-            <span>PhenoSage</span>
+            <span className="ps-display text-[18px] leading-none">
+              PhenoSage
+            </span>
           </Link>
           <SidebarNav className="flex-1" />
-          <div className="border-t border-border p-3 text-[11px] text-muted-foreground">
-            <p>v0.1 · Web-first OS</p>
+          <div className="border-t border-[rgb(var(--ps-line)/var(--ps-line-strength))] p-3">
+            <p className="ps-mono text-[10px] uppercase tracking-[0.16em] text-[rgb(var(--ps-subtle))]">
+              v0.1 · operator preview
+            </p>
           </div>
         </aside>
 
         <div className="flex min-w-0 flex-1 flex-col">
           {/* Top bar */}
-          <header className="sticky top-0 z-20 flex h-16 items-center justify-between gap-3 border-b border-border bg-background/85 px-4 backdrop-blur md:px-6">
+          <header className="sticky top-0 z-20 flex h-14 items-center justify-between gap-3 border-b border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-canvas)/0.85)] px-4 backdrop-blur md:px-6">
             {/* Mobile brand */}
             <Link
               href="/dashboard"
-              className="flex items-center gap-2 font-semibold tracking-tight md:hidden"
+              className="flex items-center gap-2 md:hidden"
             >
               <span
                 aria-hidden="true"
-                className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground"
+                className="flex h-7 w-7 items-center justify-center rounded-full bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
               >
-                <LeafIcon width={16} height={16} />
+                <LeafIcon width={14} height={14} />
               </span>
-              <span>PhenoSage</span>
+              <span className="ps-display text-[15px] leading-none">
+                PhenoSage
+              </span>
             </Link>
             <div className="flex flex-1 items-center justify-end gap-3">
               <HealthIndicator />

--- a/apps/web/src/components/app-shell/nav.tsx
+++ b/apps/web/src/components/app-shell/nav.tsx
@@ -46,21 +46,20 @@ export function SidebarNav({ className }: { className?: string }) {
             href={href}
             aria-current={active ? "page" : undefined}
             className={cn(
-              "group flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium",
-              "transition-colors duration-150",
+              "group flex items-center gap-3 rounded-full px-3.5 py-2.5 text-[14px] font-medium transition-colors duration-150",
               active
-                ? "bg-accent text-accent-foreground"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                ? "bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
+                : "text-[rgb(var(--ps-ink-2))] hover:bg-[rgb(var(--ps-ink)/0.06)] hover:text-[rgb(var(--ps-ink))]",
             )}
           >
             <Icon
-              width={18}
-              height={18}
+              width={17}
+              height={17}
               className={cn(
                 "transition-colors",
                 active
-                  ? "text-primary"
-                  : "text-muted-foreground group-hover:text-foreground",
+                  ? "text-[rgb(var(--ps-canvas))]"
+                  : "text-[rgb(var(--ps-muted))] group-hover:text-[rgb(var(--ps-ink))]",
               )}
             />
             <span>{label}</span>
@@ -76,10 +75,10 @@ export function MobileBottomNav() {
   return (
     <nav
       aria-label="Primary"
-      className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-background/90 backdrop-blur md:hidden"
+      className="fixed bottom-3 left-3 right-3 z-30 md:hidden"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
-      <ul className="grid grid-cols-5">
+      <ul className="grid grid-cols-5 gap-1 rounded-full border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface))] p-1.5 shadow-soft">
         {NAV_ITEMS.map(({ href, label, Icon }) => {
           const active = isActive(pathname, href);
           return (
@@ -89,21 +88,14 @@ export function MobileBottomNav() {
                 aria-current={active ? "page" : undefined}
                 aria-label={label}
                 className={cn(
-                  "flex h-14 flex-col items-center justify-center gap-0.5 text-[11px] transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                  "flex h-10 flex-col items-center justify-center gap-0.5 rounded-full px-1 text-[10px] font-medium transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--ps-accent))]",
                   active
-                    ? "text-primary"
-                    : "text-muted-foreground active:text-foreground",
+                    ? "bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]"
+                    : "text-[rgb(var(--ps-muted))] hover:text-[rgb(var(--ps-ink))]",
                 )}
               >
-                <span
-                  className={cn(
-                    "flex h-7 w-12 items-center justify-center rounded-full transition-colors",
-                    active && "bg-accent",
-                  )}
-                >
-                  <Icon width={20} height={20} />
-                </span>
+                <Icon width={18} height={18} />
                 <span className="leading-none">{label}</span>
               </Link>
             </li>

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -13,14 +13,17 @@ type Variant =
 type Tone = "default" | "accent" | "success" | "warning" | "danger" | "info";
 
 const VARIANTS: Record<Variant, string> = {
-  default: "bg-primary text-primary-foreground",
-  secondary: "bg-secondary text-secondary-foreground",
-  outline: "border border-border bg-transparent text-foreground",
-  success: "bg-success/15 text-success border border-success/30",
-  warning: "bg-warning/15 text-warning border border-warning/30",
+  default: "bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))]",
+  secondary: "bg-[rgb(var(--ps-ink)/0.05)] text-[rgb(var(--ps-ink-2))]",
+  outline:
+    "border border-[rgb(var(--ps-line)/var(--ps-line-strong-strength))] bg-transparent text-[rgb(var(--ps-ink-2))]",
+  success:
+    "bg-[rgb(var(--ps-ok)/0.12)] text-[rgb(var(--ps-ok))] border border-[rgb(var(--ps-ok)/0.32)]",
+  warning:
+    "bg-[rgb(var(--ps-warn)/0.16)] text-[rgb(var(--ps-warn))] border border-[rgb(var(--ps-warn)/0.36)]",
   destructive:
-    "bg-destructive/15 text-destructive border border-destructive/30",
-  info: "bg-info/15 text-info border border-info/30",
+    "bg-[rgb(var(--ps-crit)/0.16)] text-[rgb(var(--ps-crit))] border border-[rgb(var(--ps-crit)/0.36)]",
+  info: "bg-[rgb(var(--ps-accent-soft))] text-[rgb(var(--ps-accent-strong))] border border-[rgb(var(--ps-accent)/0.32)]",
 };
 
 const TONE_TO_VARIANT: Record<Tone, Variant> = {
@@ -43,7 +46,7 @@ export function Badge({ variant, tone, className, ...props }: BadgeProps) {
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium leading-none",
+        "inline-flex items-center gap-1 rounded-full px-2.5 py-[3px] font-mono text-[10.5px] uppercase tracking-[0.08em] leading-none whitespace-nowrap",
         VARIANTS[resolved],
         className,
       )}

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -22,23 +22,23 @@ type Size = "sm" | "md" | "lg" | "icon";
 
 const VARIANTS: Record<Variant, string> = {
   primary:
-    "bg-primary text-primary-foreground shadow-elevation-1 hover:bg-primary/90 active:bg-primary/95",
+    "bg-[rgb(var(--ps-ink))] text-[rgb(var(--ps-canvas))] hover:bg-[rgb(var(--ps-ink-2))]",
   secondary:
-    "bg-secondary text-secondary-foreground hover:bg-secondary/80 active:bg-secondary/70",
+    "bg-[rgb(var(--ps-accent))] text-[rgb(var(--ps-accent-ink))] hover:opacity-90",
   outline:
-    "border border-border bg-transparent text-foreground hover:bg-muted active:bg-muted/80",
-  ghost: "bg-transparent text-foreground hover:bg-muted active:bg-muted/80",
-  destructive:
-    "bg-destructive text-destructive-foreground shadow-elevation-1 hover:bg-destructive/90",
+    "border border-[rgb(var(--ps-line)/var(--ps-line-strong-strength))] bg-transparent text-[rgb(var(--ps-ink))] hover:bg-[rgb(var(--ps-ink)/0.04)]",
+  ghost:
+    "bg-transparent text-[rgb(var(--ps-ink))] hover:bg-[rgb(var(--ps-ink)/0.05)]",
+  destructive: "bg-[rgb(var(--ps-crit))] text-white hover:opacity-90",
   surface:
-    "border border-border/70 bg-card text-foreground shadow-elevation-1 hover:bg-muted/60 active:bg-muted",
-  link: "bg-transparent text-primary underline-offset-4 hover:underline px-0 h-auto",
+    "border border-[rgb(var(--ps-line)/var(--ps-line-strong-strength))] bg-[rgb(var(--ps-surface))] text-[rgb(var(--ps-ink))] hover:bg-[rgb(var(--ps-surface-2))]",
+  link: "bg-transparent text-[rgb(var(--ps-accent))] underline-offset-4 hover:underline px-0 h-auto",
 };
 
 const SIZES: Record<Size, string> = {
-  sm: "h-8 px-3 text-xs gap-1.5",
+  sm: "h-8 px-3.5 text-[12.5px] gap-1.5",
   md: "h-10 px-4 text-sm gap-2",
-  lg: "h-11 px-6 text-base gap-2",
+  lg: "h-11 px-6 text-[15px] gap-2",
   icon: "h-10 w-10 p-0",
 };
 
@@ -57,8 +57,8 @@ export function buttonVariants({
   className?: string;
 } = {}): string {
   return cn(
-    "inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium transition-colors duration-150 ease-out-expo",
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+    "inline-flex items-center justify-center whitespace-nowrap rounded-full font-medium tracking-[0.005em] transition-[background-color,color,transform,opacity] duration-150 ease-out-expo active:scale-[0.985]",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgb(var(--ps-accent))] focus-visible:ring-offset-2 focus-visible:ring-offset-[rgb(var(--ps-canvas))]",
     "disabled:pointer-events-none disabled:opacity-50",
     VARIANTS[variant],
     SIZES[size],

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,15 +1,16 @@
 import { forwardRef, type HTMLAttributes } from "react";
 import { cn } from "@/lib/cn";
 
-type CardVariant = "default" | "surface";
+type CardVariant = "default" | "surface" | "accent";
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   variant?: CardVariant;
 }
 
 const VARIANTS: Record<CardVariant, string> = {
-  default: "bg-card text-card-foreground shadow-elevation-1",
-  surface: "bg-muted/40 text-card-foreground",
+  default: "bg-[rgb(var(--ps-surface))] text-[rgb(var(--ps-ink))] shadow-soft",
+  surface: "bg-[rgb(var(--ps-surface-2)/0.7)] text-[rgb(var(--ps-ink))]",
+  accent: "bg-[rgb(var(--ps-accent-soft))] text-[rgb(var(--ps-accent-strong))]",
 };
 
 export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
@@ -20,7 +21,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
     <div
       ref={ref}
       className={cn(
-        "rounded-lg border",
+        "ps-rise rounded-[18px] border border-[rgb(var(--ps-line)/var(--ps-line-strength))]",
         VARIANTS[variant],
         "transition-shadow duration-200",
         className,
@@ -37,7 +38,7 @@ export const CardHeader = forwardRef<
   return (
     <div
       ref={ref}
-      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      className={cn("flex flex-col gap-1.5 p-6 pb-4", className)}
       {...props}
     />
   );
@@ -50,10 +51,7 @@ export const CardTitle = forwardRef<
   return (
     <h3
       ref={ref}
-      className={cn(
-        "text-base font-semibold leading-tight tracking-tight",
-        className,
-      )}
+      className={cn("ps-display text-[19px] leading-tight", className)}
       {...props}
     />
   );
@@ -66,7 +64,10 @@ export const CardDescription = forwardRef<
   return (
     <p
       ref={ref}
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn(
+        "text-[13.5px] leading-6 text-[rgb(var(--ps-muted))]",
+        className,
+      )}
       {...props}
     />
   );

--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -19,21 +19,21 @@ export function EmptyState({
   return (
     <div
       className={cn(
-        "flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-muted/30 px-6 py-14 text-center",
+        "flex flex-col items-center justify-center rounded-[18px] border border-dashed border-[rgb(var(--ps-line)/0.18)] bg-[rgb(var(--ps-surface-2)/0.55)] px-6 py-14 text-center",
         className,
       )}
     >
       {icon && (
         <div
           aria-hidden="true"
-          className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-accent text-accent-foreground"
+          className="mb-4 flex h-11 w-11 items-center justify-center rounded-full bg-[rgb(var(--ps-accent-soft))] text-[rgb(var(--ps-accent-strong))]"
         >
           {icon}
         </div>
       )}
-      <h3 className="text-base font-semibold text-foreground">{title}</h3>
+      <h3 className="ps-display text-[18px] leading-tight">{title}</h3>
       {description && (
-        <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+        <p className="mt-2 max-w-sm text-[13.5px] leading-[1.55] text-[rgb(var(--ps-muted))]">
           {description}
         </p>
       )}

--- a/apps/web/src/components/ui/page-header.tsx
+++ b/apps/web/src/components/ui/page-header.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { cn } from "@/lib/cn";
 import { ChevronRightIcon } from "@/components/icons";
+import { cn } from "@/lib/cn";
 
 interface BreadcrumbItem {
   href?: string;
@@ -23,57 +23,57 @@ export function PageHeader({
 }) {
   return (
     <header className="workspace-hero">
-      <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
-        <div className="space-y-5">
-          {breadcrumbs?.length ? (
-            <nav aria-label="Breadcrumb">
-              <ol className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                {breadcrumbs.map((item, index) => (
-                  <li
-                    key={`${item.label}-${index}`}
-                    className="flex items-center gap-2"
+      {breadcrumbs?.length ? (
+        <nav aria-label="Breadcrumb" className="mb-3">
+          <ol className="ps-mono flex flex-wrap items-center gap-1.5 text-[11px] uppercase tracking-[0.12em] text-[rgb(var(--ps-muted))]">
+            {breadcrumbs.map((item, index) => (
+              <li
+                key={`${item.label}-${index}`}
+                className="flex items-center gap-1.5"
+              >
+                {index > 0 ? (
+                  <ChevronRightIcon className="h-3 w-3 opacity-60" />
+                ) : null}
+                {item.href ? (
+                  <Link
+                    className="transition-colors hover:text-[rgb(var(--ps-ink))]"
+                    href={item.href}
                   >
-                    {index > 0 ? (
-                      <ChevronRightIcon className="h-4 w-4 text-border-strong" />
-                    ) : null}
-                    {item.href ? (
-                      <Link className="hover:text-foreground" href={item.href}>
-                        {item.label}
-                      </Link>
-                    ) : (
-                      <span aria-current="page" className="text-foreground">
-                        {item.label}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ol>
-            </nav>
-          ) : null}
+                    {item.label}
+                  </Link>
+                ) : (
+                  <span
+                    aria-current="page"
+                    className="text-[rgb(var(--ps-ink))]"
+                  >
+                    {item.label}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ol>
+        </nav>
+      ) : null}
+
+      <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+        <div className="space-y-3 max-w-3xl">
           {eyebrow ? <div>{eyebrow}</div> : null}
-          <div className="space-y-4">
-            <h1 className="text-balance max-w-4xl text-3xl font-semibold tracking-[-0.06em] text-foreground sm:text-4xl lg:text-[2.7rem]">
-              {title}
-            </h1>
-            <p className="max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
-              {description}
-            </p>
-          </div>
-        </div>
-        {actions ? (
-          <div
+          <h1
             className={cn(
-              "flex flex-wrap items-center gap-3 lg:max-w-[28rem] lg:justify-end",
+              "ps-display text-balance text-[34px] leading-[1.04] sm:text-[44px] lg:text-[52px]",
             )}
           >
+            {title}
+          </h1>
+          <p className="text-[14.5px] leading-[1.55] text-[rgb(var(--ps-muted))] sm:text-[15.5px]">
+            {description}
+          </p>
+        </div>
+        {actions ? (
+          <div className="flex flex-wrap items-center gap-2.5 lg:max-w-[28rem] lg:justify-end">
             {actions}
           </div>
         ) : null}
-      </div>
-      <div className="mt-6 flex flex-wrap gap-2">
-        <span className="metric-chip">Operator-first workspace</span>
-        <span className="metric-chip">Same-origin secured</span>
-        <span className="metric-chip">Evidence over noise</span>
       </div>
     </header>
   );

--- a/apps/web/src/components/ui/section-header.tsx
+++ b/apps/web/src/components/ui/section-header.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+/**
+ * Editorial section header — a small mono uppercase label with an optional
+ * trailing slot for counts, filters, or links. Used inside cards to title
+ * dense regions without competing with the page H1.
+ */
+export function SectionHeader({
+  label,
+  trailing,
+  className,
+}: {
+  label: ReactNode;
+  trailing?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("ps-section-head", className)}>
+      <span className="ps-eyebrow">{label}</span>
+      {trailing ? (
+        <div className="ps-mono text-[11px] text-[rgb(var(--ps-muted))]">
+          {trailing}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/stat-card.tsx
+++ b/apps/web/src/components/ui/stat-card.tsx
@@ -4,14 +4,11 @@ import { Card } from "@/components/ui/card";
 
 type StatTone = "default" | "accent" | "success" | "warning";
 
-const accentStyles: Record<StatTone, string> = {
-  default: "bg-surface/88",
-  accent:
-    "bg-[linear-gradient(135deg,rgba(var(--accent),0.10),rgba(255,255,255,0.92))]",
-  success:
-    "bg-[linear-gradient(135deg,rgba(var(--success),0.10),rgba(255,255,255,0.92))]",
-  warning:
-    "bg-[linear-gradient(135deg,rgba(var(--warning),0.10),rgba(255,255,255,0.92))]",
+const accentBars: Record<StatTone, string> = {
+  default: "bg-[rgb(var(--ps-line)/0.15)]",
+  accent: "bg-[rgb(var(--ps-accent))]",
+  success: "bg-[rgb(var(--ps-ok))]",
+  warning: "bg-[rgb(var(--ps-warn))]",
 };
 
 export function StatCard({
@@ -30,34 +27,28 @@ export function StatCard({
   value: string;
 }) {
   return (
-    <Card
-      className={cn(
-        "relative overflow-hidden p-6 shadow-[0_18px_50px_rgba(17,24,17,0.05)]",
-        accentStyles[tone],
-      )}
-    >
-      <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent/35 to-transparent" />
-      <div className="flex items-start justify-between gap-4">
-        <div className="space-y-3 z-10">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
-            {label}
-          </p>
-          <div className="space-y-1.5">
-            <p className="text-3xl font-semibold tracking-[-0.05em] text-foreground">
-              {value}
-            </p>
-            <p className="max-w-[16rem] text-sm leading-6 text-muted-foreground">
-              {detail}
-            </p>
+    <Card className="relative overflow-hidden p-5">
+      <span
+        aria-hidden="true"
+        className={cn("absolute inset-y-0 left-0 w-[3px]", accentBars[tone])}
+      />
+      <div className="flex items-start justify-between gap-4 pl-2">
+        <div className="space-y-2.5 min-w-0">
+          <p className="ps-eyebrow">{label}</p>
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="ps-display text-[34px] leading-[1]">{value}</span>
           </div>
+          <p className="text-[13px] leading-[1.5] text-[rgb(var(--ps-muted))] max-w-[20rem]">
+            {detail}
+          </p>
         </div>
         {icon ? (
-          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-[0.95rem] border border-border/70 bg-surface/90 text-accent shadow-sm z-10">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-[rgb(var(--ps-line)/0.16)] bg-[rgb(var(--ps-surface-2))] text-[rgb(var(--ps-accent))]">
             {icon}
           </div>
         ) : null}
       </div>
-      {meta ? <div className="pt-5 z-10 relative">{meta}</div> : null}
+      {meta ? <div className="pt-4 pl-2">{meta}</div> : null}
     </Card>
   );
 }

--- a/apps/web/src/components/upload-photo-panel.tsx
+++ b/apps/web/src/components/upload-photo-panel.tsx
@@ -6,7 +6,7 @@ import type { AnalysisResponse } from "@phenosage/shared";
 import { CheckCircleIcon, UploadIcon } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonStyles } from "@/components/ui/button";
-import { createSupabaseBrowserClient } from "@/lib/supabase";
+import { createSupabaseBrowserClient } from "@/lib/supabase/browser";
 
 type UploadNotice = {
   tone: "danger" | "success" | "warning";

--- a/apps/web/src/components/upload-photo-panel.tsx
+++ b/apps/web/src/components/upload-photo-panel.tsx
@@ -6,7 +6,7 @@ import type { AnalysisResponse } from "@phenosage/shared";
 import { CheckCircleIcon, UploadIcon } from "@/components/icons";
 import { Badge } from "@/components/ui/badge";
 import { Button, buttonStyles } from "@/components/ui/button";
-import { createSupabaseBrowserClient } from "@/lib/supabase/browser";
+import { createSupabaseBrowserClient } from "@/lib/supabase-client";
 
 type UploadNotice = {
   tone: "danger" | "success" | "warning";

--- a/apps/web/src/lib/supabase-client.ts
+++ b/apps/web/src/lib/supabase-client.ts
@@ -1,11 +1,27 @@
 "use client";
 
+import { createBrowserClient } from "@supabase/ssr";
+
 /**
- * Cache-bust re-export of the browser Supabase client.
+ * Browser Supabase client.
  *
- * Vercel's persistent webpack build cache predates the `lib/supabase/`
- * directory and refuses to resolve `@/lib/supabase` or `@/lib/supabase/browser`
- * even after the files exist. Importing through this top-level path forces
- * Webpack to do a fresh module-resolution pass.
+ * Inlined here (rather than re-exported from `@/lib/supabase/browser`)
+ * because Vercel's webpack environment refuses to resolve nested
+ * `@/lib/supabase/*` aliases on this project regardless of cache state.
+ * Other imports of `@/lib/...` resolve fine, so this targeted bypass
+ * keeps the rest of the module graph clean.
+ *
+ * Only NEXT_PUBLIC_* vars — safe to ship to the client bundle. Never
+ * import this from server code; the server path lives in
+ * `@/lib/server/auth`.
  */
-export { createSupabaseBrowserClient } from "@/lib/supabase/browser";
+export function createSupabaseBrowserClient() {
+  const url = process.env["NEXT_PUBLIC_SUPABASE_URL"];
+  const anonKey = process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+  if (!url || !anonKey) {
+    throw new Error(
+      "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY",
+    );
+  }
+  return createBrowserClient(url, anonKey);
+}

--- a/apps/web/src/lib/supabase-client.ts
+++ b/apps/web/src/lib/supabase-client.ts
@@ -1,0 +1,11 @@
+"use client";
+
+/**
+ * Cache-bust re-export of the browser Supabase client.
+ *
+ * Vercel's persistent webpack build cache predates the `lib/supabase/`
+ * directory and refuses to resolve `@/lib/supabase` or `@/lib/supabase/browser`
+ * even after the files exist. Importing through this top-level path forces
+ * Webpack to do a fresh module-resolution pass.
+ */
+export { createSupabaseBrowserClient } from "@/lib/supabase/browser";

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -65,6 +65,15 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        // Editorial surfaces — exposed so utility classes resolve
+        // (Tailwind colors, CSS classes in globals.css both work).
+        surface: "rgb(var(--ps-surface) / <alpha-value>)",
+        "surface-2": "rgb(var(--ps-surface-2) / <alpha-value>)",
+        panel: "rgb(var(--ps-panel) / <alpha-value>)",
+        ink: "rgb(var(--ps-ink) / <alpha-value>)",
+        "ink-2": "rgb(var(--ps-ink-2) / <alpha-value>)",
+        "accent-strong": "rgb(var(--ps-accent-strong) / <alpha-value>)",
+        "border-strong": "rgb(var(--ps-line) / var(--ps-line-strong-strength))",
         // Brand palette retained for landing decorative pieces
         brand: {
           50: "#f0fdf4",
@@ -87,6 +96,7 @@ module.exports = {
       },
       fontFamily: {
         sans: [
+          "var(--font-general-sans)",
           "ui-sans-serif",
           "-apple-system",
           "BlinkMacSystemFont",
@@ -96,7 +106,23 @@ module.exports = {
           "Arial",
           "sans-serif",
         ],
+        serif: [
+          "var(--font-fraunces)",
+          "Fraunces",
+          "Instrument Serif",
+          "Georgia",
+          "serif",
+        ],
+        display: [
+          "var(--font-fraunces)",
+          "Fraunces",
+          "Instrument Serif",
+          "Georgia",
+          "serif",
+        ],
         mono: [
+          "var(--font-jetbrains-mono)",
+          "JetBrains Mono",
           "ui-monospace",
           "SFMono-Regular",
           "Menlo",

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "framework": "nextjs",
-  "buildCommand": "pnpm build",
+  "buildCommand": "rm -rf .next/cache node_modules/.cache && pnpm build",
   "installCommand": "pnpm install --frozen-lockfile",
   "outputDirectory": ".next",
   "crons": [


### PR DESCRIPTION
Adopt the cannabis-aware editorial design from the redesign zip: hemp-paper canvas, deep cola accent, Fraunces display + JetBrains Mono labels, soft cream surfaces, pill nav. All component APIs (Button, Card, Badge, PageHeader, StatCard) preserved.

- globals.css: rgb-channel design tokens, editorial component classes (.app-page, .workspace-hero, .ps-display, .ps-eyebrow, .ps-mono, .ps-section-head, .metric-chip, .shadow-soft, .ps-trichome-bg) and matching shadcn-style HSL fallbacks
- tailwind.config.js: serif/display font stacks, surface and accent-strong color tokens
- layout.tsx: load Fraunces + JetBrains Mono via next/font
- AppShell: editorial wordmark, pill nav (sidebar + floating mobile), operator card with initials avatar
- Dashboard: date eyebrow + serif greeting, ritual band with trichome motif, restyled stat row, alerts/actions/registry/ posture grid using SectionHeader
- UI primitives: pill-radius buttons, ink-on-cream primary, cream card surface, mono uppercase badges, editorial PageHeader/StatCard/EmptyState

<!-- PhenoSage PR template. Keep PRs small and bounded. -->

## Outcome

<!-- One sentence: what user-visible or system-visible change does this make? -->

## Scope

- [ ] Single concern; no drive-by refactors
- [ ] Affected paths listed below

Affected paths:

```
<paths>
```

## Validation

Paste the output (or summary) of:

- [ ] `pnpm run validate`
- [ ] `pnpm turbo run type-check lint test`
- [ ] `pnpm turbo run build`
- [ ] `pnpm run security:routes`
- [ ] (If `apps/analysis` changed) `ruff check . && mypy app/ && pytest --cov=app`

## Test evidence

<!-- Paste test output, new test names added, coverage delta, or a link
     to a Playwright preview run. -->

## Observability impact

<!-- Does this change add/remove log lines? Introduce a new Sentry event
     category? Change an SLI? If "no impact", say so. -->

## Architecture & Forbidden Changes

Confirm none of the following were introduced (see `.github/copilot-instructions.md`):

- [ ] No browser code calls the analysis service or Supabase service-role APIs directly
- [ ] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
- [ ] No client component imports from `apps/web/src/lib/server/**`
- [ ] No `middleware.ts` added to act as a backend proxy
- [ ] No public Supabase Storage bucket for user content
- [ ] No edits to previously-committed `supabase/migrations/**` files
- [ ] No SQLite, second database, or new microservice introduced

## Affected Boundaries

Tick all that apply:

- [ ] Shared types (`packages/shared`)
- [ ] Supabase migration (`supabase/migrations/**`)
- [ ] Web Route Handler (`apps/web/src/app/api/**`)
- [ ] Server-only module (`apps/web/src/lib/server/**`)
- [ ] Analysis service contract (`apps/analysis/app/models/**`)
- [ ] Env vars / `.env.example`

If any boundary above is ticked, confirm contract symmetry across all sides
in the same PR (see `docs/playbooks/contract-safe-change-playbook.md`).

## Rollback

How do we revert this safely?

- [ ] Pure `git revert` is sufficient
- [ ] Requires migration rollback (describe below)
- [ ] Requires env var rollback (describe below)

```
<rollback notes>
```
