### PR TITLE
fix(web): keep dashboard usable when a workspace query fails

### DIFF
--- a/apps/web/src/lib/server/__tests__/workspace-overview.test.ts
+++ b/apps/web/src/lib/server/__tests__/workspace-overview.test.ts
@@ -183,17 +183,84 @@ describe("getWorkspaceOverview", () => {
     ]);
   });
 
-  it("throws a stable error when a dashboard query fails", async () => {
+  it("degrades the failing source to empty and still returns the other sources", async () => {
+    // A single Supabase query failure (missing table, RLS denial, transient
+    // network blip) must not take down the whole dashboard. The failing
+    // source contributes empty data and the rest of the overview still
+    // renders, with the failure surfaced via console.error logging.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
     const { client } = makeSupabaseMock({
-      grows: { data: [], error: null },
+      grows: {
+        data: [
+          {
+            id: "grow-new",
+            light_type: "LED",
+            medium: "coco",
+            name: "Flower tent",
+            stage: "flower",
+            start_date: "2026-04-01",
+            updated_at: "2026-05-01T00:00:00Z",
+          },
+        ],
+        error: null,
+      },
       plant_findings: { data: [], error: null },
       plant_images: { data: null, error: { message: "storage table down" } },
-      plants: { data: [], error: null },
+      plants: {
+        data: [
+          {
+            grow_id: "grow-new",
+            id: "plant-new",
+            name: "Blue Dream",
+            updated_at: "2026-05-05T00:00:00Z",
+          },
+        ],
+        error: null,
+      },
     });
     createSupabaseServerClient.mockResolvedValue(client);
 
-    await expect(getWorkspaceOverview()).rejects.toThrow(
-      "Failed to load images: storage table down",
+    const overview = await getWorkspaceOverview();
+
+    expect(overview.totals).toEqual({ grows: 1, images: 0, plants: 1 });
+    expect(overview.recentActivity.lastCaptureAt).toBeNull();
+    expect(overview.grows[0]).toMatchObject({
+      id: "grow-new",
+      imageCount: 0,
+      plantCount: 1,
+    });
+    expect(consoleError).toHaveBeenCalled();
+    const logged = consoleError.mock.calls
+      .map(([line]) => String(line))
+      .join("\n");
+    expect(logged).toContain("workspace overview query failed");
+    expect(logged).toContain("storage table down");
+    expect(logged).toContain("plant_images");
+
+    consoleError.mockRestore();
+  });
+
+  it("returns an empty overview and logs when client construction fails", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    createSupabaseServerClient.mockRejectedValue(new Error("cookies blocked"));
+
+    const overview = await getWorkspaceOverview();
+
+    expect(overview).toMatchObject({
+      grows: [],
+      openFindings: 0,
+      totals: { grows: 0, images: 0, plants: 0 },
+    });
+    expect(consoleError).toHaveBeenCalled();
+    expect(String(consoleError.mock.calls[0]?.[0])).toContain(
+      "workspace overview client init failed",
     );
+
+    consoleError.mockRestore();
   });
 });

--- a/apps/web/src/lib/server/workspace-overview.ts
+++ b/apps/web/src/lib/server/workspace-overview.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { createSupabaseServerClient } from "./auth";
+import { logServerEvent } from "./request-id";
 
 type GrowRow = {
   id: string;
@@ -107,10 +108,24 @@ export async function getWorkspaceOverview(): Promise<WorkspaceOverview> {
     return EMPTY_WORKSPACE_OVERVIEW;
   }
 
-  const supabase = await createSupabaseServerClient();
+  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  try {
+    supabase = await createSupabaseServerClient();
+  } catch (err) {
+    // Auth/cookie/env failure — log and render an empty board rather than
+    // throwing the user into the global error boundary. Reference codes
+    // surfaced by the boundary aren't actionable for this case.
+    logServerEvent("error", "workspace overview client init failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return EMPTY_WORKSPACE_OVERVIEW;
+  }
 
-  const [growsResult, plantsResult, imagesResult, findingsResult] =
-    await Promise.all([
+  // Run all four queries independently so a missing table, RLS denial, or
+  // transient network blip on one source degrades that source to "empty"
+  // instead of taking down the entire dashboard view.
+  const [growsSettled, plantsSettled, imagesSettled, findingsSettled] =
+    await Promise.allSettled([
       supabase
         .from("grows")
         .select("id,name,stage,medium,light_type,start_date,updated_at")
@@ -133,23 +148,37 @@ export async function getWorkspaceOverview(): Promise<WorkspaceOverview> {
         .limit(200),
     ]);
 
-  if (growsResult.error) {
-    throw new Error(`Failed to load grows: ${growsResult.error.message}`);
-  }
-  if (plantsResult.error) {
-    throw new Error(`Failed to load plants: ${plantsResult.error.message}`);
-  }
-  if (imagesResult.error) {
-    throw new Error(`Failed to load images: ${imagesResult.error.message}`);
-  }
-  if (findingsResult.error) {
-    throw new Error(`Failed to load findings: ${findingsResult.error.message}`);
+  function unwrap<T>(
+    label: string,
+    settled: PromiseSettledResult<{
+      data: T[] | null;
+      error: { message: string } | null;
+    }>,
+  ): T[] {
+    if (settled.status === "rejected") {
+      logServerEvent("error", "workspace overview query rejected", {
+        source: label,
+        error:
+          settled.reason instanceof Error
+            ? settled.reason.message
+            : String(settled.reason),
+      });
+      return [];
+    }
+    if (settled.value.error) {
+      logServerEvent("error", "workspace overview query failed", {
+        source: label,
+        error: settled.value.error.message,
+      });
+      return [];
+    }
+    return settled.value.data ?? [];
   }
 
-  const grows = (growsResult.data ?? []) as GrowRow[];
-  const plants = (plantsResult.data ?? []) as PlantRow[];
-  const images = (imagesResult.data ?? []) as ImageRow[];
-  const findings = (findingsResult.data ?? []) as FindingRow[];
+  const grows = unwrap<GrowRow>("grows", growsSettled);
+  const plants = unwrap<PlantRow>("plants", plantsSettled);
+  const images = unwrap<ImageRow>("plant_images", imagesSettled);
+  const findings = unwrap<FindingRow>("plant_findings", findingsSettled);
 
   const plantsByGrow = new Map<string, PlantRow[]>();
   const imagesByGrow = new Map<string, ImageRow[]>();


### PR DESCRIPTION
Resilient dashboard overview - fixes the WORKSPACE ERROR boundary that fired when any single Supabase source (grows/plants/plant_images/plant_findings) was unavailable. Switches to Promise.allSettled with per-source logging, plus a guard around client construction. Tests updated.

Underlying root cause (likely missing table or RLS denial on plant_images / plant_findings in production) should be investigated separately via the new server logs.