### PR TITLE
fix(web/dashboard): wire skip-link target and improve stat row responsiveness

### DIFF
--- a/apps/web/src/app/(app)/dashboard/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/dashboard/__tests__/page.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/server/profile", () => ({
+  getCurrentProfile: vi.fn(async () => ({
+    displayName: "Ada Lovelace",
+    email: "ada@example.com",
+    id: "user-1",
+  })),
+}));
+
+vi.mock("@/lib/server/workspace-overview", () => ({
+  getWorkspaceOverview: vi.fn(async () => ({
+    grows: [
+      {
+        id: "grow-1",
+        imageCount: 4,
+        lightType: "led",
+        medium: "soil",
+        name: "Tent A",
+        openFindingCount: 1,
+        plantCount: 2,
+        primaryPlantId: "plant-1",
+        primaryPlantName: "Blue Dream #1",
+        stage: "veg",
+        startDate: "2026-04-01T00:00:00Z",
+        updatedAt: "2026-05-10T12:00:00Z",
+      },
+    ],
+    openFindings: 1,
+    recentActivity: {
+      lastCaptureAt: "2026-05-10T12:00:00Z",
+      lastPlantUpdateAt: "2026-05-09T00:00:00Z",
+    },
+    recentFindings: [
+      {
+        createdAt: "2026-05-10T12:00:00Z",
+        growId: "grow-1",
+        id: "finding-1",
+        plantId: "plant-1",
+        plantName: "Blue Dream #1",
+        severity: "high" as const,
+        title: "Possible nitrogen deficiency",
+      },
+    ],
+    totals: { grows: 1, images: 4, plants: 2 },
+  })),
+}));
+
+import DashboardPage from "@/app/(app)/dashboard/page";
+
+async function renderPage() {
+  const ui = await DashboardPage();
+  render(ui);
+}
+
+describe("DashboardPage", () => {
+  it("renders the greeting with the operator's first name", async () => {
+    await renderPage();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /, Ada\.$/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('exposes <main id="main-content"> for the global SkipLink target', async () => {
+    await renderPage();
+    const main = document.querySelector("main#main-content");
+    expect(main).not.toBeNull();
+    expect(main?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("surfaces the workspace stats (grows, captures, findings)", async () => {
+    await renderPage();
+    expect(screen.getByText("Active grows")).toBeInTheDocument();
+    expect(screen.getByText("Capture history")).toBeInTheDocument();
+    expect(screen.getByText("Open watch items")).toBeInTheDocument();
+    expect(
+      screen.getByText("Possible nitrogen deficiency"),
+    ).toBeInTheDocument();
+  });
+
+  it("links the recent finding to the plant detail page", async () => {
+    await renderPage();
+    const reviewLink = screen.getByRole("link", { name: /review/i });
+    expect(reviewLink).toHaveAttribute("href", "/plants/plant-1");
+  });
+
+  it("offers the primary call-to-action links in the hero", async () => {
+    await renderPage();
+    expect(screen.getByRole("link", { name: /ask copilot/i })).toHaveAttribute(
+      "href",
+      "/assistant",
+    );
+    expect(screen.getByRole("link", { name: /new grow/i })).toHaveAttribute(
+      "href",
+      "/grows/new",
+    );
+  });
+
+  it("renders the empty-state copy when the workspace has no data", async () => {
+    const { getWorkspaceOverview } =
+      await import("@/lib/server/workspace-overview");
+    vi.mocked(getWorkspaceOverview).mockResolvedValueOnce({
+      grows: [],
+      openFindings: 0,
+      recentActivity: { lastCaptureAt: null, lastPlantUpdateAt: null },
+      recentFindings: [],
+      totals: { grows: 0, images: 0, plants: 0 },
+    });
+    await renderPage();
+    expect(screen.getByText("No recent activity")).toBeInTheDocument();
+    expect(screen.getByText("Grow registry still empty")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -76,7 +76,7 @@ export default async function DashboardPage() {
   const lastCapture = formatDateLabel(overview.recentActivity.lastCaptureAt);
 
   return (
-    <main className="app-page">
+    <main className="app-page outline-none" id="main-content" tabIndex={-1}>
       {/* ── Editorial header ─────────────────────────── */}
       <header className="workspace-hero">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
@@ -150,7 +150,7 @@ export default async function DashboardPage() {
       </Card>
 
       {/* ── Stat row ─────────────────────────────────── */}
-      <section className="grid gap-3.5 md:grid-cols-2 xl:grid-cols-4">
+      <section className="grid gap-3.5 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           detail={
             hasWorkspaceData


### PR DESCRIPTION
## Summary

Two focused improvements to the authenticated **Dashboard** page (/dashboard):

### 1. A11y bug — skip link was a no-op
The root layout renders `<SkipLink />` which targets `#main-content`, but the dashboard's `<main>` had no matching `id`. Keyboard users hitting the skip link landed on nothing. Added `id=""main-content"" tabIndex={-1}` to the dashboard `<main>` so the skip link now focuses the page content.

### 2. Responsive — stat row wasted space at lg
The 4-up stat row used `md:grid-cols-2 xl:grid-cols-4`. With the persistent sidebar showing from `lg` (1024px), that meant a cramped 2-column stat row across the entire 1024–1279px range. Changed to `sm:grid-cols-2 lg:grid-cols-4` so:
- `sm` (640px+): 2 cols (better than waiting until `md`)
- `lg` (1024px+): full 4 cols, matching where the sidebar appears

### 3. Test coverage
Added `apps/web/src/app/(app)/dashboard/__tests__/page.test.tsx` covering:
- Greeting renders with the operator's first name
- `<main id=""main-content"" tabindex=""-1"">` is exposed for the skip link
- Stat surfaces (Active grows / Capture history / Open watch items) render
- Recent finding link targets `/plants/{plantId}`
- Hero CTAs (`Ask copilot`, `New grow`) link to the right routes
- Empty-state copy renders when the workspace has no data

## Verification
- `pnpm lint` ✅
- `pnpm type-check` ✅
- `pnpm test` ✅ (329 tests, +6 new)
- `pnpm build` ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>