### PR TITLE
fix(web): wrap /api/chat in top-level try/catch so failures return a JSON 500

### DIFF
--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -161,7 +161,7 @@ describe("POST /api/chat", () => {
     });
   });
 
-  it("surfaces a SANITISED error to the client when the upstream fails", async () => {
+  it("surfaces a sanitized error to the client when the upstream fails", async () => {
     getServerSession.mockResolvedValue({ user: { id: "u1" } });
     streamMock.mockReturnValue(failingStream());
 
@@ -202,8 +202,11 @@ describe("POST /api/chat", () => {
     expect(streamMock).not.toHaveBeenCalled();
   });
 
-  it("returns a structured JSON 500 when the OpenAI client throws synchronously", async () => {
-    // Mirrors a missing OPENAI_API_KEY: getAIClient() throws synchronously.
+  it("returns a structured JSON 500 when openai.chat.completions.stream throws synchronously", async () => {
+    // Mirrors an openai SDK init failure (e.g. an upstream constructor
+    // throwing on auth/setup). The route's top-level catch must convert
+    // this into a parseable envelope; the underlying error text must not
+    // leak to the client.
     getServerSession.mockResolvedValue({ user: { id: "u1" } });
     streamMock.mockImplementationOnce(() => {
       throw new Error("Missing OPENAI_API_KEY");

--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -180,4 +180,40 @@ describe("POST /api/chat", () => {
     expect(message).toMatch(/Chat stream failed \(request /);
     expect(message).not.toMatch(/secret context here/);
   });
+
+  it("returns a structured JSON 500 when getServerSession throws synchronously", async () => {
+    // Mirrors what happens in production when Supabase env is misconfigured
+    // or the auth service is unreachable. The client must receive a
+    // parseable JSON body with a requestId for support correlation — not
+    // a bare 500 (which is what surfaced as "Request failed with 500.").
+    (getServerSession as Mock).mockRejectedValueOnce(
+      new Error("supabase env not set"),
+    );
+
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(500);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = (await res.json()) as { error: string; requestId: string };
+    expect(body.error).toMatch(/temporarily unavailable/i);
+    expect(body.requestId).toBeTruthy();
+    // The underlying error message must NOT leak to the client.
+    expect(JSON.stringify(body)).not.toMatch(/supabase env not set/);
+    // The upstream OpenAI client must never be touched.
+    expect(streamMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured JSON 500 when the OpenAI client throws synchronously", async () => {
+    // Mirrors a missing OPENAI_API_KEY: getAIClient() throws synchronously.
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementationOnce(() => {
+      throw new Error("Missing OPENAI_API_KEY");
+    });
+
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(500);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = (await res.json()) as { error: string; requestId: string };
+    expect(body.error).toMatch(/temporarily unavailable/i);
+    expect(JSON.stringify(body)).not.toMatch(/OPENAI_API_KEY/);
+  });
 });

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -178,7 +178,7 @@ export async function POST(request: NextRequest) {
             logServerEvent("error", "chat stream failed", {
               requestId,
               userId,
-              error: err instanceof Error ? err.message : "unknown_error",
+              error: err instanceof Error ? err.message : String(err),
             });
           }
           controller.error(
@@ -217,7 +217,7 @@ export async function POST(request: NextRequest) {
     logServerEvent("error", "chat request failed before stream", {
       requestId,
       userId,
-      error: err instanceof Error ? err.message : "unknown_error",
+      error: err instanceof Error ? err.message : String(err),
       stack: err instanceof Error ? err.stack : undefined,
     });
     return attachRequestId(

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -19,16 +19,26 @@ const MAX_GROW_ID_LENGTH = 64;
 // Accepts a threadId + message, streams OpenAI response back.
 // Context is injected server-side from the user's grow data.
 export async function POST(request: NextRequest) {
-  const requestId = getOrCreateRequestId(request);
+  // Resolve a request id up front but fall back to a fixed sentinel if even
+  // that fails (e.g. a runtime without crypto.randomUUID). This way the
+  // top-level catch below can still emit a structured envelope rather than
+  // re-throwing into Next's default error handler.
+  let requestId: string;
+  try {
+    requestId = getOrCreateRequestId(request);
+  } catch {
+    requestId = "unknown";
+  }
 
   // Single top-level safety net so any synchronous throw before we hand
-  // back the streaming response (e.g. missing OPENAI_API_KEY in
-  // getAIClient(), a Supabase auth blow-up in getServerSession(), or an
-  // openai SDK constructor failure) lands as a structured JSON 500
-  // instead of a bare Next.js error page. Without this the chat UI shows
-  // "Request failed with 500." with no further detail because there's no
-  // parseable body. Errors raised AFTER we return the ReadableStream are
-  // handled inside the stream itself (see start(controller) below).
+  // back the streaming response (a Supabase auth blow-up in
+  // getServerSession(), a missing OPENAI_API_KEY in getAIClient(), or an
+  // openai SDK constructor failure on the .stream() call) lands as a
+  // structured JSON 500 instead of a bare Next.js error page. Without
+  // this the chat UI shows "Request failed with 500." with no further
+  // detail because there's no parseable body. Errors raised AFTER we
+  // return the ReadableStream are handled inside the stream itself (see
+  // start(controller) below).
   let userId: string | null = null;
   try {
     const session = await getServerSession();
@@ -146,7 +156,7 @@ export async function POST(request: NextRequest) {
     });
 
     // Stream the response. If OpenAI errors mid-stream we surface a
-    // SANITISED error to the ReadableStream consumer (just the requestId
+    // sanitized error to the ReadableStream consumer (just the requestId
     // for support correlation) — never the upstream wording, which can
     // leak internal detail and depend on third-party message text.
     const readable = new ReadableStream({

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -20,167 +20,206 @@ const MAX_GROW_ID_LENGTH = 64;
 // Context is injected server-side from the user's grow data.
 export async function POST(request: NextRequest) {
   const requestId = getOrCreateRequestId(request);
-  const session = await getServerSession();
-  if (!session) {
-    return attachRequestId(
-      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
-      requestId,
-    );
-  }
 
-  // Reuse the user id we already have from the session — calling
-  // getServerUser() here adds a redundant Supabase round-trip that can
-  // fail independently and 500 chat for users with valid sessions.
-  const userId = session.user?.id ?? null;
-
-  // Namespace the limiter key so chat doesn't share a quota with other
-  // routes (uploads, analyze) that use rateLimitKeyFromRequest.
-  const rate = await rateLimit({
-    key: `chat:${rateLimitKeyFromRequest(request, userId)}`,
-    limit: 20,
-    windowMs: 60_000,
-  });
-  if (!rate.ok) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Too many chat requests. Try again shortly.", requestId },
-        { status: 429 },
-      ),
-      requestId,
-    );
-  }
-
-  let body: { threadId?: string; message?: string; growId?: string };
+  // Single top-level safety net so any synchronous throw before we hand
+  // back the streaming response (e.g. missing OPENAI_API_KEY in
+  // getAIClient(), a Supabase auth blow-up in getServerSession(), or an
+  // openai SDK constructor failure) lands as a structured JSON 500
+  // instead of a bare Next.js error page. Without this the chat UI shows
+  // "Request failed with 500." with no further detail because there's no
+  // parseable body. Errors raised AFTER we return the ReadableStream are
+  // handled inside the stream itself (see start(controller) below).
+  let userId: string | null = null;
   try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Request body must be valid JSON.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
+    const session = await getServerSession();
+    if (!session) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Unauthorized", requestId },
+          { status: 401 },
+        ),
+        requestId,
+      );
+    }
 
-  const message = typeof body?.message === "string" ? body.message.trim() : "";
-  if (!message) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "message is required", requestId },
-        { status: 400 },
+    // Reuse the user id we already have from the session — calling
+    // getServerUser() here adds a redundant Supabase round-trip that can
+    // fail independently and 500 chat for users with valid sessions.
+    userId = session.user?.id ?? null;
+
+    // Namespace the limiter key so chat doesn't share a quota with other
+    // routes (uploads, analyze) that use rateLimitKeyFromRequest.
+    const rate = await rateLimit({
+      key: `chat:${rateLimitKeyFromRequest(request, userId)}`,
+      limit: 20,
+      windowMs: 60_000,
+    });
+    if (!rate.ok) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Too many chat requests. Try again shortly.", requestId },
+          { status: 429 },
+        ),
+        requestId,
+      );
+    }
+
+    let body: { threadId?: string; message?: string; growId?: string };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Request body must be valid JSON.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+
+    const message =
+      typeof body?.message === "string" ? body.message.trim() : "";
+    if (!message) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "message is required", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`,
+            requestId,
+          },
+          { status: 413 },
+        ),
+        requestId,
+      );
+    }
+    if (
+      typeof body.threadId === "string" &&
+      body.threadId.length > MAX_THREAD_ID_LENGTH
+    ) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "threadId is too long.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    if (
+      typeof body.growId === "string" &&
+      body.growId.length > MAX_GROW_ID_LENGTH
+    ) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "growId is too long.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+
+    const openai = getAIClient();
+
+    // TODO: Load grow context from DB to inject as system context
+    // TODO: Persist ChatThread + ChatMessage rows via Supabase service role
+
+    const stream = openai.chat.completions.stream({
+      model: "gpt-4o",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are PhenoSage, a professional cannabis grow advisor. " +
+            "You have access to the user's grow data and plant history. " +
+            "Give precise, evidence-based advice. Be concise and professional.",
+        },
+        { role: "user", content: message },
+      ],
+      stream: true,
+    });
+
+    // Stream the response. If OpenAI errors mid-stream we surface a
+    // SANITISED error to the ReadableStream consumer (just the requestId
+    // for support correlation) — never the upstream wording, which can
+    // leak internal detail and depend on third-party message text.
+    const readable = new ReadableStream({
+      async start(controller) {
+        try {
+          for await (const chunk of stream) {
+            const delta = chunk.choices[0]?.delta?.content;
+            if (delta) {
+              controller.enqueue(new TextEncoder().encode(delta));
+            }
+          }
+          controller.close();
+        } catch (err) {
+          const isAbort = err instanceof Error && err.name === "AbortError";
+          if (!isAbort) {
+            // User-initiated cancellations are not failures — only log when
+            // something actually went wrong upstream. Logging AbortError
+            // creates false-positive noise in monitoring.
+            logServerEvent("error", "chat stream failed", {
+              requestId,
+              userId,
+              error: err instanceof Error ? err.message : "unknown_error",
+            });
+          }
+          controller.error(
+            new Error(
+              `Chat stream failed (request ${requestId}). Please try again.`,
+            ),
+          );
+        }
+      },
+      cancel() {
+        // Browser disconnected (user navigated away or hit Stop). Best-effort
+        // upstream abort so we stop billing tokens we'll never deliver.
+        try {
+          (stream as { abort?: () => void }).abort?.();
+        } catch {
+          /* ignore */
+        }
+      },
+    });
+
+    return new NextResponse(readable, {
+      headers: withRequestIdHeader(
+        {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Transfer-Encoding": "chunked",
+        },
+        requestId,
       ),
+    });
+  } catch (err) {
+    // Log the underlying cause for ops; surface only a generic message +
+    // requestId to the client so we never leak server-side detail (which
+    // could include the OpenAI API key, Supabase URL, env-misconfig hints,
+    // or stack frames). Operators can correlate the requestId between
+    // this log line and the user's browser console.
+    logServerEvent("error", "chat request failed before stream", {
       requestId,
-    );
-  }
-  if (message.length > MAX_MESSAGE_LENGTH) {
+      userId,
+      error: err instanceof Error ? err.message : "unknown_error",
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return attachRequestId(
       NextResponse.json(
         {
-          error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`,
+          error:
+            "Chat is temporarily unavailable. Please try again in a moment.",
           requestId,
         },
-        { status: 413 },
+        { status: 500 },
       ),
       requestId,
     );
   }
-  if (
-    typeof body.threadId === "string" &&
-    body.threadId.length > MAX_THREAD_ID_LENGTH
-  ) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "threadId is too long.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-  if (
-    typeof body.growId === "string" &&
-    body.growId.length > MAX_GROW_ID_LENGTH
-  ) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "growId is too long.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-
-  const openai = getAIClient();
-
-  // TODO: Load grow context from DB to inject as system context
-  // TODO: Persist ChatThread + ChatMessage rows via Supabase service role
-
-  const stream = openai.chat.completions.stream({
-    model: "gpt-4o",
-    messages: [
-      {
-        role: "system",
-        content:
-          "You are PhenoSage, a professional cannabis grow advisor. " +
-          "You have access to the user's grow data and plant history. " +
-          "Give precise, evidence-based advice. Be concise and professional.",
-      },
-      { role: "user", content: message },
-    ],
-    stream: true,
-  });
-
-  // Stream the response. If OpenAI errors mid-stream we surface a
-  // SANITISED error to the ReadableStream consumer (just the requestId
-  // for support correlation) — never the upstream wording, which can
-  // leak internal detail and depend on third-party message text.
-  const readable = new ReadableStream({
-    async start(controller) {
-      try {
-        for await (const chunk of stream) {
-          const delta = chunk.choices[0]?.delta?.content;
-          if (delta) {
-            controller.enqueue(new TextEncoder().encode(delta));
-          }
-        }
-        controller.close();
-      } catch (err) {
-        const isAbort = err instanceof Error && err.name === "AbortError";
-        if (!isAbort) {
-          // User-initiated cancellations are not failures — only log when
-          // something actually went wrong upstream. Logging AbortError
-          // creates false-positive noise in monitoring.
-          logServerEvent("error", "chat stream failed", {
-            requestId,
-            userId,
-            error: err instanceof Error ? err.message : "unknown_error",
-          });
-        }
-        controller.error(
-          new Error(
-            `Chat stream failed (request ${requestId}). Please try again.`,
-          ),
-        );
-      }
-    },
-    cancel() {
-      // Browser disconnected (user navigated away or hit Stop). Best-effort
-      // upstream abort so we stop billing tokens we'll never deliver.
-      try {
-        (stream as { abort?: () => void }).abort?.();
-      } catch {
-        /* ignore */
-      }
-    },
-  });
-
-  return new NextResponse(readable, {
-    headers: withRequestIdHeader(
-      {
-        "Content-Type": "text/plain; charset=utf-8",
-        "Transfer-Encoding": "chunked",
-      },
-      requestId,
-    ),
-  });
 }


### PR DESCRIPTION
## Outcome

User-reported: the chat UI on production shows **"Request failed with 500."** when sending a message, with no further detail in the UI or in Vercel logs.

## Root cause

The chat route does six things that can throw synchronously before it returns the streaming `NextResponse`:

- `getOrCreateRequestId(request)`
- `await getServerSession()` (Supabase env + reachability)
- `await rateLimit(...)` (became `async` in #116)
- `await request.json()` (already in its own try/catch)
- `getAIClient()` — **throws when `OPENAI_API_KEY` is missing**
- `openai.chat.completions.stream(...)` — openai 6 SDK constructor

None of those throws had a handler. Any one of them produced a bare 500 with no parseable body — which is exactly what the user reported. Vercel runtime logs confirm a `/api/chat 500` around the same window but the response body was empty; the client UI's fallback `Request failed with ${res.status}.` message took over.

## Fix

Single top-level `try/catch` around the prep phase. On error:

- `logServerEvent("error", "chat request failed before stream", {requestId, userId, error, stack})` — full debug context server-side so the **next** failure is diagnosable in Vercel logs.
- Return a JSON envelope `{ error, requestId }` with status 500 and the `x-request-id` header so the client UI can display a parseable message and operators can correlate.

The in-stream `start(controller)` catch is unchanged — it handles mid-stream OpenAI failures, which fire **after** we return the `NextResponse`, so it lives outside the new try.

## Scope

- [x] Single concern; no drive-by refactors
- [x] Affected paths listed below

```
apps/web/src/app/api/chat/route.ts                    (try/catch wrap + structured 500)
apps/web/src/app/api/chat/__tests__/route.test.ts     (2 new error-envelope cases)
```

## Validation

- [x] `pnpm --filter web exec vitest run src/app/api/chat` — **11/11 pass** (was 9, +2 new)
- [x] `pnpm turbo run type-check lint test` — 306 web tests pass
- [x] `pnpm run validate` — clean
- [x] `pnpm run security:routes` — 9/9 route files clean

## Architecture & Forbidden Changes

- [x] No browser code calls analysis or Supabase service-role APIs directly
- [x] No server-only secrets leaked to client modules
- [x] No client component imports from `apps/web/src/lib/server/**`
- [x] No middleware added
- [x] No public Supabase Storage bucket
- [x] No migration edits

## Affected Boundaries

- [x] Web Route Handler — error envelope shape change for the failure path (was bare 500 / empty body; now `{ error, requestId }` JSON). Forward-compatible for the client which already parses `data.error`.

## Rollback

- [x] Pure `git revert` is sufficient

## Notes

This is a **safety-net fix**, not a root-cause fix for the specific 500 the user hit. Vercel runtime log queries timed out before surfacing the underlying error message, so I don't yet know whether the prod failure was Supabase auth, missing `OPENAI_API_KEY`, openai SDK init, or something else. Once this lands, the **next** occurrence will log the full stack server-side and the user will see a sensible message + a `requestId` they can include in a support report.

If the recurrence on the deployed app turns out to be missing `OPENAI_API_KEY` (the most likely candidate given the openai 4→6 upgrade in #107 and the dependency dance today), the fix is to verify Vercel project env vars in `Settings → Environment Variables` for production.

https://claude.ai/code/session_018H3GPNLbzDAAo9euffapiG

---
_Generated by [Claude Code](https://claude.ai/code/session_018H3GPNLbzDAAo9euffapiG)_