### PR TITLE
fix(chat): public /api/chat/diag endpoint + build SHA in error envelope

### DIFF
--- a/apps/web/src/app/api/chat/diag/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/diag/__tests__/route.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GET } from "../route";
+
+describe("GET /api/chat/diag", () => {
+  const origEnv = process.env;
+  beforeEach(() => {
+    process.env = { ...origEnv };
+    delete process.env.GEMINI_API_KEY;
+    delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    delete process.env.GOOGLE_API_KEY;
+    delete process.env.VERCEL_GIT_COMMIT_SHA;
+    delete process.env.COMMIT_SHA;
+    delete process.env.GITHUB_SHA;
+  });
+  afterEach(() => {
+    process.env = origEnv;
+    vi.restoreAllMocks();
+  });
+
+  it("returns ok=false and a clear hint when no Gemini alias is set", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      buildSha: string;
+      buildShaShort: string;
+      aliases: Record<string, boolean>;
+      aiEnvInventory: string[];
+      hint: string;
+    };
+    expect(body.ok).toBe(false);
+    expect(body.aliases).toEqual({
+      GEMINI_API_KEY: false,
+      GOOGLE_GENERATIVE_AI_API_KEY: false,
+      GOOGLE_API_KEY: false,
+    });
+    expect(body.hint).toMatch(/No Gemini key alias/i);
+  });
+
+  it("returns ok=true when GEMINI_API_KEY is set, without leaking the value", async () => {
+    process.env.GEMINI_API_KEY = "AIza-secret-value";
+    const res = await GET();
+    const body = (await res.json()) as {
+      ok: boolean;
+      aliases: Record<string, boolean>;
+      aiEnvInventory: string[];
+      hint: string;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.aliases.GEMINI_API_KEY).toBe(true);
+    const raw = JSON.stringify(body);
+    expect(raw).not.toContain("AIza-secret-value");
+    expect(body.hint).toMatch(/At least one Gemini key alias is set/i);
+  });
+
+  it("recognises GOOGLE_GENERATIVE_AI_API_KEY and GOOGLE_API_KEY aliases", async () => {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "v1";
+    process.env.GOOGLE_API_KEY = "v2";
+    const res = await GET();
+    const body = (await res.json()) as {
+      ok: boolean;
+      aliases: Record<string, boolean>;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.aliases.GOOGLE_GENERATIVE_AI_API_KEY).toBe(true);
+    expect(body.aliases.GOOGLE_API_KEY).toBe(true);
+  });
+
+  it("includes the build SHA from VERCEL_GIT_COMMIT_SHA", async () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = "abcdef1234567890";
+    const res = await GET();
+    const body = (await res.json()) as {
+      buildSha: string;
+      buildShaShort: string;
+    };
+    expect(body.buildSha).toBe("abcdef1234567890");
+    expect(body.buildShaShort).toBe("abcdef1");
+  });
+
+  it("falls back to 'unknown' when no SHA env is set", async () => {
+    const res = await GET();
+    const body = (await res.json()) as { buildSha: string };
+    expect(body.buildSha).toBe("unknown");
+  });
+
+  it("lists key-shaped env names but never their values", async () => {
+    process.env.GEMINI_API_KEY = "secret-gemini";
+    process.env.SOME_OTHER_API_KEY = "secret-other";
+    process.env.UNRELATED_VAR = "ignored";
+    const res = await GET();
+    const body = (await res.json()) as { aiEnvInventory: string[] };
+    expect(body.aiEnvInventory).toContain("GEMINI_API_KEY");
+    expect(body.aiEnvInventory).toContain("SOME_OTHER_API_KEY");
+    expect(body.aiEnvInventory).not.toContain("UNRELATED_VAR");
+    const raw = JSON.stringify(body);
+    expect(raw).not.toContain("secret-gemini");
+    expect(raw).not.toContain("secret-other");
+  });
+
+  it("sets no-store cache header so a stale CDN copy can never mask reality", async () => {
+    const res = await GET();
+    expect(res.headers.get("cache-control") || "").toMatch(/no-store/i);
+  });
+});

--- a/apps/web/src/app/api/chat/diag/route.ts
+++ b/apps/web/src/app/api/chat/diag/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+
+// Public diagnostic endpoint for the chat subsystem.
+//
+// Returns ONLY:
+//   * The build SHA the running deployment was compiled from (so an operator
+//     can verify which commit is live without needing Vercel dashboard access).
+//   * Boolean presence of each Gemini-key alias the chat route accepts.
+//   * The list of env variable NAMES (never values) that look like AI / API
+//     credentials. This is identical to what the top-level chat error catch
+//     surfaces on `ai_unconfigured`, but available without having to provoke
+//     a 500 from the chat route. Names are already documented publicly in
+//     `.env.example`, so listing them does not leak secrets.
+//
+// This endpoint is intentionally unauthenticated so the operator can hit it
+// from any browser tab — including the user-facing app — to instantly
+// confirm whether the deployment they are talking to has the Gemini key set.
+// No values are ever returned.
+export const dynamic = "force-dynamic";
+
+const NEEDLE =
+  /(GEMINI|GOOGLE|OPENAI|ANTHROPIC|VERTEX|AI[_-]?KEY|API[_-]?KEY)/i;
+const SAFE_TO_LIST = /^[A-Z][A-Z0-9_]{2,80}$/;
+
+function listAiEnvNames(): string[] {
+  return Object.keys(process.env)
+    .filter(
+      (k) =>
+        SAFE_TO_LIST.test(k) &&
+        NEEDLE.test(k) &&
+        typeof process.env[k] === "string" &&
+        (process.env[k] as string).length > 0,
+    )
+    .sort();
+}
+
+export async function GET() {
+  const buildSha =
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.COMMIT_SHA ||
+    process.env.GITHUB_SHA ||
+    "unknown";
+  const buildShaShort = buildSha.slice(0, 7);
+  const aliases = {
+    GEMINI_API_KEY: Boolean(process.env.GEMINI_API_KEY),
+    GOOGLE_GENERATIVE_AI_API_KEY: Boolean(
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+    ),
+    GOOGLE_API_KEY: Boolean(process.env.GOOGLE_API_KEY),
+  } as const;
+  const anyAliasSet = Object.values(aliases).some(Boolean);
+  const aiEnvInventory = listAiEnvNames();
+  return NextResponse.json(
+    {
+      ok: anyAliasSet,
+      buildSha,
+      buildShaShort,
+      aliases,
+      aiEnvInventory,
+      hint: anyAliasSet
+        ? "At least one Gemini key alias is set. If chat still fails the cause is downstream (model quota, network, db)."
+        : "No Gemini key alias is set on this deployment's runtime. Add GEMINI_API_KEY (or one of the accepted aliases) under Vercel → Settings → Environment Variables → Production, then redeploy.",
+    },
+    {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -538,6 +538,16 @@ export async function POST(request: NextRequest) {
       error: errMsg,
       stack: err instanceof Error ? err.stack : undefined,
     });
+    // Embed the build SHA in every error so that when a user pastes the
+    // message we can immediately tell which deployment served the request
+    // (Vercel deployment URLs are pinned per build, so a stale tab can hit
+    // an old build forever — this label removes that ambiguity).
+    const buildSha =
+      process.env.VERCEL_GIT_COMMIT_SHA ||
+      process.env.COMMIT_SHA ||
+      process.env.GITHUB_SHA ||
+      "unknown";
+    const buildShaShort = buildSha.slice(0, 7);
     let userFacing: string;
     if (reason === "ai_unconfigured") {
       const found =
@@ -545,15 +555,16 @@ export async function POST(request: NextRequest) {
           ? aiEnvInventory.join(", ")
           : "none";
       userFacing =
-        `Chat request failed (ai_unconfigured, request ${requestId}). ` +
+        `Chat request failed (ai_unconfigured, request ${requestId}, build ${buildShaShort}). ` +
         `No GEMINI_API_KEY / GOOGLE_GENERATIVE_AI_API_KEY / GOOGLE_API_KEY ` +
         `is set in this deployment's runtime env. Key-shaped vars present: ${found}. ` +
         `Add the key under one of those three names in Vercel → Settings → ` +
-        `Environment Variables → Production, then redeploy.`;
+        `Environment Variables → Production, then redeploy. ` +
+        `Visit /api/chat/diag for a live env-presence check.`;
     } else if (reason) {
-      userFacing = `Chat request failed (${reason}, request ${requestId}). Please contact the site operator.`;
+      userFacing = `Chat request failed (${reason}, request ${requestId}, build ${buildShaShort}). Please contact the site operator.`;
     } else {
-      userFacing = `Chat request failed (request ${requestId}). Please try again.`;
+      userFacing = `Chat request failed (request ${requestId}, build ${buildShaShort}). Please try again.`;
     }
     return attachRequestId(
       NextResponse.json(
@@ -561,6 +572,7 @@ export async function POST(request: NextRequest) {
           error: userFacing,
           requestId,
           reason,
+          buildSha,
           ...(aiEnvInventory ? { aiEnvInventory } : {}),
         },
         { status: 500 },


### PR DESCRIPTION
Closes the diagnostic loop on the lingering ai_unconfigured production failure.

**Why** — the user's last error pasted verbatim a string that exists only in pre-PR-#127 code, while the latest deploy of main is a09ddf1 (post-#127). Vercel pins each deploy to its own URL, so a stale browser tab can hit an old build forever. We need to (a) confirm which build a request actually hit, and (b) check env presence without provoking a 500.

**Changes**

1. **New GET /api/chat/diag** — public, unauthenticated. Returns build SHA, boolean presence of each Gemini key alias, key-shaped env-name inventory, and a hint string. Visiting it from any tab instantly reveals if the deployment serving the page has the key set.
2. **Build SHA in chat error envelope** — every user-facing chat error now includes uild <short-sha> so a pasted error message identifies the exact deploy that served it.

**Safety** — never returns env values; only NAMES (already public in .env.example) and the public commit SHA.

**Tests** — 7 new diag tests + 18 existing chat route tests + 14 thread tests = 39 passing. tsc clean.