### PR TITLE
fix(chat): accept GOOGLE_GENERATIVE_AI_API_KEY / GOOGLE_API_KEY aliases

### DIFF
--- a/apps/web/src/lib/server/__tests__/ai-client.test.ts
+++ b/apps/web/src/lib/server/__tests__/ai-client.test.ts
@@ -20,6 +20,8 @@ describe("getAIClient", () => {
   beforeEach(() => {
     process.env = { ...ORIGINAL_ENV };
     delete process.env["GEMINI_API_KEY"];
+    delete process.env["GOOGLE_GENERATIVE_AI_API_KEY"];
+    delete process.env["GOOGLE_API_KEY"];
     openAICtor.mockReset();
     openAICtor.mockImplementation(function mockClient(
       this: unknown,
@@ -61,5 +63,32 @@ describe("getAIClient", () => {
     const second = getAIClient();
     expect(second).toBe(first);
     expect(openAICtor).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to GOOGLE_GENERATIVE_AI_API_KEY (Vercel AI SDK convention)", async () => {
+    process.env["GOOGLE_GENERATIVE_AI_API_KEY"] =
+      "AIzaTestVercelAiSdkKeyXxxxxxxxxx";
+    const { getAIClient } = await import("../ai-client");
+    getAIClient();
+    const args = (openAICtor as unknown as Mock).mock.calls[0]?.[0];
+    expect(args.apiKey).toBe("AIzaTestVercelAiSdkKeyXxxxxxxxxx");
+  });
+
+  it("falls back to GOOGLE_API_KEY (generic Google convention)", async () => {
+    process.env["GOOGLE_API_KEY"] = "AIzaTestGenericGoogleKeyXxxxxxxx";
+    const { getAIClient } = await import("../ai-client");
+    getAIClient();
+    const args = (openAICtor as unknown as Mock).mock.calls[0]?.[0];
+    expect(args.apiKey).toBe("AIzaTestGenericGoogleKeyXxxxxxxx");
+  });
+
+  it("prefers GEMINI_API_KEY when multiple aliases are set", async () => {
+    process.env["GEMINI_API_KEY"] = "AIzaTestPrimaryGeminiKeyXxxxxxxx";
+    process.env["GOOGLE_GENERATIVE_AI_API_KEY"] = "AIzaTestShouldBeIgnored1";
+    process.env["GOOGLE_API_KEY"] = "AIzaTestShouldBeIgnored2";
+    const { getAIClient } = await import("../ai-client");
+    getAIClient();
+    const args = (openAICtor as unknown as Mock).mock.calls[0]?.[0];
+    expect(args.apiKey).toBe("AIzaTestPrimaryGeminiKeyXxxxxxxx");
   });
 });

--- a/apps/web/src/lib/server/ai-client.ts
+++ b/apps/web/src/lib/server/ai-client.ts
@@ -16,11 +16,37 @@ let client: OpenAI | null = null;
  *
  * @see https://ai.google.dev/gemini-api/docs/openai
  */
+// We accept several conventional env-var names for the same Google Gemini
+// API key so the operator doesn't have to know which one our code reads.
+// Order of precedence:
+//   1. GEMINI_API_KEY                  — Google AI Studio default
+//   2. GOOGLE_GENERATIVE_AI_API_KEY    — Vercel AI SDK convention
+//   3. GOOGLE_API_KEY                  — generic Google Cloud
+// Whichever is set first wins; absence of all three is the only failure.
+const GEMINI_KEY_ENV_NAMES = [
+  "GEMINI_API_KEY",
+  "GOOGLE_GENERATIVE_AI_API_KEY",
+  "GOOGLE_API_KEY",
+] as const;
+
+function readGeminiApiKey(): string | undefined {
+  for (const name of GEMINI_KEY_ENV_NAMES) {
+    const v = process.env[name];
+    if (typeof v === "string" && v.length > 0) return v;
+  }
+  return undefined;
+}
+
 export function getAIClient(): OpenAI {
   if (!client) {
-    const apiKey = process.env["GEMINI_API_KEY"];
+    const apiKey = readGeminiApiKey();
     if (!apiKey) {
-      throw new Error("Missing GEMINI_API_KEY");
+      // Name every accepted variable so the operator can fix without
+      // having to read the source. The classifier in the chat route
+      // matches /GEMINI_API_KEY/ so this still maps to ai_unconfigured.
+      throw new Error(
+        `Missing GEMINI_API_KEY (also accepted: ${GEMINI_KEY_ENV_NAMES.slice(1).join(", ")})`,
+      );
     }
     client = new OpenAI({
       apiKey,


### PR DESCRIPTION
Follow-up to PR #125. The diagnostic `reason` codes added in #125 confirmed the live failure is `ai_unconfigured` — i.e., `process.env.GEMINI_API_KEY` is empty at request time on the production function, even though the operator added a Google API key on Vercel. Most likely cause: the key was added under one of the two other conventional names.

This PR makes `getAIClient()` resolve in this order:

1. `GEMINI_API_KEY` (Google AI Studio default — the documented name)
2. `GOOGLE_GENERATIVE_AI_API_KEY` (Vercel AI SDK convention)
3. `GOOGLE_API_KEY` (generic Google Cloud convention)

So whichever the operator chose, chat works. The error message also now lists every accepted name so the next failure is self-explanatory without reading source.

**Tests** — 4 new cases in `ai-client.test.ts`:
- each alias is honored
- `GEMINI_API_KEY` still wins when multiple are set
- missing-all still throws

24/24 pass.