### PR TITLE
fix(chat): default to gemini-2.5-flash + diagnostic reason codes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ ANALYSIS_SERVICE_URL=https://your-analysis-service.railway.app
 ANALYSIS_SERVICE_API_KEY=your-internal-api-key
 
 # ─── Google Gemini API (chat) ────────────────────────────────────────────────
-# Server-side only. Free tier: 1,500 req/day on gemini-2.0-flash, no card.
+# Server-side only. Free tier on gemini-2.5-flash, no card required.
 # Generate at https://aistudio.google.com/app/apikey
 # The chat route uses the openai SDK pointed at Gemini's OpenAI-compatible
 # endpoint, so all tool calls / streaming / message format stay identical.

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -16,7 +16,7 @@ ANALYSIS_SERVICE_URL=https://your-analysis.railway.app
 ANALYSIS_SERVICE_API_KEY=your-internal-shared-secret
 
 # ─── Google Gemini API (chat) ────────────────────────────────────────────────
-# Server-side only. Free tier: 1,500 req/day on gemini-2.0-flash, no card.
+# Server-side only. Free tier on gemini-2.5-flash, no card required.
 # Generate at https://aistudio.google.com/app/apikey
 # We use the openai SDK pointed at Gemini's OpenAI-compatible endpoint,
 # so tool calls / streaming / message format all stay identical.

--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -222,7 +222,7 @@ describe("POST /api/chat", () => {
       stream: boolean;
       messages: Array<{ role: string; content: string }>;
     };
-    expect(args.model).toBe("gemini-2.0-flash");
+    expect(args.model).toBe("gemini-2.5-flash");
     expect(args.stream).toBe(true);
     // First two messages are the canonical system prompts; the user message
     // is appended last.

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -40,10 +40,15 @@ const MAX_GROW_ID_LENGTH = 64;
 const MAX_PLANT_ID_LENGTH = 64;
 const MAX_TOOL_ITERATIONS = 4;
 // Google Gemini's OpenAI-compatible endpoint accepts the model name in the
-// same `model:` field. gemini-2.0-flash is GA, free-tier (1,500 req/day),
-// supports streaming + tool calls + multi-turn conversations — ideal fit
-// for the cultivator-assistant workload.
-const MODEL = "gemini-2.0-flash";
+// same `model:` field. We default to gemini-2.5-flash because gemini-2.0-flash
+// no longer carries free-tier allocation on most projects (returns 429 with
+// `limit: 0`), while gemini-2.5-flash is the current free-tier-eligible
+// generation that still supports streaming + tool calls + multi-turn.
+//
+// Override via CHAT_MODEL when billing is enabled (e.g. CHAT_MODEL=gemini-2.5-pro
+// or CHAT_MODEL=gemini-3.1-pro-preview) to promote to a pro model without code
+// changes.
+const MODEL = process.env["CHAT_MODEL"] || "gemini-2.5-flash";
 
 type IncomingMessage = {
   role: "user" | "assistant";
@@ -486,18 +491,39 @@ export async function POST(request: NextRequest) {
     // key, Supabase URL, env-misconfig hints, or stack frames). Operators
     // can correlate the requestId between this log line and the user's
     // browser console / network tab.
+    const errMsg = err instanceof Error ? err.message : String(err);
+    // Classify common configuration / dependency failures into a short,
+    // non-sensitive code. The code names a *category* (which env var or
+    // upstream is misconfigured) without echoing the secret value or the
+    // raw exception text. Operators can map the code to the relevant
+    // Vercel env var without needing log access.
+    let reason: string | null = null;
+    if (/GEMINI_API_KEY/i.test(errMsg)) {
+      reason = "ai_unconfigured"; // GEMINI_API_KEY missing on this deployment
+    } else if (
+      /SUPABASE_SERVICE_ROLE_KEY|NEXT_PUBLIC_SUPABASE_URL/i.test(errMsg)
+    ) {
+      reason = "db_unconfigured"; // service-role env missing on this deployment
+    } else if (/fetch failed|ECONNREFUSED|ENOTFOUND|ETIMEDOUT/i.test(errMsg)) {
+      reason = "upstream_unreachable";
+    }
     logServerEvent("error", "chat request failed before stream", {
       requestId,
       userId,
       threadId,
-      error: err instanceof Error ? err.message : String(err),
+      reason,
+      error: errMsg,
       stack: err instanceof Error ? err.stack : undefined,
     });
+    const userFacing = reason
+      ? `Chat request failed (${reason}, request ${requestId}). Please contact the site operator.`
+      : `Chat request failed (request ${requestId}). Please try again.`;
     return attachRequestId(
       NextResponse.json(
         {
-          error: `Chat request failed (request ${requestId}). Please try again.`,
+          error: userFacing,
           requestId,
+          reason,
         },
         { status: 500 },
       ),


### PR DESCRIPTION
## Why the chat is failing in prod

Tested the live `GEMINI_API_KEY` against Google's OpenAI-compat endpoint:

- `gemini-2.0-flash` → **429 RESOURCE_EXHAUSTED, `limit: 0`** (no free-tier allocation on this project)
- `gemini-2.5-pro` / `gemini-3.1-pro-preview` → 429 (require billing)
- `gemini-2.5-flash` / `gemini-2.5-flash-lite` / `gemini-flash-latest` → **200 OK**

The deployed route hardcodes `gemini-2.0-flash` (PR #124), so every chat send hits 429. Because that 429 actually surfaces *during* streaming, it should have been caught by the inner stream catch (line 379) and rendered inline — but the user is seeing the **top-level** `Chat request failed (request <id>)` envelope, which means the throw happened earlier (most likely `getAIClient` or `getDbClient` env-var miss on the deployment that was active before they added the key on Vercel).

## Fix

1. **Switch default model to `gemini-2.5-flash`** — the current free-tier-eligible generation that still supports streaming + tool calls + multi-turn. Override via `CHAT_MODEL` env so the operator can promote to `gemini-2.5-pro` / `gemini-3.1-pro-preview` once billing is enabled — no code change needed.
2. **Add a diagnostic `reason` classifier** to the top-level catch (`ai_unconfigured` / `db_unconfigured` / `upstream_unreachable`). The reason is included in the JSON body and the user-visible string so the next failure tells us exactly which dependency died — without ever leaking secret values or stack frames.

## Tests

- 18/18 chat route tests pass (including the existing `no-secret-leak` and `prep-throw` cases).
- `tsc --noEmit` clean.

## Operator action after merge

- Vercel auto-redeploys on push to `main` → new build picks up the `GEMINI_API_KEY` you added.
- Free tier on `gemini-2.5-flash` is sufficient for normal use. To run a pro model, enable billing on the Google Cloud project and set `CHAT_MODEL=gemini-2.5-pro` (or `gemini-3.1-pro-preview`) in Vercel env, then redeploy.
- Reminder: the key `AIzaSyCMpwIrjlPkx8zJj91usvhq6Kaw3weqlN0` was pasted in chat — please rotate it.