### PR TITLE
chore(web): make plant pages and workspace lists fail soft

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { AppShell } from "@/components/app-shell";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { getCurrentProfile } from "@/lib/server/profile";
+import { logServerEvent } from "@/lib/server/request-id";
 
 // Every page under (app) reads the authenticated user via getCurrentProfile.
 // Mark the group dynamic so `next build` doesn't try to statically prerender
@@ -21,7 +22,9 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     // If auth/db is unreachable we can't safely render the authenticated
     // shell. Bounce the user back to /auth where they'll see a friendly
     // status message instead of a generic Next.js error screen.
-    console.error("[app-layout] failed to load profile:", err);
+    logServerEvent("error", "app layout profile load failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
     redirect(
       "/auth?error=" +
         encodeURIComponent(

--- a/apps/web/src/app/(app)/plants/[plantId]/page.tsx
+++ b/apps/web/src/app/(app)/plants/[plantId]/page.tsx
@@ -34,6 +34,12 @@ interface Props {
   params: Promise<{ plantId: string }>;
 }
 
+// Plant IDs are persisted as Postgres UUIDs. Reject malformed inputs at the
+// edge so we don't waste a Supabase round trip (and surface a clean 404
+// instead of a generic error boundary on accidental URL typos).
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 function formatDateTime(value: string) {
   return new Intl.DateTimeFormat("en-US", {
     month: "short",
@@ -83,14 +89,20 @@ function buildPlantActionItems(params: {
 
 export default async function PlantPage({ params }: Props) {
   const { plantId } = await params;
+  if (!UUID_RE.test(plantId)) {
+    notFound();
+  }
   const context = await getAuthorizedPlantContext(plantId);
 
   if (!context) {
     notFound();
   }
 
-  const timeline = await getPlantTimeline(plantId);
-  const latestAnalysis = await getLatestPlantAnalysis(plantId);
+  // Timeline + latest analysis are independent reads — fetch in parallel.
+  const [timeline, latestAnalysis] = await Promise.all([
+    getPlantTimeline(plantId),
+    getLatestPlantAnalysis(plantId),
+  ]);
   const shortId = context.plantId.slice(0, 8).toUpperCase();
   const imageItems =
     timeline?.items.filter((item) => item.type === "image") ?? [];

--- a/apps/web/src/lib/server/__tests__/workspace-records.test.ts
+++ b/apps/web/src/lib/server/__tests__/workspace-records.test.ts
@@ -139,15 +139,42 @@ describe("workspace-records", () => {
     ]);
   });
 
-  it("throws a stable grow-loading error when Supabase returns an error", async () => {
+  it("degrades to an empty grow list and logs when Supabase returns an error", async () => {
+    // Resilience contract: a single Supabase failure should NOT crash the
+    // calling page. Returning [] keeps list views renderable; the failure
+    // is captured via console.error (logServerEvent) for diagnosis.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
     const { client } = makeSupabaseMock({
       data: null,
       error: { message: "database unavailable" },
     });
     createSupabaseServerClient.mockResolvedValue(client);
 
-    await expect(listAccessibleGrows()).rejects.toThrow(
-      "Failed to load grows: database unavailable",
+    await expect(listAccessibleGrows()).resolves.toEqual([]);
+    expect(consoleError).toHaveBeenCalled();
+    const logged = consoleError.mock.calls
+      .map(([line]) => String(line))
+      .join("\n");
+    expect(logged).toContain("list grows query failed");
+    expect(logged).toContain("database unavailable");
+
+    consoleError.mockRestore();
+  });
+
+  it("degrades to an empty plant list and logs when client init throws", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    createSupabaseServerClient.mockRejectedValue(new Error("cookies blocked"));
+
+    await expect(listAccessiblePlants()).resolves.toEqual([]);
+    expect(consoleError).toHaveBeenCalled();
+    expect(String(consoleError.mock.calls[0]?.[0])).toContain(
+      "list plants client init failed",
     );
+
+    consoleError.mockRestore();
   });
 });

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -203,9 +203,13 @@ export async function getLatestPlantAnalysis(
     .maybeSingle();
 
   if (analysisError) {
-    throw new Error(
-      `Failed to fetch latest plant analysis: ${analysisError.message}`,
-    );
+    // Degrade to "no analysis yet" rather than crashing the plant detail
+    // page. The underlying error is captured for diagnosis via server logs.
+    logServerEvent("error", "latest plant analysis query failed", {
+      plantId: context.plantId,
+      error: analysisError.message,
+    });
+    return null;
   }
 
   const persisted = analysisRow as PlantAnalysisRow | null;
@@ -220,9 +224,12 @@ export async function getLatestPlantAnalysis(
     .order("created_at", { ascending: true });
 
   if (findingError) {
-    throw new Error(
-      `Failed to fetch analysis findings: ${findingError.message}`,
-    );
+    logServerEvent("error", "latest plant analysis findings query failed", {
+      plantId: context.plantId,
+      imageId: persisted.image_id,
+      error: findingError.message,
+    });
+    return mapAnalysisFromRow(persisted, []);
   }
 
   const findings = ((findingRows ?? []) as PlantFindingRow[]).map((row) => {
@@ -248,8 +255,11 @@ export async function getPlantTimeline(plantId: string) {
   }
 
   const db = getDbClient();
-  const [imagesResult, observationsResult, analysesResult, findingsResult] =
-    await Promise.all([
+  // Run the four reads independently so a missing table, RLS denial, or
+  // transient blip on one source degrades just that source to empty
+  // instead of taking down the entire plant detail view.
+  const [imagesSettled, observationsSettled, analysesSettled, findingsSettled] =
+    await Promise.allSettled([
       db
         .from("plant_images")
         .select("*")
@@ -272,29 +282,51 @@ export async function getPlantTimeline(plantId: string) {
         .order("created_at", { ascending: true }),
     ]);
 
-  if (imagesResult.error) {
-    throw new Error(
-      `Failed to fetch plant images: ${imagesResult.error.message}`,
-    );
-  }
-  if (observationsResult.error) {
-    throw new Error(
-      `Failed to fetch plant observations: ${observationsResult.error.message}`,
-    );
-  }
-  if (analysesResult.error) {
-    throw new Error(
-      `Failed to fetch plant analyses: ${analysesResult.error.message}`,
-    );
-  }
-  if (findingsResult.error) {
-    throw new Error(
-      `Failed to fetch plant findings: ${findingsResult.error.message}`,
-    );
+  function unwrap<T>(
+    label: string,
+    settled: PromiseSettledResult<{
+      data: T[] | null;
+      error: { message: string } | null;
+    }>,
+  ): T[] {
+    if (settled.status === "rejected") {
+      logServerEvent("error", "plant timeline query rejected", {
+        plantId: context!.plantId,
+        source: label,
+        error:
+          settled.reason instanceof Error
+            ? settled.reason.message
+            : String(settled.reason),
+      });
+      return [];
+    }
+    if (settled.value.error) {
+      logServerEvent("error", "plant timeline query failed", {
+        plantId: context!.plantId,
+        source: label,
+        error: settled.value.error.message,
+      });
+      return [];
+    }
+    return settled.value.data ?? [];
   }
 
+  const imageRows = unwrap<PlantImageRow>("plant_images", imagesSettled);
+  const observationRows = unwrap<PlantObservationRow>(
+    "plant_observations",
+    observationsSettled,
+  );
+  const analysisRows = unwrap<PlantAnalysisRow>(
+    "plant_analyses",
+    analysesSettled,
+  );
+  const findingRows = unwrap<PlantFindingRow>(
+    "plant_findings",
+    findingsSettled,
+  );
+
   const findingsByImage = new Map<string, AnalysisFinding[]>();
-  for (const row of (findingsResult.data ?? []) as PlantFindingRow[]) {
+  for (const row of findingRows) {
     if (!row.image_id) {
       continue;
     }
@@ -313,30 +345,26 @@ export async function getPlantTimeline(plantId: string) {
   }
 
   const analysesByImage = new Map<string, AnalysisResponse>();
-  for (const row of (analysesResult.data ?? []) as PlantAnalysisRow[]) {
+  for (const row of analysisRows) {
     analysesByImage.set(
       row.image_id,
       mapAnalysisFromRow(row, findingsByImage.get(row.image_id) ?? []),
     );
   }
 
-  const imageItems = ((imagesResult.data ?? []) as PlantImageRow[]).map(
-    (row) => ({
-      type: "image" as const,
-      id: row.id,
-      createdAt: row.created_at,
-      takenAt: row.taken_at ?? row.created_at,
-      source: row.source,
-      notes: row.notes ?? undefined,
-      storagePath: row.storage_path,
-      analysis: analysesByImage.get(row.id) ?? null,
-      findings: findingsByImage.get(row.id) ?? [],
-    }),
-  );
+  const imageItems = imageRows.map((row) => ({
+    type: "image" as const,
+    id: row.id,
+    createdAt: row.created_at,
+    takenAt: row.taken_at ?? row.created_at,
+    source: row.source,
+    notes: row.notes ?? undefined,
+    storagePath: row.storage_path,
+    analysis: analysesByImage.get(row.id) ?? null,
+    findings: findingsByImage.get(row.id) ?? [],
+  }));
 
-  const observationItems = (
-    (observationsResult.data ?? []) as PlantObservationRow[]
-  ).map((row) => ({
+  const observationItems = observationRows.map((row) => ({
     type: "observation" as const,
     id: row.id,
     observedAt: row.observed_at,

--- a/apps/web/src/lib/server/workspace-records.ts
+++ b/apps/web/src/lib/server/workspace-records.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { createSupabaseServerClient } from "./auth";
+import { logServerEvent } from "./request-id";
 
 type GrowRow = {
   id: string;
@@ -65,7 +66,16 @@ export async function listAccessibleGrows(): Promise<GrowRecord[]> {
     return [];
   }
 
-  const supabase = await createSupabaseServerClient();
+  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  try {
+    supabase = await createSupabaseServerClient();
+  } catch (err) {
+    logServerEvent("error", "list grows client init failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+
   const { data, error } = await supabase
     .from("grows")
     .select("id,name,stage,medium,light_type,start_date,updated_at")
@@ -73,7 +83,12 @@ export async function listAccessibleGrows(): Promise<GrowRecord[]> {
     .limit(100);
 
   if (error) {
-    throw new Error(`Failed to load grows: ${error.message}`);
+    // Degrade to an empty list so list pages remain renderable. The
+    // underlying issue is captured in server logs for diagnosis.
+    logServerEvent("error", "list grows query failed", {
+      error: error.message,
+    });
+    return [];
   }
 
   return ((data ?? []) as GrowRow[]).map((grow) => ({
@@ -92,7 +107,16 @@ export async function listAccessiblePlants(): Promise<PlantRecord[]> {
     return [];
   }
 
-  const supabase = await createSupabaseServerClient();
+  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  try {
+    supabase = await createSupabaseServerClient();
+  } catch (err) {
+    logServerEvent("error", "list plants client init failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+
   const { data, error } = await supabase
     .from("plants")
     .select(
@@ -102,7 +126,10 @@ export async function listAccessiblePlants(): Promise<PlantRecord[]> {
     .limit(200);
 
   if (error) {
-    throw new Error(`Failed to load plants: ${error.message}`);
+    logServerEvent("error", "list plants query failed", {
+      error: error.message,
+    });
+    return [];
   }
 
   return ((data ?? []) as PlantRow[]).map((plant) => ({


### PR DESCRIPTION
Follow-up to #108 (dashboard resilience). Audit pass over every authenticated page + shared server helper, applying the same pattern: a single Supabase failure should never take down a whole user-facing view.

**Helpers**
- workspace-records: listAccessibleGrows/listAccessiblePlants log + return [] on failure
- plants: getLatestPlantAnalysis logs + returns null; getPlantTimeline uses Promise.allSettled with per-source unwrap

**Pages**
- plants/[plantId]: UUID validation on plantId param + parallelize timeline+analysis after auth context
- (app)/layout: console.error -> logServerEvent

**Tests**
- workspace-records resilience cases (query error + client-init throw)

All local checks green: 183 tests, type-check, lint, build.