### PR TITLE
fix(chat): render in-stream errors inline (eliminates the bare-500)

### DIFF
--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -333,22 +333,41 @@ describe("POST /api/chat", () => {
     expect(args.messages[1]?.content).toContain("flower");
   });
 
-  it("surfaces a SANITISED error to the client when the upstream fails", async () => {
+  it("renders a SANITISED inline error in the response body when the upstream fails mid-stream", async () => {
+    // Regression: when controller.error() was used here, Vercel converted
+    // the 200 streaming response into a bare 500 with empty body and the
+    // chat client showed the generic "Request failed with 500.". We now
+    // enqueue a human-readable note and close cleanly so the user gets a
+    // useful inline explanation and a requestId for support.
     getServerSession.mockResolvedValue({ user: { id: "u1" } });
     streamMock.mockImplementation(() => failingStream());
 
     const res = await POST(jsonRequest({ message: "hi" }));
     expect(res.status).toBe(200);
-    let caught: unknown = null;
-    try {
-      await res.text();
-    } catch (err) {
-      caught = err;
-    }
-    expect(caught).toBeInstanceOf(Error);
-    const message = caught instanceof Error ? caught.message : "";
-    expect(message).toMatch(/Chat stream failed \(request /);
-    expect(message).not.toMatch(/secret context here/);
+    const text = await res.text();
+    expect(text).toMatch(/Something went wrong reaching the model/);
+    expect(text).toMatch(/request /);
+    // The upstream wording must never leak to the client envelope.
+    expect(text).not.toMatch(/secret context here/);
+  });
+
+  it("classifies upstream 429 / quota failures with a specific user-facing message", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() => ({
+      async *[Symbol.asyncIterator](): AsyncGenerator<Chunk> {
+        const e = new Error("You exceeded your current quota");
+        (e as Error & { status?: number }).status = 429;
+        throw e;
+      },
+      finalChatCompletion: () => Promise.reject(new Error("never")),
+    }));
+
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toMatch(/rate-limited or out of quota/);
+    // Must not echo OpenAI's specific wording verbatim.
+    expect(text).not.toMatch(/You exceeded your current quota/);
   });
 
   it("creates a new thread, persists the user + assistant messages, and returns the thread id", async () => {

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -385,17 +385,76 @@ export async function POST(request: NextRequest) {
             }
             return;
           }
+          // Classify the upstream error so we can surface something
+          // useful inline. We deliberately do NOT call controller.error()
+          // here: when no bytes have been flushed yet, Vercel converts a
+          // would-be 200 streaming response into a bare 500 with empty
+          // body, which the chat client cannot parse and shows as the
+          // generic "Request failed with 500.". Instead we enqueue a
+          // human-readable error as the assistant's body and close the
+          // stream normally. The HTTP status stays 200, the user sees a
+          // specific explanation, and the underlying cause is captured in
+          // the server log with the requestId for ops correlation.
+          const errMsg = err instanceof Error ? err.message : String(err);
+          const status =
+            err && typeof err === "object" && "status" in err
+              ? Number((err as { status?: unknown }).status)
+              : undefined;
+          const code =
+            err && typeof err === "object" && "code" in err
+              ? String((err as { code?: unknown }).code)
+              : undefined;
+
+          let userFacing: string;
+          if (
+            status === 429 ||
+            code === "insufficient_quota" ||
+            /quota|rate.?limit/i.test(errMsg)
+          ) {
+            userFacing =
+              "The AI service is rate-limited or out of quota right now. Please try again in a moment, or contact support if this persists.";
+          } else if (status === 401 || status === 403) {
+            userFacing =
+              "The AI service rejected the request (auth or permission). The site operator has been notified.";
+          } else if (status && status >= 500) {
+            userFacing =
+              "The AI service is temporarily unavailable. Please try again in a few seconds.";
+          } else {
+            userFacing =
+              "Something went wrong reaching the model. Please try again.";
+          }
+
           logServerEvent("error", "chat stream failed", {
             requestId,
             userId,
             threadId,
-            error: err instanceof Error ? err.message : String(err),
+            upstreamStatus: status,
+            upstreamCode: code,
+            error: errMsg,
           });
-          controller.error(
-            new Error(
-              `Chat stream failed (request ${requestId}). Please try again.`,
-            ),
-          );
+
+          // If we'd already streamed some assistant text, separate the
+          // partial reply from the error note. If we hadn't streamed
+          // anything, this enqueue is what commits the 200 status to the
+          // wire.
+          const prefix = assistantBuffer
+            ? "\n\n_Stream interrupted before completion._\n\n"
+            : "";
+          const tail = `${prefix}${userFacing} (request ${requestId})`;
+          try {
+            controller.enqueue(encoder.encode(tail));
+            assistantBuffer += tail;
+          } catch {
+            /* controller may already be in an error state */
+          }
+          // Persist whatever the user actually saw, including the inline
+          // error, so the saved transcript matches reality.
+          await persistAssistant();
+          try {
+            controller.close();
+          } catch {
+            /* already closed */
+          }
         }
       },
     });


### PR DESCRIPTION
## Summary

The user reported `"Request failed with 500."` was **still** appearing after #122 merged. Production smoking gun: the failed `POST /api/chat` at 19:18:11 UTC matched our `chat stream failed` log path *and* matched `"429"` and `"quota"` in the log body — i.e. the OpenAI account is rate-limited / out of credits, and our `for await (chunk of stream)` is throwing 429 mid-stream.

### Why #122's top-level catch wasn't enough

#122 wrapped the **prep phase**. The throw is happening **inside the ReadableStream's `start(controller)`** after `return new NextResponse(readable, { status: 200, … })`. The previous code reacted with `controller.error(...)`. Because no bytes had been enqueued yet, **Vercel converts the would-be 200 streaming response into a bare 500 with empty body**. The chat client cannot parse JSON from an empty 500 so it falls back to `"Request failed with ${status}."` — exactly the screenshot the user posted.

### Fix

Instead of `controller.error(...)`, **classify the upstream failure and enqueue a human-readable inline note as the assistant's body**, then `controller.close()` cleanly:

- **Quota / 429 / rate-limit** → `"The AI service is rate-limited or out of quota right now…"`
- **401 / 403** → `"…rejected the request (auth or permission). Operator notified."`
- **5xx** → `"…temporarily unavailable. Please try again in a few seconds."`
- **Default** → `"Something went wrong reaching the model. Please try again."`

Every message ends with `(request <id>)` for support correlation. The HTTP status stays **200**, the user sees a specific explanation, and the saved chat_messages row matches what they actually saw.

Also: the error log line now carries `upstreamStatus` and `upstreamCode` for faster ops triage.

## Operator action

Once this is deployed, please **check the OpenAI account billing/quota at platform.openai.com**. The user's chat session was hitting 429 — either the org is out of credits this billing cycle or hitting the per-minute token cap. The chat UI will now tell users this directly instead of showing a generic 500.

## Test plan

- [x] `pnpm run validate` — clean
- [x] `pnpm turbo run type-check lint test` — 327 / 327 pass
- [x] New regression test: when the upstream stream throws, response is **HTTP 200** with the inline classifier message in the body (was previously bare 500)
- [x] New test: 429 / quota errors trigger the specific quota-message classifier
- [ ] After deploy: open `/assistant` as a logged-in user, send a message. If quota is still exhausted you'll now see a clear quota message inline (not "Request failed with 500."). If quota is restored, the message streams normally.

https://claude.ai/code/session_01YFwjLEZkzjnKGMb5rFcDQg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFwjLEZkzjnKGMb5rFcDQg)_