### PR TITLE
perf(chat): no-buffer streaming headers + forward AbortSignal upstream

### DIFF
--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -477,4 +477,38 @@ describe("POST /api/chat", () => {
     expect(body.error).toMatch(/Chat request failed/);
     expect(body.error).not.toMatch(new RegExp(internalErrorText));
   });
+
+  it("sets no-buffer streaming headers so intermediaries cannot pool the response", async () => {
+    // Without these headers Vercel's edge / nginx-style proxies will
+    // buffer the entire model response and flush it as a single chunk,
+    // defeating the token-by-token streaming UX. Lock them in.
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() => textOnlyStream(["ok"]));
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") || "").toMatch(
+      /text\/plain; charset=utf-8/i,
+    );
+    expect(res.headers.get("cache-control") || "").toMatch(/no-store/i);
+    expect(res.headers.get("cache-control") || "").toMatch(/no-transform/i);
+    expect(res.headers.get("x-accel-buffering") || "").toBe("no");
+    // Drain so the persistAssistant tail-effect runs cleanly.
+    await res.text();
+  });
+
+  it("forwards the inbound AbortSignal to the upstream stream call", async () => {
+    // Closing the browser tab mid-reply must also cancel the upstream
+    // Gemini call, otherwise we keep paying for tokens nobody will see.
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() => textOnlyStream(["ok"]));
+    const res = await POST(jsonRequest({ message: "hi" }));
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(streamMock).toHaveBeenCalled();
+    const lastCall = streamMock.mock.calls[streamMock.mock.calls.length - 1];
+    // Second positional arg is the request options object (signal lives here).
+    const opts = lastCall?.[1] as { signal?: AbortSignal } | undefined;
+    expect(opts).toBeDefined();
+    expect(opts?.signal).toBeInstanceOf(AbortSignal);
+  });
 });

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -310,14 +310,21 @@ export async function POST(request: NextRequest) {
 
         try {
           for (let iter = 0; iter < MAX_TOOL_ITERATIONS; iter++) {
-            const stream = openai.chat.completions.stream({
-              model: MODEL,
-              messages: working,
-              tools: CHAT_TOOL_DEFINITIONS,
-              tool_choice: "auto",
-              temperature: 0.3,
-              stream: true,
-            });
+            const stream = openai.chat.completions.stream(
+              {
+                model: MODEL,
+                messages: working,
+                tools: CHAT_TOOL_DEFINITIONS,
+                tool_choice: "auto",
+                temperature: 0.3,
+                stream: true,
+              },
+              // Forward the inbound request's AbortSignal so a client
+              // disconnect mid-reply also cancels the upstream Gemini
+              // call. Without this, navigating away wastes tokens for
+              // up to MAX_TOOL_ITERATIONS rounds of completion.
+              { signal: request.signal },
+            );
 
             for await (const chunk of stream) {
               const delta = chunk.choices[0]?.delta?.content;
@@ -470,7 +477,12 @@ export async function POST(request: NextRequest) {
 
     const responseHeaders: Record<string, string> = {
       "Content-Type": "text/plain; charset=utf-8",
-      "Transfer-Encoding": "chunked",
+      // Defeat any intermediary buffering so tokens reach the browser the
+      // moment the model emits them. Without these, Vercel's edge layer
+      // and any proxy in between can pool the response into one big
+      // chunk, defeating the streaming UX.
+      "Cache-Control": "no-store, no-transform",
+      "X-Accel-Buffering": "no",
     };
     if (threadId) {
       responseHeaders["X-Chat-Thread-Id"] = threadId;


### PR DESCRIPTION
Two real-world optimizations now that chat is fully working:

1. **No-buffer streaming headers** — add Cache-Control: no-store, no-transform and X-Accel-Buffering: no on the streamed response. Without them, Vercel's edge layer / any intermediary proxy can pool the response into one chunk, killing the token-by-token UX. (Removed the manually-set Transfer-Encoding: chunked header — Next.js manages this for streamed responses.)

2. **Forward AbortSignal to upstream** — pass request.signal into openai.chat.completions.stream(). Today, when a user navigates away mid-reply, the upstream Gemini call keeps generating up to MAX_TOOL_ITERATIONS rounds — wasted tokens & quota. Now the disconnect propagates.

**Tests:** 2 new tests lock both behaviours in. 345/345 across suite. tsc + lint clean. Production build succeeds.