### PR TITLE
fix(chat): JSON 500 envelope + audit optimizations

### DIFF
--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -10,14 +10,9 @@ vi.mock("@/lib/server/auth", () => ({
   getServerSession: (...args: unknown[]) => getServerSession(...args),
 }));
 
+const getAIClient = vi.fn();
 vi.mock("@/lib/server/ai-client", () => ({
-  getAIClient: () => ({
-    chat: {
-      completions: {
-        stream: (...args: unknown[]) => streamMock(...args),
-      },
-    },
-  }),
+  getAIClient: (...args: unknown[]) => getAIClient(...args),
 }));
 
 vi.mock("@/lib/server/chat-context", () => ({
@@ -128,6 +123,13 @@ describe("POST /api/chat", () => {
     createThread.mockResolvedValue("thread_new");
     appendMessage.mockResolvedValue(undefined);
     touchThread.mockResolvedValue(undefined);
+    getAIClient.mockReturnValue({
+      chat: {
+        completions: {
+          stream: (...args: unknown[]) => streamMock(...args),
+        },
+      },
+    });
     __resetRateLimitStore();
   });
 
@@ -413,5 +415,47 @@ describe("POST /api/chat", () => {
     expect(streamMock).not.toHaveBeenCalled();
     expect(createThread).not.toHaveBeenCalled();
     expect(appendMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured JSON 500 (not a bare 500) when prep throws synchronously", async () => {
+    // Reproduces the production bug from PR #118 / the chat 500 in Vercel
+    // logs: the synchronous throw used to propagate out of the route and
+    // Next would render a bare 500 with an empty body, which the chat
+    // client could not parse. The top-level catch must envelope it.
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    const internalErrorText = "internal-env-var-missing";
+    createThread.mockImplementation(() => {
+      throw new Error(internalErrorText);
+    });
+
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toMatch(/application\/json/);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = (await res.json()) as { error?: string; requestId?: string };
+    expect(body.error).toMatch(/Chat request failed/);
+    expect(body.requestId).toBeTruthy();
+    // The internal cause must NEVER leak to the client envelope.
+    expect(body.error).not.toMatch(new RegExp(internalErrorText));
+    expect(streamMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a structured JSON 500 when getAIClient throws after persistence", async () => {
+    // appendMessage succeeds but getAIClient blows up (e.g. env var
+    // missing). Without the top-level catch this produced a bare 500 in
+    // production because the throw fired *after* appendMessage but
+    // *before* the ReadableStream was returned.
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    createThread.mockResolvedValue("thread_xyz");
+    const internalErrorText = "openai-client-init-failed";
+    getAIClient.mockImplementation(() => {
+      throw new Error(internalErrorText);
+    });
+
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error?: string };
+    expect(body.error).toMatch(/Chat request failed/);
+    expect(body.error).not.toMatch(new RegExp(internalErrorText));
   });
 });

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAIClient } from "@/lib/server/ai-client";
-import { getServerSession } from "@/lib/server/auth";
+import {
+  createSupabaseServerClient,
+  getServerSession,
+} from "@/lib/server/auth";
 import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
 import {
   attachRequestId,
@@ -53,318 +56,389 @@ function isIncomingMessage(v: unknown): v is IncomingMessage {
 }
 
 export async function POST(request: NextRequest) {
-  const requestId = getOrCreateRequestId(request);
-  const session = await getServerSession();
-  if (!session) {
-    return attachRequestId(
-      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
-      requestId,
-    );
-  }
-
-  const userId = session.user?.id ?? null;
-
-  const rate = await rateLimit({
-    key: `chat:${rateLimitKeyFromRequest(request, userId)}`,
-    limit: 20,
-    windowMs: 60_000,
-  });
-  if (!rate.ok) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Too many chat requests. Try again shortly.", requestId },
-        { status: 429 },
-      ),
-      requestId,
-    );
-  }
-
-  let body: {
-    threadId?: string;
-    message?: string;
-    growId?: string;
-    plantId?: string;
-    history?: unknown;
-  };
+  // Resolve a request id up front but fall back to a sentinel if even that
+  // fails — we want the top-level catch below to always be able to emit a
+  // structured envelope instead of re-throwing into Next's default error
+  // handler (which yields a bare 500 the chat UI can't parse).
+  let requestId: string;
   try {
-    body = (await request.json()) as typeof body;
+    requestId = getOrCreateRequestId(request);
   } catch {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Request body must be valid JSON.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
+    requestId = "unknown";
   }
 
-  const message = typeof body?.message === "string" ? body.message.trim() : "";
-  if (!message) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "message is required", requestId },
-        { status: 400 },
-      ),
+  // Single top-level safety net. Any synchronous throw or unhandled
+  // rejection before we hand back the streaming response (Supabase auth
+  // failure, missing env var in getAIClient / getDbClient, openai SDK
+  // constructor blow-up, Postgres write failure in chat-persistence, etc.)
+  // lands here as a structured JSON 500 with the requestId, never a bare
+  // 500 with an empty body. Errors *during* streaming are handled inside
+  // the ReadableStream's start(controller) below.
+  let userId: string | null = null;
+  let threadId: string | null = null;
+  try {
+    const session = await getServerSession();
+    if (!session) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Unauthorized", requestId },
+          { status: 401 },
+        ),
+        requestId,
+      );
+    }
+
+    userId = session.user?.id ?? null;
+
+    const rate = await rateLimit({
+      key: `chat:${rateLimitKeyFromRequest(request, userId)}`,
+      limit: 20,
+      windowMs: 60_000,
+    });
+    if (!rate.ok) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Too many chat requests. Try again shortly.", requestId },
+          { status: 429 },
+        ),
+        requestId,
+      );
+    }
+
+    let body: {
+      threadId?: string;
+      message?: string;
+      growId?: string;
+      plantId?: string;
+      history?: unknown;
+    };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Request body must be valid JSON.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+
+    const message =
+      typeof body?.message === "string" ? body.message.trim() : "";
+    if (!message) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "message is required", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`,
+            requestId,
+          },
+          { status: 413 },
+        ),
+        requestId,
+      );
+    }
+    if (
+      typeof body.threadId === "string" &&
+      body.threadId.length > MAX_THREAD_ID_LENGTH
+    ) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "threadId is too long.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    if (
+      typeof body.growId === "string" &&
+      body.growId.length > MAX_GROW_ID_LENGTH
+    ) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "growId is too long.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    if (
+      typeof body.plantId === "string" &&
+      body.plantId.length > MAX_PLANT_ID_LENGTH
+    ) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "plantId is too long.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+
+    // Validate optional client-supplied history. We trust role+content shape but
+    // not the model identities — the server prepends the canonical system
+    // prompt, so any "system" entries from the client are discarded.
+    const rawHistory = Array.isArray(body.history) ? body.history : [];
+    const history: IncomingMessage[] = rawHistory
+      .filter(isIncomingMessage)
+      .slice(-MAX_HISTORY_MESSAGES)
+      .filter(
+        (m) => m.content.length > 0 && m.content.length <= MAX_MESSAGE_LENGTH,
+      );
+
+    const growId =
+      typeof body.growId === "string" && body.growId.length > 0
+        ? body.growId
+        : null;
+
+    // Resolve / create the chat thread. We only persist when we have an
+    // authenticated user id; anonymous flows shouldn't happen here (we 401'd
+    // upstream) but we guard anyway. threadId is declared at the function
+    // scope above so the top-level catch can include it in error logs.
+    if (userId) {
+      const incomingThreadId =
+        typeof body.threadId === "string" && body.threadId.length > 0
+          ? body.threadId
+          : null;
+      if (incomingThreadId) {
+        const owns = await assertThreadOwner(incomingThreadId, userId);
+        if (!owns) {
+          return attachRequestId(
+            NextResponse.json(
+              { error: "Thread not found.", requestId },
+              { status: 404 },
+            ),
+            requestId,
+          );
+        }
+        threadId = incomingThreadId;
+      } else {
+        threadId = await createThread({
+          userId,
+          growId,
+          firstUserMessage: message,
+        });
+      }
+
+      // Persist the user message before we call out to the model so the
+      // transcript is durable even if the stream errors.
+      if (threadId) {
+        await appendMessage({
+          threadId,
+          role: "user",
+          content: message,
+        });
+      }
+    }
+
+    // Load grow context up-front so the model has the basics without needing
+    // a tool call on every turn. Tool calls remain available for deeper data.
+    const growContext = await loadGrowContextSummary(growId);
+
+    const openai = getAIClient();
+
+    const baseMessages: ChatCompletionMessageParam[] = [
+      { role: "system", content: CHAT_SYSTEM_PROMPT },
+      { role: "system", content: renderGrowContextBlock(growContext) },
+      ...history.map<ChatCompletionMessageParam>((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+      { role: "user", content: message },
+    ];
+
+    const encoder = new TextEncoder();
+    // Share one user-scoped supabase client across all tool calls in this
+    // request. Each call previously re-parsed cookies and re-built the
+    // client, which adds up across the (up to 4) tool-loop iterations.
+    // executeChatTool() falls back to creating its own client per-call when
+    // this one is undefined, so init failure is non-fatal.
+    let cachedSupabase:
+      | Awaited<ReturnType<typeof createSupabaseServerClient>>
+      | undefined;
+    try {
+      cachedSupabase = await createSupabaseServerClient();
+    } catch {
+      cachedSupabase = undefined;
+    }
+    const toolCtx: {
+      userId: string | null;
+      requestId: string;
+      supabase?: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+    } = {
+      userId,
       requestId,
-    );
-  }
-  if (message.length > MAX_MESSAGE_LENGTH) {
+    };
+    if (cachedSupabase) toolCtx.supabase = cachedSupabase;
+
+    // Buffer the assistant tokens as they stream so we can persist a single
+    // chat_messages row once the response completes.
+    let assistantBuffer = "";
+
+    const persistAssistant = async () => {
+      if (!threadId || !assistantBuffer) return;
+      await appendMessage({
+        threadId,
+        role: "assistant",
+        content: assistantBuffer,
+        metadata: { model: MODEL },
+      });
+      await touchThread(threadId);
+    };
+
+    const readable = new ReadableStream({
+      async start(controller) {
+        const working: ChatCompletionMessageParam[] = [...baseMessages];
+
+        try {
+          for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
+            const stream = openai.chat.completions.stream({
+              model: MODEL,
+              messages: working,
+              tools: CHAT_TOOL_DEFINITIONS,
+              tool_choice: "auto",
+              temperature: 0.3,
+              stream: true,
+            });
+
+            for await (const chunk of stream) {
+              const delta = chunk.choices[0]?.delta?.content;
+              if (delta) {
+                assistantBuffer += delta;
+                controller.enqueue(encoder.encode(delta));
+              }
+            }
+
+            const final = await stream.finalChatCompletion();
+            const choice = final.choices[0];
+            const toolCalls = choice?.message?.tool_calls as
+              | ChatCompletionMessageToolCall[]
+              | undefined;
+
+            if (!toolCalls || toolCalls.length === 0) {
+              // Final answer already streamed.
+              await persistAssistant();
+              controller.close();
+              return;
+            }
+
+            // Append the assistant turn with its tool_calls, then execute each.
+            working.push({
+              role: "assistant",
+              content: choice?.message?.content ?? "",
+              tool_calls: toolCalls,
+            });
+
+            for (const tc of toolCalls) {
+              if (tc.type !== "function") continue;
+              let parsedArgs: unknown = {};
+              try {
+                parsedArgs = tc.function.arguments
+                  ? JSON.parse(tc.function.arguments)
+                  : {};
+              } catch {
+                parsedArgs = {};
+              }
+
+              const result = await executeChatTool(
+                tc.function.name,
+                parsedArgs,
+                toolCtx,
+              );
+
+              working.push({
+                role: "tool",
+                tool_call_id: tc.id,
+                content: JSON.stringify(result).slice(0, 16_000),
+              });
+            }
+            // Loop and let the model use the tool results.
+          }
+
+          // Hit iteration cap without a final answer. Surface a fallback so the
+          // user isn't left with silence.
+          const fallback =
+            "\n\nI gathered some data but couldn't finalize a response. Could you rephrase or narrow the question?";
+          controller.enqueue(encoder.encode(fallback));
+          assistantBuffer += fallback;
+          await persistAssistant();
+          controller.close();
+        } catch (err) {
+          const isAbort = err instanceof Error && err.name === "AbortError";
+          if (isAbort) {
+            // Browser disconnected mid-stream. Persist whatever we already
+            // streamed so the user still sees their partial reply on reload.
+            await persistAssistant();
+            try {
+              controller.close();
+            } catch {
+              /* already closed */
+            }
+            return;
+          }
+          logServerEvent("error", "chat stream failed", {
+            requestId,
+            userId,
+            threadId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          controller.error(
+            new Error(
+              `Chat stream failed (request ${requestId}). Please try again.`,
+            ),
+          );
+        }
+      },
+    });
+
+    const responseHeaders: Record<string, string> = {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Transfer-Encoding": "chunked",
+    };
+    if (threadId) {
+      responseHeaders["X-Chat-Thread-Id"] = threadId;
+      // Browser fetch() only exposes headers in this allow-list when reading
+      // from a Next.js Route Handler that surfaces them via Access-Control-
+      // Expose-Headers. Same-origin reads work without it but we set it to be
+      // safe if a preview URL ever serves the page from a different origin.
+      responseHeaders["Access-Control-Expose-Headers"] = "X-Chat-Thread-Id";
+    }
+
+    return new NextResponse(readable, {
+      headers: withRequestIdHeader(responseHeaders, requestId),
+    });
+  } catch (err) {
+    // Log the underlying cause for operators; surface only a generic
+    // message + requestId + (when available) threadId to the client so we
+    // never leak server-side detail (which could include the OpenAI API
+    // key, Supabase URL, env-misconfig hints, or stack frames). Operators
+    // can correlate the requestId between this log line and the user's
+    // browser console / network tab.
+    logServerEvent("error", "chat request failed before stream", {
+      requestId,
+      userId,
+      threadId,
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     return attachRequestId(
       NextResponse.json(
         {
-          error: `message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`,
+          error: `Chat request failed (request ${requestId}). Please try again.`,
           requestId,
         },
-        { status: 413 },
+        { status: 500 },
       ),
       requestId,
     );
   }
-  if (
-    typeof body.threadId === "string" &&
-    body.threadId.length > MAX_THREAD_ID_LENGTH
-  ) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "threadId is too long.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-  if (
-    typeof body.growId === "string" &&
-    body.growId.length > MAX_GROW_ID_LENGTH
-  ) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "growId is too long.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-  if (
-    typeof body.plantId === "string" &&
-    body.plantId.length > MAX_PLANT_ID_LENGTH
-  ) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "plantId is too long.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-
-  // Validate optional client-supplied history. We trust role+content shape but
-  // not the model identities — the server prepends the canonical system
-  // prompt, so any "system" entries from the client are discarded.
-  const rawHistory = Array.isArray(body.history) ? body.history : [];
-  const history: IncomingMessage[] = rawHistory
-    .filter(isIncomingMessage)
-    .slice(-MAX_HISTORY_MESSAGES)
-    .filter(
-      (m) => m.content.length > 0 && m.content.length <= MAX_MESSAGE_LENGTH,
-    );
-
-  const growId =
-    typeof body.growId === "string" && body.growId.length > 0
-      ? body.growId
-      : null;
-
-  // Resolve / create the chat thread. We only persist when we have an
-  // authenticated user id; anonymous flows shouldn't happen here (we 401'd
-  // upstream) but we guard anyway.
-  let threadId: string | null = null;
-  if (userId) {
-    const incomingThreadId =
-      typeof body.threadId === "string" && body.threadId.length > 0
-        ? body.threadId
-        : null;
-    if (incomingThreadId) {
-      const owns = await assertThreadOwner(incomingThreadId, userId);
-      if (!owns) {
-        return attachRequestId(
-          NextResponse.json(
-            { error: "Thread not found.", requestId },
-            { status: 404 },
-          ),
-          requestId,
-        );
-      }
-      threadId = incomingThreadId;
-    } else {
-      threadId = await createThread({
-        userId,
-        growId,
-        firstUserMessage: message,
-      });
-    }
-
-    // Persist the user message before we call out to the model so the
-    // transcript is durable even if the stream errors.
-    if (threadId) {
-      await appendMessage({
-        threadId,
-        role: "user",
-        content: message,
-      });
-    }
-  }
-
-  // Load grow context up-front so the model has the basics without needing
-  // a tool call on every turn. Tool calls remain available for deeper data.
-  const growContext = await loadGrowContextSummary(growId);
-
-  const openai = getAIClient();
-
-  const baseMessages: ChatCompletionMessageParam[] = [
-    { role: "system", content: CHAT_SYSTEM_PROMPT },
-    { role: "system", content: renderGrowContextBlock(growContext) },
-    ...history.map<ChatCompletionMessageParam>((m) => ({
-      role: m.role,
-      content: m.content,
-    })),
-    { role: "user", content: message },
-  ];
-
-  const encoder = new TextEncoder();
-  const toolCtx = { userId, requestId };
-
-  // Buffer the assistant tokens as they stream so we can persist a single
-  // chat_messages row once the response completes.
-  let assistantBuffer = "";
-
-  const persistAssistant = async () => {
-    if (!threadId || !assistantBuffer) return;
-    await appendMessage({
-      threadId,
-      role: "assistant",
-      content: assistantBuffer,
-      metadata: { model: MODEL },
-    });
-    await touchThread(threadId);
-  };
-
-  const readable = new ReadableStream({
-    async start(controller) {
-      const working: ChatCompletionMessageParam[] = [...baseMessages];
-
-      try {
-        for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
-          const stream = openai.chat.completions.stream({
-            model: MODEL,
-            messages: working,
-            tools: CHAT_TOOL_DEFINITIONS,
-            tool_choice: "auto",
-            temperature: 0.3,
-            stream: true,
-          });
-
-          for await (const chunk of stream) {
-            const delta = chunk.choices[0]?.delta?.content;
-            if (delta) {
-              assistantBuffer += delta;
-              controller.enqueue(encoder.encode(delta));
-            }
-          }
-
-          const final = await stream.finalChatCompletion();
-          const choice = final.choices[0];
-          const toolCalls = choice?.message?.tool_calls as
-            | ChatCompletionMessageToolCall[]
-            | undefined;
-
-          if (!toolCalls || toolCalls.length === 0) {
-            // Final answer already streamed.
-            await persistAssistant();
-            controller.close();
-            return;
-          }
-
-          // Append the assistant turn with its tool_calls, then execute each.
-          working.push({
-            role: "assistant",
-            content: choice?.message?.content ?? "",
-            tool_calls: toolCalls,
-          });
-
-          for (const tc of toolCalls) {
-            if (tc.type !== "function") continue;
-            let parsedArgs: unknown = {};
-            try {
-              parsedArgs = tc.function.arguments
-                ? JSON.parse(tc.function.arguments)
-                : {};
-            } catch {
-              parsedArgs = {};
-            }
-
-            const result = await executeChatTool(
-              tc.function.name,
-              parsedArgs,
-              toolCtx,
-            );
-
-            working.push({
-              role: "tool",
-              tool_call_id: tc.id,
-              content: JSON.stringify(result).slice(0, 16_000),
-            });
-          }
-          // Loop and let the model use the tool results.
-        }
-
-        // Hit iteration cap without a final answer. Surface a fallback so the
-        // user isn't left with silence.
-        const fallback =
-          "\n\nI gathered some data but couldn't finalize a response. Could you rephrase or narrow the question?";
-        controller.enqueue(encoder.encode(fallback));
-        assistantBuffer += fallback;
-        await persistAssistant();
-        controller.close();
-      } catch (err) {
-        const isAbort = err instanceof Error && err.name === "AbortError";
-        if (isAbort) {
-          // Browser disconnected mid-stream. Persist whatever we already
-          // streamed so the user still sees their partial reply on reload.
-          await persistAssistant();
-          try {
-            controller.close();
-          } catch {
-            /* already closed */
-          }
-          return;
-        }
-        logServerEvent("error", "chat stream failed", {
-          requestId,
-          userId,
-          error: err instanceof Error ? err.message : "unknown_error",
-        });
-        controller.error(
-          new Error(
-            `Chat stream failed (request ${requestId}). Please try again.`,
-          ),
-        );
-      }
-    },
-  });
-
-  const responseHeaders: Record<string, string> = {
-    "Content-Type": "text/plain; charset=utf-8",
-    "Transfer-Encoding": "chunked",
-  };
-  if (threadId) {
-    responseHeaders["X-Chat-Thread-Id"] = threadId;
-    // Browser fetch() only exposes headers in this allow-list when reading
-    // from a Next.js Route Handler that surfaces them via Access-Control-
-    // Expose-Headers. Same-origin reads work without it but we set it to be
-    // safe if a preview URL ever serves the page from a different origin.
-    responseHeaders["Access-Control-Expose-Headers"] = "X-Chat-Thread-Id";
-  }
-
-  return new NextResponse(readable, {
-    headers: withRequestIdHeader(responseHeaders, requestId),
-  });
 }

--- a/apps/web/src/app/api/chat/threads/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/threads/__tests__/route.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/server/chat-persistence", () => ({
   listThreadsForUser: (...args: unknown[]) => listThreadsForUser(...args),
 }));
 
+import { __resetRateLimitStore } from "@/lib/server/rate-limit";
 import { GET } from "../route";
 
 function getRequest(): NextRequest {
@@ -22,6 +23,7 @@ describe("GET /api/chat/threads", () => {
   beforeEach(() => {
     (getServerSession as Mock).mockReset();
     listThreadsForUser.mockReset();
+    __resetRateLimitStore();
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -59,5 +61,17 @@ describe("GET /api/chat/threads", () => {
 
     const res = await GET(getRequest());
     expect(res.status).toBe(500);
+  });
+
+  it("rate-limits at 30 requests per minute per user", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "spam" } });
+    listThreadsForUser.mockResolvedValue([]);
+
+    for (let i = 0; i < 30; i++) {
+      const ok = await GET(getRequest());
+      expect(ok.status).toBe(200);
+    }
+    const limited = await GET(getRequest());
+    expect(limited.status).toBe(429);
   });
 });

--- a/apps/web/src/app/api/chat/threads/route.ts
+++ b/apps/web/src/app/api/chat/threads/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "@/lib/server/auth";
 import { listThreadsForUser } from "@/lib/server/chat-persistence";
+import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
 import {
   attachRequestId,
   getOrCreateRequestId,
@@ -10,16 +11,44 @@ import {
 // GET /api/chat/threads
 // Returns the authenticated user's chat threads, most-recently-updated first.
 export async function GET(request: NextRequest) {
-  const requestId = getOrCreateRequestId(request);
-  const session = await getServerSession();
-  if (!session) {
-    return attachRequestId(
-      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
-      requestId,
-    );
+  let requestId: string;
+  try {
+    requestId = getOrCreateRequestId(request);
+  } catch {
+    requestId = "unknown";
   }
 
   try {
+    const session = await getServerSession();
+    if (!session) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Unauthorized", requestId },
+          { status: 401 },
+        ),
+        requestId,
+      );
+    }
+
+    const userId = session.user?.id ?? null;
+    const rate = await rateLimit({
+      key: `chat-threads:${rateLimitKeyFromRequest(request, userId)}`,
+      limit: 30,
+      windowMs: 60_000,
+    });
+    if (!rate.ok) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: "Too many chat-thread requests. Try again shortly.",
+            requestId,
+          },
+          { status: 429 },
+        ),
+        requestId,
+      );
+    }
+
     const threads = await listThreadsForUser();
     return attachRequestId(
       NextResponse.json({ threads, requestId }),
@@ -28,7 +57,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     logServerEvent("error", "chat threads list route failed", {
       requestId,
-      error: error instanceof Error ? error.message : "unknown_error",
+      error: error instanceof Error ? error.message : String(error),
     });
     return attachRequestId(
       NextResponse.json(

--- a/apps/web/src/app/assistant/chat-client.tsx
+++ b/apps/web/src/app/assistant/chat-client.tsx
@@ -237,7 +237,16 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
     async (text: string) => {
       const trimmed = text.trim();
       if (!trimmed) return;
+      // Two-phase guard against double-click / double-submit races:
+      // 1. abortRef catches the case where the previous fetch hasn't yet
+      //    finished and the user clicks Send (or Enter) again.
+      // 2. We claim the abortRef BEFORE setMessages / fetch so a second
+      //    near-simultaneous click sees the claim and bails — previously
+      //    the guard relied on streaming state which is async and gives a
+      //    short race window where two fetches could fire.
       if (abortRef.current) return;
+      const controller = new AbortController();
+      abortRef.current = controller;
       setError(null);
 
       const userMsg: Message = { id: newId(), role: "user", content: trimmed };
@@ -257,9 +266,6 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
       });
       setInput("");
       setStreaming(true);
-
-      const controller = new AbortController();
-      abortRef.current = controller;
 
       try {
         const res = await fetch("/api/chat", {
@@ -439,6 +445,35 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
               Replies will use {activeGrow.name}&apos;s data.
             </span>
           )}
+
+          {/* Mobile thread picker — desktop has the sidebar; phones get
+              a select + new-chat button right next to the grow picker so
+              users on small screens can still switch / start threads. */}
+          <div className="ml-auto flex items-center gap-2 md:hidden">
+            <label htmlFor="thread-picker-mobile" className="sr-only">
+              Chat thread
+            </label>
+            <select
+              id="thread-picker-mobile"
+              value={threadId ?? ""}
+              onChange={(e) => {
+                const id = e.target.value;
+                if (!id) {
+                  startNewThread();
+                } else {
+                  void loadThread(id);
+                }
+              }}
+              className="h-8 max-w-[10rem] truncate rounded-md border border-input bg-background px-2 text-xs text-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/40"
+            >
+              <option value="">+ New chat</option>
+              {threads.map((t) => (
+                <option key={t.id} value={t.id}>
+                  {t.title ?? "Untitled chat"}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
         <div ref={scrollerRef} className="flex-1 overflow-y-auto bg-background">

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -151,163 +151,196 @@ const EventsArgs = z.object({
 });
 const LatestAnalysisArgs = z.object({ plantId: z.string().min(1) });
 
+type ChatToolContext = {
+  userId: string | null;
+  requestId: string;
+  // Optional cached supabase client so repeat tool calls within one request
+  // don't pay the auth-cookie-parse + client-init cost on every invocation.
+  supabase?: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+};
+
 export async function executeChatTool(
   name: string,
   rawArgs: unknown,
-  ctx: { userId: string | null; requestId: string },
+  ctx: ChatToolContext,
 ): Promise<ToolResult> {
+  const started = Date.now();
   let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
-  try {
-    supabase = await createSupabaseServerClient();
-  } catch (err) {
-    logServerEvent("error", "chat tool client init failed", {
-      requestId: ctx.requestId,
-      userId: ctx.userId,
-      tool: name,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return { ok: false, error: "data backend unavailable" };
+  if (ctx.supabase) {
+    supabase = ctx.supabase;
+  } else {
+    try {
+      supabase = await createSupabaseServerClient();
+    } catch (err) {
+      logServerEvent("error", "chat tool client init failed", {
+        requestId: ctx.requestId,
+        userId: ctx.userId,
+        tool: name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { ok: false, error: "data backend unavailable" };
+    }
   }
 
-  try {
-    switch (name) {
-      case "list_grows": {
-        const args = ListGrowsArgs.parse(rawArgs ?? {});
-        const limit = numClamp(args.limit, 10, 25);
-        const { data, error } = await supabase
-          .from("grows")
-          .select(
-            "id,name,stage,medium,light_type,start_date,target_harvest_date,is_archived,updated_at",
-          )
-          .eq("is_archived", false)
-          .order("updated_at", { ascending: false })
-          .limit(limit);
-        if (error) return { ok: false, error: error.message };
-        return { ok: true, data: data ?? [] };
-      }
-
-      case "list_plants": {
-        const args = ListPlantsArgs.parse(rawArgs);
-        const limit = numClamp(args.limit, 25, 50);
-        const { data, error } = await supabase
-          .from("plants")
-          .select("id,name,strain,batch_label,notes,is_archived,updated_at")
-          .eq("grow_id", args.growId)
-          .eq("is_archived", false)
-          .order("updated_at", { ascending: false })
-          .limit(limit);
-        if (error) return { ok: false, error: error.message };
-        return { ok: true, data: data ?? [] };
-      }
-
-      case "get_recent_findings": {
-        const args = FindingsArgs.parse(rawArgs ?? {});
-        if (!args.growId && !args.plantId) {
-          return {
-            ok: false,
-            error: "Provide growId or plantId to scope findings.",
-          };
+  // Inner IIFE so we can log every tool invocation with its outcome and
+  // latency through a single return path. This is the cheapest way to give
+  // ops a clear audit trail of which tools the assistant actually ran for
+  // a given chat request — invaluable when a user reports a wrong answer.
+  const result: ToolResult = await (async (): Promise<ToolResult> => {
+    try {
+      switch (name) {
+        case "list_grows": {
+          const args = ListGrowsArgs.parse(rawArgs ?? {});
+          const limit = numClamp(args.limit, 10, 25);
+          const { data, error } = await supabase
+            .from("grows")
+            .select(
+              "id,name,stage,medium,light_type,start_date,target_harvest_date,is_archived,updated_at",
+            )
+            .eq("is_archived", false)
+            .order("updated_at", { ascending: false })
+            .limit(limit);
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
         }
-        const limit = numClamp(args.limit, 10, 25);
-        const sinceDays = numClamp(args.sinceDays, 30, 365);
-        const since = new Date(
-          Date.now() - sinceDays * 24 * 60 * 60 * 1000,
-        ).toISOString();
 
-        let q = supabase
-          .from("plant_findings")
-          .select(
-            "id,plant_id,grow_id,image_id,category,severity,title,description,recommendation,resolved_at,created_at",
-          )
-          .gte("created_at", since)
-          .order("created_at", { ascending: false })
-          .limit(limit);
-        if (args.plantId) q = q.eq("plant_id", args.plantId);
-        if (args.growId) q = q.eq("grow_id", args.growId);
-
-        const { data, error } = await q;
-        if (error) return { ok: false, error: error.message };
-        return { ok: true, data: data ?? [] };
-      }
-
-      case "get_recent_observations": {
-        const args = ObservationsArgs.parse(rawArgs ?? {});
-        if (!args.growId && !args.plantId) {
-          return {
-            ok: false,
-            error: "Provide growId or plantId to scope observations.",
-          };
+        case "list_plants": {
+          const args = ListPlantsArgs.parse(rawArgs);
+          const limit = numClamp(args.limit, 25, 50);
+          const { data, error } = await supabase
+            .from("plants")
+            .select("id,name,strain,batch_label,notes,is_archived,updated_at")
+            .eq("grow_id", args.growId)
+            .eq("is_archived", false)
+            .order("updated_at", { ascending: false })
+            .limit(limit);
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
         }
-        const limit = numClamp(args.limit, 10, 25);
-        let q = supabase
-          .from("plant_observations")
-          .select("id,plant_id,grow_id,observed_at,height_cm,notes,created_at")
-          .order("observed_at", { ascending: false })
-          .limit(limit);
-        if (args.plantId) q = q.eq("plant_id", args.plantId);
-        if (args.growId) q = q.eq("grow_id", args.growId);
 
-        const { data, error } = await q;
-        if (error) return { ok: false, error: error.message };
-        return { ok: true, data: data ?? [] };
-      }
+        case "get_recent_findings": {
+          const args = FindingsArgs.parse(rawArgs ?? {});
+          if (!args.growId && !args.plantId) {
+            return {
+              ok: false,
+              error: "Provide growId or plantId to scope findings.",
+            };
+          }
+          const limit = numClamp(args.limit, 10, 25);
+          const sinceDays = numClamp(args.sinceDays, 30, 365);
+          const since = new Date(
+            Date.now() - sinceDays * 24 * 60 * 60 * 1000,
+          ).toISOString();
 
-      case "get_grow_events": {
-        const args = EventsArgs.parse(rawArgs ?? {});
-        if (!args.growId && !args.plantId) {
-          return {
-            ok: false,
-            error: "Provide growId or plantId to scope events.",
-          };
+          let q = supabase
+            .from("plant_findings")
+            .select(
+              "id,plant_id,grow_id,image_id,category,severity,title,description,recommendation,resolved_at,created_at",
+            )
+            .gte("created_at", since)
+            .order("created_at", { ascending: false })
+            .limit(limit);
+          if (args.plantId) q = q.eq("plant_id", args.plantId);
+          if (args.growId) q = q.eq("grow_id", args.growId);
+
+          const { data, error } = await q;
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
         }
-        const limit = numClamp(args.limit, 15, 50);
-        const sinceDays = numClamp(args.sinceDays, 14, 365);
-        const since = new Date(
-          Date.now() - sinceDays * 24 * 60 * 60 * 1000,
-        ).toISOString();
 
-        let q = supabase
-          .from("grow_events")
-          .select("id,grow_id,plant_id,event_type,notes,occurred_at,created_at")
-          .gte("occurred_at", since)
-          .order("occurred_at", { ascending: false })
-          .limit(limit);
-        if (args.plantId) q = q.eq("plant_id", args.plantId);
-        if (args.growId) q = q.eq("grow_id", args.growId);
+        case "get_recent_observations": {
+          const args = ObservationsArgs.parse(rawArgs ?? {});
+          if (!args.growId && !args.plantId) {
+            return {
+              ok: false,
+              error: "Provide growId or plantId to scope observations.",
+            };
+          }
+          const limit = numClamp(args.limit, 10, 25);
+          let q = supabase
+            .from("plant_observations")
+            .select(
+              "id,plant_id,grow_id,observed_at,height_cm,notes,created_at",
+            )
+            .order("observed_at", { ascending: false })
+            .limit(limit);
+          if (args.plantId) q = q.eq("plant_id", args.plantId);
+          if (args.growId) q = q.eq("grow_id", args.growId);
 
-        const { data, error } = await q;
-        if (error) return { ok: false, error: error.message };
-        return { ok: true, data: data ?? [] };
+          const { data, error } = await q;
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
+        }
+
+        case "get_grow_events": {
+          const args = EventsArgs.parse(rawArgs ?? {});
+          if (!args.growId && !args.plantId) {
+            return {
+              ok: false,
+              error: "Provide growId or plantId to scope events.",
+            };
+          }
+          const limit = numClamp(args.limit, 15, 50);
+          const sinceDays = numClamp(args.sinceDays, 14, 365);
+          const since = new Date(
+            Date.now() - sinceDays * 24 * 60 * 60 * 1000,
+          ).toISOString();
+
+          let q = supabase
+            .from("grow_events")
+            .select(
+              "id,grow_id,plant_id,event_type,notes,occurred_at,created_at",
+            )
+            .gte("occurred_at", since)
+            .order("occurred_at", { ascending: false })
+            .limit(limit);
+          if (args.plantId) q = q.eq("plant_id", args.plantId);
+          if (args.growId) q = q.eq("grow_id", args.growId);
+
+          const { data, error } = await q;
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
+        }
+
+        case "get_latest_analysis": {
+          const args = LatestAnalysisArgs.parse(rawArgs);
+          const { data, error } = await supabase
+            .from("plant_analyses")
+            .select(
+              "id,plant_id,grow_id,image_id,compared_to_image_id,overall_health_score,summary,comparison_summary,analysis_mode,is_fallback,model_version,created_at",
+            )
+            .eq("plant_id", args.plantId)
+            .order("created_at", { ascending: false })
+            .limit(1)
+            .maybeSingle();
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? null };
+        }
+
+        default:
+          return { ok: false, error: `Unknown tool: ${name}` };
       }
-
-      case "get_latest_analysis": {
-        const args = LatestAnalysisArgs.parse(rawArgs);
-        const { data, error } = await supabase
-          .from("plant_analyses")
-          .select(
-            "id,plant_id,grow_id,image_id,compared_to_image_id,overall_health_score,summary,comparison_summary,analysis_mode,is_fallback,model_version,created_at",
-          )
-          .eq("plant_id", args.plantId)
-          .order("created_at", { ascending: false })
-          .limit(1)
-          .maybeSingle();
-        if (error) return { ok: false, error: error.message };
-        return { ok: true, data: data ?? null };
+    } catch (err) {
+      if (err instanceof z.ZodError) {
+        return { ok: false, error: `Invalid arguments: ${err.message}` };
       }
-
-      default:
-        return { ok: false, error: `Unknown tool: ${name}` };
+      logServerEvent("error", "chat tool execution failed", {
+        requestId: ctx.requestId,
+        userId: ctx.userId,
+        tool: name,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return { ok: false, error: "tool execution failed" };
     }
-  } catch (err) {
-    if (err instanceof z.ZodError) {
-      return { ok: false, error: `Invalid arguments: ${err.message}` };
-    }
-    logServerEvent("error", "chat tool execution failed", {
-      requestId: ctx.requestId,
-      userId: ctx.userId,
-      tool: name,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return { ok: false, error: "tool execution failed" };
-  }
+  })();
+
+  logServerEvent("info", "chat tool invoked", {
+    requestId: ctx.requestId,
+    userId: ctx.userId,
+    tool: name,
+    ok: result.ok,
+    durationMs: Date.now() - started,
+  });
+
+  return result;
 }


### PR DESCRIPTION
## Summary

Fixes the production chat 500 the user is hitting on every send, plus the audit optimizations from the final review.

### Root cause (the 500)

Vercel runtime logs show every `POST /api/chat` 500 carries only the benign Supabase `console.warn` and **no error-level log of our own** — proof that the throw fired *outside* every try/catch. Since #119 + #120 the route can synchronously throw from many places (`getServerSession`, `rateLimit`, `assertThreadOwner`, `createThread`, `appendMessage`, `loadGrowContextSummary`, `getAIClient`, the openai SDK constructor) and none of them were wrapped at the top level. The bare 500 leaves Next with no response body, which is exactly what the chat UI surfaces as `"Request failed with 500."`.

The user's earlier PR #118 already diagnosed this same shape of bug but was never merged before #119 / #120 landed, and #120 *expanded* the throw surface.

### Fix

- Wrap the whole `/api/chat` prep phase in a top-level try/catch that returns a structured `{ error, requestId }` JSON 500. The cause is logged server-side with `userId` + `threadId` + stack; the client never sees internal text.
- Harden `getOrCreateRequestId` so even if the id helper itself throws, the envelope still goes out.

### Audit optimizations rolled in

- **Rate-limit `GET /api/chat/threads`** — 30 req/min/user (was unbounded — a trivial spam surface).
- **Reuse one user-scoped Supabase client** across every chat-tool call within a single request (previously re-parsed cookies + rebuilt the client up to 12× per turn).
- **Tool-invocation logs** — `chat tool invoked` with `ok` + `durationMs` for every tool call so ops can audit which tools the assistant ran for a given request id.
- **`threadId` in chat-stream error logs** for traceability.
- **Double-click race fix in the chat client** — claim `abortRef` *before* fetch so a second near-simultaneous Send-click bails instead of firing a duplicate POST.
- **Mobile thread picker** — the desktop sidebar is `hidden md:flex`; phones now get a thread `<select>` + new-chat option next to the grow picker.

## Test plan

- [x] `pnpm run validate` — env / route / import / code-scanning all green
- [x] `pnpm turbo run type-check lint test` — clean (326 / 326 pass)
- [x] New tests: synchronous throw from `createThread` and from `getAIClient` both yield JSON 500 with a request id, and the internal error text never leaks (regression coverage for the bare-500 bug)
- [x] New test: `/api/chat/threads` 429s at the 31st request in a minute
- [ ] Verify deploy: open `/assistant` on production, send a message, confirm it no longer 500s
- [ ] Mobile preview: confirm the `<select>` thread picker shows on phones

https://claude.ai/code/session_01YFwjLEZkzjnKGMb5rFcDQg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFwjLEZkzjnKGMb5rFcDQg)_