### PR TITLE
test(web): fix workspace-overview test stale after PR #91 + #103

### DIFF
--- a/apps/web/src/lib/server/__tests__/workspace-overview.test.ts
+++ b/apps/web/src/lib/server/__tests__/workspace-overview.test.ts
@@ -167,6 +167,9 @@ describe("getWorkspaceOverview", () => {
       primaryPlantId: "plant-new",
       primaryPlantName: "Blue Dream",
     });
+    // recentFindings intentionally excludes resolved findings so the
+    // visible list aligns with the openFindings count badge (see
+    // workspace-overview.ts: filter on !finding.resolved_at).
     expect(overview.recentFindings).toEqual([
       {
         createdAt: "2026-05-03T00:00:00Z",
@@ -176,15 +179,6 @@ describe("getWorkspaceOverview", () => {
         plantName: "Blue Dream",
         severity: "medium",
         title: "Magnesium deficiency",
-      },
-      {
-        createdAt: "2026-05-02T00:00:00Z",
-        growId: "grow-old",
-        id: "finding-resolved",
-        plantId: "plant-missing",
-        plantName: "Plant",
-        severity: "low",
-        title: "Resolved pest pressure",
       },
     ]);
   });


### PR DESCRIPTION
PR #91 changed getWorkspaceOverview to filter out resolved findings (correctly aligning the recent-findings list with the openFindings badge), but the test added concurrently in PR #103 still expected both. Both PRs were green individually; the combined merge broke main CI. This updates the test to match the new behavior.

Fixes red CI on main (commit c06b401).