### PR TITLE
Chat image upload + analysis + realtime cross-page refresh

### DIFF
--- a/apps/web/src/app/(app)/dashboard/__tests__/page.test.tsx
+++ b/apps/web/src/app/(app)/dashboard/__tests__/page.test.tsx
@@ -2,6 +2,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
+vi.mock("@/components/live-analysis-refresher", () => ({
+  LiveAnalysisRefresher: () => null,
+}));
+
 vi.mock("@/lib/server/profile", () => ({
   getCurrentProfile: vi.fn(async () => ({
     displayName: "Ada Lovelace",

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
   ShieldIcon,
   SparkIcon,
 } from "@/components/icons";
+import { LiveAnalysisRefresher } from "@/components/live-analysis-refresher";
 import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -416,6 +417,7 @@ export default async function DashboardPage() {
           </CardContent>
         </Card>
       </section>
+      <LiveAnalysisRefresher growIds={overview.grows.map((g) => g.id)} />
     </main>
   );
 }

--- a/apps/web/src/app/(app)/grows/page.tsx
+++ b/apps/web/src/app/(app)/grows/page.tsx
@@ -18,6 +18,7 @@ import {
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 import { getWorkspaceOverview } from "@/lib/server/workspace-overview";
+import { LiveAnalysisRefresher } from "@/components/live-analysis-refresher";
 
 export const metadata: Metadata = { title: "Grows" };
 
@@ -237,6 +238,7 @@ export default async function GrowsPage() {
           </CardContent>
         </Card>
       </section>
+      <LiveAnalysisRefresher growIds={overview.grows.map((g) => g.id)} />
     </main>
   );
 }

--- a/apps/web/src/app/(app)/plants/[plantId]/page.tsx
+++ b/apps/web/src/app/(app)/plants/[plantId]/page.tsx
@@ -10,6 +10,7 @@ import {
   SparkIcon,
   TimelineIcon,
 } from "@/components/icons";
+import { LiveAnalysisRefresher } from "@/components/live-analysis-refresher";
 import { UploadPhotoPanel } from "@/components/upload-photo-panel";
 import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
@@ -532,6 +533,7 @@ export default async function PlantPage({ params }: Props) {
           </Card>
         </div>
       </section>
+      <LiveAnalysisRefresher growIds={[context.growId]} />
     </main>
   );
 }

--- a/apps/web/src/app/(app)/plants/page.tsx
+++ b/apps/web/src/app/(app)/plants/page.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
+import { LiveAnalysisRefresher } from "@/components/live-analysis-refresher";
 import { PageHeader } from "@/components/ui/page-header";
 import {
   listAccessibleGrows,
@@ -160,6 +161,7 @@ export default async function PlantsPage() {
           </CardContent>
         </Card>
       </section>
+      <LiveAnalysisRefresher growIds={grows.map((g) => g.id)} />
     </main>
   );
 }

--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -21,12 +21,17 @@ import {
   executeChatTool,
 } from "@/lib/server/chat-tools";
 import {
+  appendChatAttachment,
   appendMessage,
   assertThreadOwner,
   createThread,
   touchThread,
 } from "@/lib/server/chat-persistence";
+import { runAndPersistPlantAnalysis } from "@/lib/server/plants";
+import { getAuthorizedPlantContext } from "@/lib/server/plant-access";
+import { getStorageClient } from "@/lib/server/storage";
 import type {
+  ChatCompletionContentPart,
   ChatCompletionMessageParam,
   ChatCompletionMessageToolCall,
 } from "openai/resources/chat/completions";
@@ -120,6 +125,7 @@ export async function POST(request: NextRequest) {
       growId?: string;
       plantId?: string;
       history?: unknown;
+      attachments?: unknown;
     };
     try {
       body = (await request.json()) as typeof body;
@@ -135,10 +141,67 @@ export async function POST(request: NextRequest) {
 
     const message =
       typeof body?.message === "string" ? body.message.trim() : "";
-    if (!message) {
+
+    // Parse and validate attachments BEFORE the empty-message check, so a
+    // user can send an image with no text ("what's wrong with this plant?"
+    // is a perfectly valid wordless intent).
+    type IncomingAttachment = {
+      kind: "image";
+      plantId: string;
+      imageId: string;
+      storagePath: string;
+    };
+    const MAX_ATTACHMENTS = 1; // MVP: serial analysis comparisons require this.
+    const rawAttachments = Array.isArray(body.attachments)
+      ? body.attachments
+      : [];
+    if (rawAttachments.length > MAX_ATTACHMENTS) {
       return attachRequestId(
         NextResponse.json(
-          { error: "message is required", requestId },
+          {
+            error: `Up to ${MAX_ATTACHMENTS} attachment per message is supported right now.`,
+            requestId,
+          },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    const attachments: IncomingAttachment[] = [];
+    for (const a of rawAttachments) {
+      if (
+        !a ||
+        typeof a !== "object" ||
+        (a as { kind?: unknown }).kind !== "image" ||
+        typeof (a as { plantId?: unknown }).plantId !== "string" ||
+        typeof (a as { imageId?: unknown }).imageId !== "string" ||
+        typeof (a as { storagePath?: unknown }).storagePath !== "string"
+      ) {
+        return attachRequestId(
+          NextResponse.json(
+            {
+              error:
+                "Each attachment must be { kind: 'image', plantId, imageId, storagePath }.",
+              requestId,
+            },
+            { status: 400 },
+          ),
+          requestId,
+        );
+      }
+      const att = a as IncomingAttachment;
+      attachments.push({
+        kind: "image",
+        plantId: att.plantId,
+        imageId: att.imageId,
+        storagePath: att.storagePath,
+      });
+    }
+
+    if (!message && attachments.length === 0) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "message or attachment is required", requestId },
           { status: 400 },
         ),
         requestId,
@@ -213,6 +276,16 @@ export async function POST(request: NextRequest) {
     // authenticated user id; anonymous flows shouldn't happen here (we 401'd
     // upstream) but we guard anyway. threadId is declared at the function
     // scope above so the top-level catch can include it in error logs.
+    let userMessageId: string | null = null;
+    // Effective text we tell the model the user said. When the user sent
+    // only an image with no text, we synthesize a minimal default so the
+    // model has *some* instruction; when they sent text, we use it as-is.
+    const effectiveUserText =
+      message ||
+      (attachments.length > 0
+        ? "Please analyze this plant image and explain anything notable, including changes versus prior images if you can see them."
+        : "");
+
     if (userId) {
       const incomingThreadId =
         typeof body.threadId === "string" && body.threadId.length > 0
@@ -234,18 +307,150 @@ export async function POST(request: NextRequest) {
         threadId = await createThread({
           userId,
           growId,
-          firstUserMessage: message,
+          firstUserMessage: effectiveUserText,
         });
       }
 
       // Persist the user message before we call out to the model so the
-      // transcript is durable even if the stream errors.
+      // transcript is durable even if the stream errors. We capture the
+      // returned id so attachment rows can foreign-key to this exact
+      // chat_messages row.
       if (threadId) {
-        await appendMessage({
+        userMessageId = await appendMessage({
           threadId,
           role: "user",
-          content: message,
+          content: effectiveUserText,
         });
+      }
+    }
+
+    // ─── Inline image analysis ──────────────────────────────────────────────
+    // For each attachment, run the existing sync plant-analysis pipeline so
+    // (a) the timeline gets a new analysis row and (b) the model has the
+    // findings JSON in its context. We bound this with an 8s timeout per
+    // image — beyond that the user is left waiting too long for chat
+    // streaming to feel responsive, so we fall back to a "still working on
+    // it" message and let the realtime channel push the result to whatever
+    // page they navigate to next.
+    type ResolvedAttachment = {
+      kind: "image";
+      plantId: string;
+      imageId: string;
+      storagePath: string;
+      analysisJson: unknown | null;
+      analysisId: string | null;
+      timedOut: boolean;
+      errorMessage?: string;
+      // Base64 data URL of the image bytes, ready to drop into a
+      // multimodal user message as `image_url`.
+      dataUrl: string | null;
+    };
+    const ANALYSIS_TIMEOUT_MS = 8_000;
+    const resolvedAttachments: ResolvedAttachment[] = [];
+    if (attachments.length > 0) {
+      const storage = getStorageClient();
+      for (const att of attachments) {
+        // Authorize the plant — RLS-gated via the user's session — before
+        // doing anything expensive. We deliberately do NOT trust the
+        // imageId/storagePath the client sent; we only re-verify the plant.
+        // The image row's existence is verified implicitly by
+        // runAndPersistPlantAnalysis selecting it.
+        const plantCtx = await getAuthorizedPlantContext(att.plantId);
+        if (!plantCtx) {
+          resolvedAttachments.push({
+            ...att,
+            analysisJson: null,
+            analysisId: null,
+            timedOut: false,
+            errorMessage: "plant not accessible",
+            dataUrl: null,
+          });
+          continue;
+        }
+
+        // Pull the raw image bytes from storage in parallel with the
+        // analysis call so we don't double the wall-time.
+        const downloadPromise = storage
+          .from("plant-images")
+          .download(att.storagePath)
+          .then(async ({ data, error }) => {
+            if (error || !data) return null;
+            try {
+              const buf = Buffer.from(await data.arrayBuffer());
+              // Default to image/jpeg if we don't know — Gemini accepts
+              // any of the standard image MIMEs for image_url parts.
+              const mime = (data as Blob).type || "image/jpeg";
+              return `data:${mime};base64,${buf.toString("base64")}`;
+            } catch {
+              return null;
+            }
+          })
+          .catch(() => null);
+
+        const analysisPromise = runAndPersistPlantAnalysis({
+          plantId: att.plantId,
+          imageId: att.imageId,
+          requestId,
+        }).then(
+          (r) => ({ ok: true as const, value: r }),
+          (err: unknown) => ({
+            ok: false as const,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+        );
+
+        const timeoutPromise = new Promise<{ timedOut: true }>((resolve) =>
+          setTimeout(() => resolve({ timedOut: true }), ANALYSIS_TIMEOUT_MS),
+        );
+
+        const [analysisOutcome, dataUrl] = await Promise.all([
+          Promise.race([analysisPromise, timeoutPromise]),
+          downloadPromise,
+        ]);
+
+        if ("timedOut" in analysisOutcome) {
+          resolvedAttachments.push({
+            ...att,
+            analysisJson: null,
+            analysisId: null,
+            timedOut: true,
+            dataUrl,
+          });
+        } else if (!analysisOutcome.ok) {
+          resolvedAttachments.push({
+            ...att,
+            analysisJson: null,
+            analysisId: null,
+            timedOut: false,
+            errorMessage: analysisOutcome.error,
+            dataUrl,
+          });
+        } else {
+          const r = analysisOutcome.value;
+          resolvedAttachments.push({
+            ...att,
+            analysisJson: r?.analysis ?? null,
+            analysisId: r?.analysisId ?? null,
+            timedOut: false,
+            dataUrl,
+          });
+        }
+
+        // Persist the chat_message_attachments row regardless of analysis
+        // outcome — we want the image visible in the transcript even if
+        // analysis timed out (the realtime channel will fill in the
+        // analysis result on whatever page the user navigates to).
+        const last = resolvedAttachments[resolvedAttachments.length - 1]!;
+        if (userMessageId) {
+          await appendChatAttachment({
+            messageId: userMessageId,
+            kind: "image",
+            plantId: att.plantId,
+            imageId: att.imageId,
+            storagePath: att.storagePath,
+            analysisId: last.analysisId,
+          });
+        }
       }
     }
 
@@ -255,14 +460,71 @@ export async function POST(request: NextRequest) {
 
     const openai = getAIClient();
 
+    // Build the user turn. When images are attached we send a multipart
+    // content array (text + image_url for each image) so Gemini's
+    // OpenAI-compat endpoint sees the actual pixels — that's the whole
+    // point of attaching an image to a chat message.
+    const userParts: ChatCompletionContentPart[] = [];
+    if (effectiveUserText) {
+      userParts.push({ type: "text", text: effectiveUserText });
+    }
+    for (const att of resolvedAttachments) {
+      if (att.dataUrl) {
+        userParts.push({
+          type: "image_url",
+          image_url: { url: att.dataUrl },
+        });
+      }
+    }
+
+    // Build an analysis-results system note from any attachments that
+    // completed analysis in time. Including the structured findings JSON
+    // alongside the raw image gives the model both signal sources to
+    // ground its reply in.
+    let analysisSystemNote: string | null = null;
+    const analyzed = resolvedAttachments.filter((a) => a.analysisJson !== null);
+    const stillRunning = resolvedAttachments.filter((a) => a.timedOut);
+    const failed = resolvedAttachments.filter(
+      (a) => a.errorMessage && !a.timedOut,
+    );
+    if (analyzed.length > 0 || stillRunning.length > 0 || failed.length > 0) {
+      const lines: string[] = ["## Inline image analysis"];
+      for (const a of analyzed) {
+        lines.push(
+          `- Plant ${a.plantId} / image ${a.imageId}: ${JSON.stringify(a.analysisJson).slice(0, 4_000)}`,
+        );
+      }
+      for (const a of stillRunning) {
+        lines.push(
+          `- Plant ${a.plantId} / image ${a.imageId}: analysis still running (timed out > ${ANALYSIS_TIMEOUT_MS}ms). Tell the user the analysis is processing and will appear on the plant page shortly.`,
+        );
+      }
+      for (const a of failed) {
+        lines.push(
+          `- Plant ${a.plantId} / image ${a.imageId}: analysis failed (${a.errorMessage}). Continue from visual inspection only.`,
+        );
+      }
+      analysisSystemNote = lines.join("\n");
+    }
+
     const baseMessages: ChatCompletionMessageParam[] = [
       { role: "system", content: CHAT_SYSTEM_PROMPT },
       { role: "system", content: renderGrowContextBlock(growContext) },
+      ...(analysisSystemNote
+        ? ([
+            { role: "system", content: analysisSystemNote },
+          ] as ChatCompletionMessageParam[])
+        : []),
       ...history.map<ChatCompletionMessageParam>((m) => ({
         role: m.role,
         content: m.content,
       })),
-      { role: "user", content: message },
+      {
+        role: "user",
+        content: userParts.some((p) => p.type === "image_url")
+          ? userParts
+          : effectiveUserText,
+      },
     ];
 
     const encoder = new TextEncoder();

--- a/apps/web/src/app/api/grows/[growId]/quick-capture-plant/route.ts
+++ b/apps/web/src/app/api/grows/[growId]/quick-capture-plant/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  createSupabaseServerClient,
+  getServerSession,
+} from "@/lib/server/auth";
+import { getOrCreateQuickCapturePlant } from "@/lib/server/plants";
+import { attachRequestId, getOrCreateRequestId } from "@/lib/server/request-id";
+
+// POST /api/grows/[growId]/quick-capture-plant
+// Returns the (auto-created if missing) "Quick captures" plant id for the
+// given grow. Used by the chat composer when the user attaches an image
+// without first picking a specific plant — every chat-uploaded image must
+// land in a real plants row so the existing analysis + timeline pipelines
+// can take it from there unmodified.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ growId: string }> },
+) {
+  const requestId = getOrCreateRequestId(request);
+  const { growId } = await params;
+  if (!growId) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "growId is required.", requestId },
+        { status: 400 },
+      ),
+      requestId,
+    );
+  }
+
+  const session = await getServerSession();
+  if (!session?.user) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "You must be signed in.", requestId },
+        { status: 401 },
+      ),
+      requestId,
+    );
+  }
+
+  // Ownership check via the user-scoped client (RLS).
+  const supabase = await createSupabaseServerClient();
+  const { data: ownedGrow, error: ownershipError } = await supabase
+    .from("grows")
+    .select("id")
+    .eq("id", growId)
+    .maybeSingle();
+  if (ownershipError) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Failed to verify grow access.", requestId },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
+  if (!ownedGrow) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Grow not found.", requestId },
+        { status: 404 },
+      ),
+      requestId,
+    );
+  }
+
+  const result = await getOrCreateQuickCapturePlant({ growId });
+  if (!result) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Could not create quick-capture plant.", requestId },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
+
+  const res = NextResponse.json({ plantId: result.plantId, requestId });
+  return attachRequestId(res, requestId);
+}

--- a/apps/web/src/app/api/uploads/sign/route.ts
+++ b/apps/web/src/app/api/uploads/sign/route.ts
@@ -48,6 +48,7 @@ export async function POST(request: NextRequest) {
     takenAt?: string;
     source?: "camera" | "upload";
     notes?: string;
+    chatThreadId?: string;
   };
 
   if (!body.plantId || !body.fileName || !body.contentType) {
@@ -55,6 +56,24 @@ export async function POST(request: NextRequest) {
       NextResponse.json(
         { error: "plantId, fileName, and contentType are required", requestId },
         { status: 400 },
+      ),
+      requestId,
+    );
+  }
+
+  // Explicitly recognise (and reject) video MIME types with a structured
+  // reason code so the chat UI can render a "video coming soon" affordance
+  // instead of a generic "Unsupported content type" toast. Video support
+  // requires frame-extraction infrastructure not yet in place.
+  if (body.contentType.startsWith("video/")) {
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error: "Video uploads are not yet supported.",
+          reason: "video_unsupported",
+          requestId,
+        },
+        { status: 415 },
       ),
       requestId,
     );
@@ -91,7 +110,11 @@ export async function POST(request: NextRequest) {
     }
 
     return attachRequestId(
-      NextResponse.json({ ...prepared, requestId }),
+      NextResponse.json({
+        ...prepared,
+        chatThreadId: body.chatThreadId ?? null,
+        requestId,
+      }),
       requestId,
     );
   } catch (error) {

--- a/apps/web/src/app/assistant/chat-client.tsx
+++ b/apps/web/src/app/assistant/chat-client.tsx
@@ -6,6 +6,8 @@ import {
   useMemo,
   useRef,
   useState,
+  type ChangeEvent,
+  type DragEvent,
   type FormEvent,
   type KeyboardEvent,
   type ReactNode,
@@ -14,14 +16,24 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { SendIcon } from "@/components/ui/icons";
 import { cn } from "@/lib/cn";
+import { createSupabaseBrowserClient } from "@/lib/supabase-client";
 import { renderMarkdown } from "./markdown";
 
 type Role = "user" | "assistant";
+
+type ChatAttachment = {
+  id?: string;
+  kind: "image";
+  plantId: string;
+  imageId: string;
+  storagePath: string;
+};
 
 interface Message {
   id: string;
   role: Role;
   content: string;
+  attachments?: ChatAttachment[];
 }
 
 type PromptCategory = {
@@ -132,6 +144,16 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [threadsLoading, setThreadsLoading] = useState(false);
 
+  // Image upload state. We support a single pending attachment per turn
+  // (server enforces the same limit for the inline analysis path); the
+  // resolved plant id is sticky across the thread so the user only has
+  // to pick a target plant on the FIRST attachment of a thread.
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [attachmentUploading, setAttachmentUploading] = useState(false);
+  const [threadPlantId, setThreadPlantId] = useState<string | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
   const abortRef = useRef<AbortController | null>(null);
   const scrollerRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -186,6 +208,8 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
     setThreadId(null);
     setMessages([WELCOME]);
     setError(null);
+    setPendingFile(null);
+    setThreadPlantId(null);
   }, []);
 
   const loadThread = useCallback(async (id: string) => {
@@ -201,13 +225,44 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
         return;
       }
       const data = (await res.json()) as {
-        messages: Array<{ id: string; role: Role; content: string }>;
+        messages: Array<{
+          id: string;
+          role: Role;
+          content: string;
+          attachments?: Array<{
+            id?: string;
+            kind: string;
+            plantId: string;
+            imageId: string;
+            storagePath: string;
+          }>;
+        }>;
       };
       const loaded: Message[] = (data.messages ?? [])
         .filter((m) => m.role === "user" || m.role === "assistant")
-        .map((m) => ({ id: m.id, role: m.role, content: m.content }));
+        .map((m) => ({
+          id: m.id,
+          role: m.role,
+          content: m.content,
+          attachments: (m.attachments ?? [])
+            .filter((a) => a.kind === "image")
+            .map((a) => {
+              const att: ChatAttachment = {
+                kind: "image",
+                plantId: a.plantId,
+                imageId: a.imageId,
+                storagePath: a.storagePath,
+              };
+              if (a.id) att.id = a.id;
+              return att;
+            }),
+        }));
       setMessages(loaded.length > 0 ? loaded : [WELCOME]);
       setThreadId(id);
+      // Reset attachment selection when switching threads — last thread's
+      // selected plant should not bleed into the new one.
+      setPendingFile(null);
+      setThreadPlantId(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load thread.");
     }
@@ -233,10 +288,140 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
     [refreshThreads, startNewThread, threadId],
   );
 
+  // Resolves the plant id to attach images to. Sticky per thread: once
+  // resolved (either via the user picking a specific plant or the
+  // auto-created "Quick captures" inbox for the active grow) we reuse it
+  // for subsequent attachments in the same thread.
+  const resolveAttachmentPlantId = useCallback(async (): Promise<
+    string | null
+  > => {
+    if (threadPlantId) return threadPlantId;
+    if (!growId) {
+      setError(
+        "Pick a grow before attaching an image — uploads are organized per grow.",
+      );
+      return null;
+    }
+    try {
+      const res = await fetch(
+        `/api/grows/${encodeURIComponent(growId)}/quick-capture-plant`,
+        { method: "POST" },
+      );
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setError(
+          data.error || `Failed to prepare plant for upload (${res.status}).`,
+        );
+        return null;
+      }
+      const data = (await res.json()) as { plantId?: string };
+      if (!data.plantId) {
+        setError("Server did not return a plant id for the upload.");
+        return null;
+      }
+      setThreadPlantId(data.plantId);
+      return data.plantId;
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to prepare attachment.",
+      );
+      return null;
+    }
+  }, [growId, threadPlantId]);
+
+  const uploadPendingAttachment = useCallback(
+    async (file: File): Promise<ChatAttachment | null> => {
+      const plantId = await resolveAttachmentPlantId();
+      if (!plantId) return null;
+
+      setAttachmentUploading(true);
+      try {
+        const signRes = await fetch("/api/uploads/sign", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            plantId,
+            fileName: file.name,
+            contentType: file.type || "image/jpeg",
+            chatThreadId: threadId,
+          }),
+        });
+        const signPayload = (await signRes.json()) as {
+          error?: string;
+          reason?: string;
+          imageId?: string;
+          storagePath?: string;
+          token?: string;
+        };
+        if (!signRes.ok) {
+          if (signPayload.reason === "video_unsupported") {
+            setError("Video uploads aren't supported yet — try an image.");
+          } else {
+            setError(signPayload.error || "Failed to prepare upload.");
+          }
+          return null;
+        }
+        if (
+          !signPayload.storagePath ||
+          !signPayload.token ||
+          !signPayload.imageId
+        ) {
+          setError("Upload signing did not return the required fields.");
+          return null;
+        }
+
+        const supabase = createSupabaseBrowserClient();
+        const { error: uploadError } = await supabase.storage
+          .from("plant-images")
+          .uploadToSignedUrl(signPayload.storagePath, signPayload.token, file, {
+            contentType: file.type || "image/jpeg",
+          });
+        if (uploadError) {
+          setError(uploadError.message);
+          return null;
+        }
+
+        // Persist the plant_images row so the existing analysis +
+        // timeline pipelines can find it.
+        const persistRes = await fetch(`/api/plants/${plantId}/images`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            imageId: signPayload.imageId,
+            storagePath: signPayload.storagePath,
+            source: "upload",
+          }),
+        });
+        if (!persistRes.ok) {
+          const data = (await persistRes.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          setError(data.error || "Failed to record uploaded image.");
+          return null;
+        }
+
+        return {
+          kind: "image",
+          plantId,
+          imageId: signPayload.imageId,
+          storagePath: signPayload.storagePath,
+        };
+      } finally {
+        setAttachmentUploading(false);
+      }
+    },
+    [resolveAttachmentPlantId, threadId],
+  );
+
   const send = useCallback(
     async (text: string) => {
       const trimmed = text.trim();
-      if (!trimmed) return;
+      const hasFile = pendingFile !== null;
+      // Either text or a file is required — server allows the file-only
+      // case and synthesizes a default prompt.
+      if (!trimmed && !hasFile) return;
       // Two-phase guard against double-click / double-submit races:
       // 1. abortRef catches the case where the previous fetch hasn't yet
       //    finished and the user clicks Send (or Enter) again.
@@ -245,11 +430,37 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
       //    the guard relied on streaming state which is async and gives a
       //    short race window where two fetches could fire.
       if (abortRef.current) return;
+      if (attachmentUploading) return;
       const controller = new AbortController();
       abortRef.current = controller;
       setError(null);
 
-      const userMsg: Message = { id: newId(), role: "user", content: trimmed };
+      // If there's a pending file we have to upload it BEFORE we POST to
+      // /api/chat — the chat route consumes attachment refs and runs
+      // analysis inline. We deliberately do this before any UI state
+      // mutation so an upload failure leaves the composer intact for
+      // retry.
+      let uploadedAttachment: ChatAttachment | null = null;
+      if (pendingFile) {
+        uploadedAttachment = await uploadPendingAttachment(pendingFile);
+        if (!uploadedAttachment) {
+          abortRef.current = null;
+          return;
+        }
+      }
+
+      const displayText =
+        trimmed ||
+        "Please analyze this plant image and tell me what you see, including changes from prior images.";
+      const attachments: ChatAttachment[] = uploadedAttachment
+        ? [uploadedAttachment]
+        : [];
+      const userMsg: Message = {
+        id: newId(),
+        role: "user",
+        content: displayText,
+        attachments,
+      };
       const assistantId = newId();
 
       let historyToSend: Array<{ role: Role; content: string }> = [];
@@ -265,6 +476,7 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
         ];
       });
       setInput("");
+      setPendingFile(null);
       setStreaming(true);
 
       try {
@@ -276,6 +488,12 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
             history: historyToSend,
             growId,
             threadId,
+            attachments: attachments.map((a) => ({
+              kind: a.kind,
+              plantId: a.plantId,
+              imageId: a.imageId,
+              storagePath: a.storagePath,
+            })),
           }),
           signal: controller.signal,
         });
@@ -331,8 +549,62 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
         abortRef.current = null;
       }
     },
-    [growId, refreshThreads, threadId],
+    [
+      attachmentUploading,
+      growId,
+      pendingFile,
+      refreshThreads,
+      threadId,
+      uploadPendingAttachment,
+    ],
   );
+
+  const onFileSelected = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    if (!file) return;
+    if (file.type.startsWith("video/")) {
+      setError("Video uploads aren't supported yet — try an image.");
+      return;
+    }
+    if (!file.type.startsWith("image/")) {
+      setError("Only image files can be attached right now.");
+      return;
+    }
+    setPendingFile(file);
+    setError(null);
+    // Allow re-selecting the same file later (browsers don't fire change
+    // for an unchanged value).
+    e.target.value = "";
+  };
+
+  const onDragEnter = (e: DragEvent<HTMLFormElement>) => {
+    if (e.dataTransfer?.types.includes("Files")) {
+      e.preventDefault();
+      setDragActive(true);
+    }
+  };
+  const onDragLeave = (e: DragEvent<HTMLFormElement>) => {
+    if (e.currentTarget === e.target) setDragActive(false);
+  };
+  const onDragOver = (e: DragEvent<HTMLFormElement>) => {
+    if (e.dataTransfer?.types.includes("Files")) e.preventDefault();
+  };
+  const onDrop = (e: DragEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setDragActive(false);
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    if (file.type.startsWith("video/")) {
+      setError("Video uploads aren't supported yet — try an image.");
+      return;
+    }
+    if (!file.type.startsWith("image/")) {
+      setError("Only image files can be attached right now.");
+      return;
+    }
+    setPendingFile(file);
+    setError(null);
+  };
 
   const onSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -536,43 +808,106 @@ export function AssistantChat({ grows }: { grows: GrowOption[] }) {
           <div className="mx-auto w-full max-w-3xl px-5 py-4 sm:px-6 lg:px-8">
             <form
               onSubmit={onSubmit}
-              className="flex items-end gap-2 rounded-lg border border-input bg-background p-2 shadow-elevation-1 focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/40"
+              onDragEnter={onDragEnter}
+              onDragLeave={onDragLeave}
+              onDragOver={onDragOver}
+              onDrop={onDrop}
+              className={cn(
+                "flex flex-col gap-2 rounded-lg border border-input bg-background p-2 shadow-elevation-1 focus-within:border-ring focus-within:ring-2 focus-within:ring-ring/40",
+                dragActive && "border-primary ring-2 ring-primary/40",
+              )}
               aria-label="Send message"
             >
-              <label htmlFor="composer" className="sr-only">
-                Ask the copilot
-              </label>
-              <textarea
-                ref={textareaRef}
-                id="composer"
-                rows={1}
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={onKeyDown}
-                maxLength={4000}
-                placeholder="Ask about your grow — symptoms, EC, training, IPM…  (Enter to send, Shift+Enter for newline)"
-                disabled={streaming}
-                className="max-h-48 min-h-[2.5rem] flex-1 resize-none border-0 bg-transparent px-2 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/heic"
+                className="sr-only"
+                onChange={onFileSelected}
+                aria-label="Attach a plant image"
               />
-              {streaming ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="md"
-                  onClick={stop}
-                >
-                  Stop
-                </Button>
-              ) : (
-                <Button
-                  type="submit"
-                  size="md"
-                  disabled={!input.trim()}
-                  rightIcon={<SendIcon width={14} height={14} />}
-                >
-                  Send
-                </Button>
+              {pendingFile && (
+                <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2 py-1.5 text-xs">
+                  <span aria-hidden>📷</span>
+                  <span
+                    className="truncate font-medium"
+                    title={pendingFile.name}
+                  >
+                    {pendingFile.name}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {(pendingFile.size / 1024).toFixed(0)} KB
+                  </span>
+                  {attachmentUploading && (
+                    <span className="text-muted-foreground">uploading…</span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => setPendingFile(null)}
+                    aria-label="Remove attachment"
+                    disabled={attachmentUploading || streaming}
+                    className="ml-auto rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50"
+                  >
+                    ×
+                  </button>
+                </div>
               )}
+              <div className="flex items-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={streaming || attachmentUploading}
+                  className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                  aria-label="Attach an image"
+                  title={
+                    growId
+                      ? "Attach a plant image"
+                      : "Pick a grow first to attach an image"
+                  }
+                >
+                  <span className="text-lg leading-none">📎</span>
+                </button>
+                <label htmlFor="composer" className="sr-only">
+                  Ask the copilot
+                </label>
+                <textarea
+                  ref={textareaRef}
+                  id="composer"
+                  rows={1}
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={onKeyDown}
+                  maxLength={4000}
+                  placeholder={
+                    pendingFile
+                      ? "Add an optional note about the image…"
+                      : "Ask about your grow — symptoms, EC, training, IPM…  (Enter to send, Shift+Enter for newline). Drag in an image to analyze it."
+                  }
+                  disabled={streaming}
+                  className="max-h-48 min-h-[2.5rem] flex-1 resize-none border-0 bg-transparent px-2 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                />
+                {streaming ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="md"
+                    onClick={stop}
+                  >
+                    Stop
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    size="md"
+                    disabled={
+                      attachmentUploading || (!input.trim() && !pendingFile)
+                    }
+                    rightIcon={<SendIcon width={14} height={14} />}
+                  >
+                    Send
+                  </Button>
+                )}
+              </div>
             </form>
             <p className="mt-2 text-center text-[11px] text-muted-foreground">
               Replies are generated by AI grounded in your grow data. Verify
@@ -605,7 +940,24 @@ function ChatBubble({
     );
   } else if (isUser) {
     rendered = (
-      <span className="whitespace-pre-wrap break-words">{message.content}</span>
+      <div className="space-y-2">
+        {message.attachments && message.attachments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {message.attachments.map((a, idx) => (
+              <span
+                key={a.id ?? `${a.imageId}-${idx}`}
+                className="inline-flex items-center gap-1 rounded-md bg-primary/20 px-2 py-0.5 text-[11px] font-medium text-primary-foreground/90"
+                title={`Image ${a.imageId}`}
+              >
+                <span aria-hidden>📷</span> image attached
+              </span>
+            ))}
+          </div>
+        )}
+        <span className="whitespace-pre-wrap break-words">
+          {message.content}
+        </span>
+      </div>
     );
   } else {
     rendered = (

--- a/apps/web/src/components/live-analysis-refresher.tsx
+++ b/apps/web/src/components/live-analysis-refresher.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useLiveAnalysis } from "@/lib/use-live-analysis";
+
+/**
+ * Tiny client island that subscribes to live analysis events for the
+ * given grows and triggers `router.refresh()` when new analyses or
+ * findings land. Render this from any server component that wants its
+ * data to update automatically when the chat composer (or any other
+ * surface) creates a new analysis.
+ *
+ * Returns nothing visible — it's pure side effect. Place it at the
+ * bottom of the page so it doesn't affect layout.
+ */
+export function LiveAnalysisRefresher({ growIds }: { growIds: string[] }) {
+  useLiveAnalysis({ growIds });
+  return null;
+}

--- a/apps/web/src/lib/server/__tests__/plants.test.ts
+++ b/apps/web/src/lib/server/__tests__/plants.test.ts
@@ -93,9 +93,12 @@ function makeAnalysisPersistenceDb(params?: {
     ],
     params?.imageError,
   );
-  const upsert = vi.fn().mockResolvedValue({
+  const single = vi.fn().mockResolvedValue({
+    data: params?.upsertError ? null : { id: "analysis-1" },
     error: params?.upsertError ? { message: params.upsertError } : null,
   });
+  const upsertSelect = vi.fn(() => ({ single }));
+  const upsert = vi.fn(() => ({ select: upsertSelect }));
   const deleteEq = vi.fn().mockResolvedValue({
     error: params?.deleteError ? { message: params.deleteError } : null,
   });
@@ -788,7 +791,12 @@ describe("plants server helpers", () => {
       ],
       error: null,
     });
-    const upsert = vi.fn().mockResolvedValue({ error: null });
+    const upsertSingle = vi
+      .fn()
+      .mockResolvedValue({ data: { id: "analysis-1" }, error: null });
+    const upsert = vi.fn(() => ({
+      select: vi.fn(() => ({ single: upsertSingle })),
+    }));
     const deleteEq = vi.fn().mockResolvedValue({ error: null });
     const deleteFn = vi.fn(() => ({ eq: deleteEq }));
     const insert = vi.fn().mockResolvedValue({ error: null });

--- a/apps/web/src/lib/server/chat-persistence.ts
+++ b/apps/web/src/lib/server/chat-persistence.ts
@@ -21,12 +21,22 @@ export type ChatThreadRow = {
   updatedAt: string;
 };
 
+export type ChatMessageAttachment = {
+  id: string;
+  kind: "image";
+  plantId: string;
+  imageId: string;
+  storagePath: string;
+  analysisId: string | null;
+};
+
 export type ChatMessageRow = {
   id: string;
   threadId: string;
   role: "user" | "assistant" | "system";
   content: string;
   createdAt: string;
+  attachments: ChatMessageAttachment[];
 };
 
 function deriveTitle(firstUserMessage: string): string {
@@ -84,8 +94,11 @@ export async function appendMessage(params: {
   role: "user" | "assistant" | "system";
   content: string;
   metadata?: Record<string, unknown>;
-}): Promise<void> {
-  if (!params.content) return;
+}): Promise<string | null> {
+  // Allow empty content when an attachment is the user's only payload.
+  // (Empty assistant rows are still skipped — the streaming path only calls
+  // this after at least one token landed.)
+  if (params.role !== "user" && !params.content) return null;
   const db = getDbClient();
   // The chat_messages.valid_metadata constraint requires the JSON object to
   // contain at least one of tokens / model / context. We don't try to write
@@ -98,11 +111,48 @@ export async function appendMessage(params: {
   if (params.metadata && Object.keys(params.metadata).length > 0) {
     insertRow["metadata"] = params.metadata;
   }
-  const { error } = await db.from("chat_messages").insert(insertRow);
-  if (error) {
+  const { data, error } = await db
+    .from("chat_messages")
+    .insert(insertRow)
+    .select("id")
+    .single();
+  if (error || !data) {
     logServerEvent("error", "chat message insert failed", {
       threadId: params.threadId,
       role: params.role,
+      error: error?.message ?? "no row",
+    });
+    return null;
+  }
+  return (data as { id: string }).id;
+}
+
+/**
+ * Records a chat-message attachment row (image uploaded inline in the
+ * assistant chat). Service-role insert; RLS on the table gates downstream
+ * reads to the thread owner.
+ */
+export async function appendChatAttachment(params: {
+  messageId: string;
+  kind: "image";
+  plantId: string;
+  imageId: string;
+  storagePath: string;
+  analysisId?: string | null;
+}): Promise<void> {
+  const db = getDbClient();
+  const { error } = await db.from("chat_message_attachments").insert({
+    message_id: params.messageId,
+    kind: params.kind,
+    plant_id: params.plantId,
+    image_id: params.imageId,
+    storage_path: params.storagePath,
+    analysis_id: params.analysisId ?? null,
+  });
+  if (error) {
+    logServerEvent("error", "chat attachment insert failed", {
+      messageId: params.messageId,
+      imageId: params.imageId,
       error: error.message,
     });
   }
@@ -169,7 +219,9 @@ export async function getThreadMessages(
 
   const { data, error } = await supabase
     .from("chat_messages")
-    .select("id,thread_id,role,content,created_at")
+    .select(
+      "id,thread_id,role,content,created_at,chat_message_attachments(id,kind,plant_id,image_id,storage_path,analysis_id)",
+    )
     .eq("thread_id", threadId)
     .order("created_at", { ascending: true })
     .limit(500);
@@ -187,6 +239,14 @@ export async function getThreadMessages(
       role: "user" | "assistant" | "system";
       content: string;
       created_at: string;
+      chat_message_attachments?: Array<{
+        id: string;
+        kind: "image";
+        plant_id: string;
+        image_id: string;
+        storage_path: string;
+        analysis_id: string | null;
+      }> | null;
     }>
   ).map((row) => ({
     id: row.id,
@@ -194,6 +254,14 @@ export async function getThreadMessages(
     role: row.role,
     content: row.content,
     createdAt: row.created_at,
+    attachments: (row.chat_message_attachments ?? []).map((a) => ({
+      id: a.id,
+      kind: a.kind,
+      plantId: a.plant_id,
+      imageId: a.image_id,
+      storagePath: a.storage_path,
+      analysisId: a.analysis_id,
+    })),
   }));
 }
 

--- a/apps/web/src/lib/server/chat-prompt.ts
+++ b/apps/web/src/lib/server/chat-prompt.ts
@@ -49,6 +49,14 @@ You have tools to look up the grower's actual data — grows, plants, findings, 
 
 Call a tool *before* speculating. If a tool returns nothing, say so plainly and ask for the missing detail. Never invent data.
 
+# Image-attached turns
+When the user attaches a plant image, you can:
+- See the image directly (it's included in the user turn).
+- Read the structured analysis JSON in a "## Inline image analysis" system note (when present).
+- Pull more history with the \`get_analysis_history\` tool to discuss trends across recent images.
+
+When images are attached, lead with what you actually observe in the image, then cross-check against the analysis JSON. If the analysis is still running (timeout note in the system block), say so and give your visual read while the structured result catches up. If multiple images for the same plant are in the conversation history, comment on what changed.
+
 # Boundaries
 - Cultivation only. If asked about legality, medical use, dosing, dispensary advice, or anything off-topic, redirect once politely and stay on cultivation.
 - No claims about medical efficacy.

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -118,6 +118,26 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_analysis_history",
+      description:
+        "Return the recent image-analysis history for a plant (newest first) so you can describe trends over time. Each row includes overall_health_score, summary, comparison_summary, model_version, and created_at — use these to discuss progression, regression, or stability.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: { type: "string" },
+          limit: {
+            type: "number",
+            description: "Max history rows. Default 8, max 20.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -150,6 +170,10 @@ const EventsArgs = z.object({
   sinceDays: z.number().optional(),
 });
 const LatestAnalysisArgs = z.object({ plantId: z.string().min(1) });
+const AnalysisHistoryArgs = z.object({
+  plantId: z.string().min(1),
+  limit: z.number().optional(),
+});
 
 type ChatToolContext = {
   userId: string | null;
@@ -315,6 +339,21 @@ export async function executeChatTool(
             .maybeSingle();
           if (error) return { ok: false, error: error.message };
           return { ok: true, data: data ?? null };
+        }
+
+        case "get_analysis_history": {
+          const args = AnalysisHistoryArgs.parse(rawArgs);
+          const limit = numClamp(args.limit, 8, 20);
+          const { data, error } = await supabase
+            .from("plant_analyses")
+            .select(
+              "id,plant_id,image_id,overall_health_score,summary,comparison_summary,analysis_mode,is_fallback,model_version,analyzed_at,created_at",
+            )
+            .eq("plant_id", args.plantId)
+            .order("analyzed_at", { ascending: false })
+            .limit(limit);
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
         }
 
         default:

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -453,28 +453,33 @@ export async function runAndPersistPlantAnalysis(params: {
 
   const analysis = await analyzeImage(analyzeParams);
 
-  const { error: upsertError } = await db.from("plant_analyses").upsert(
-    {
-      plant_id: context.plantId,
-      grow_id: context.growId,
-      image_id: currentImage.id,
-      compared_to_image_id: analysis.comparedToImageId ?? null,
-      overall_health_score: analysis.overallHealthScore,
-      summary: analysis.summary,
-      comparison_summary: analysis.comparisonSummary ?? null,
-      analyzed_at: analysis.analyzedAt,
-      model_version: analysis.modelVersion,
-      analysis_mode: analysis.analysisMode ?? "fallback",
-      is_fallback: analysis.isFallback ?? false,
-      fallback_reason: analysis.fallbackReason ?? null,
-      request_id: analysis.requestId ?? params.requestId,
-    },
-    { onConflict: "image_id" },
-  );
+  const { data: upsertData, error: upsertError } = await db
+    .from("plant_analyses")
+    .upsert(
+      {
+        plant_id: context.plantId,
+        grow_id: context.growId,
+        image_id: currentImage.id,
+        compared_to_image_id: analysis.comparedToImageId ?? null,
+        overall_health_score: analysis.overallHealthScore,
+        summary: analysis.summary,
+        comparison_summary: analysis.comparisonSummary ?? null,
+        analyzed_at: analysis.analyzedAt,
+        model_version: analysis.modelVersion,
+        analysis_mode: analysis.analysisMode ?? "fallback",
+        is_fallback: analysis.isFallback ?? false,
+        fallback_reason: analysis.fallbackReason ?? null,
+        request_id: analysis.requestId ?? params.requestId,
+      },
+      { onConflict: "image_id" },
+    )
+    .select("id")
+    .single();
 
   if (upsertError) {
     throw new Error(`Failed to persist plant analysis: ${upsertError.message}`);
   }
+  const analysisId = (upsertData as { id: string } | null)?.id ?? null;
 
   const { error: deleteError } = await db
     .from("plant_findings")
@@ -514,5 +519,57 @@ export async function runAndPersistPlantAnalysis(params: {
     isFallback: analysis.isFallback,
   });
 
-  return { context, analysis };
+  return { context, analysis, analysisId, imageId: currentImage.id };
+}
+
+/**
+ * Returns the plant id of the "Quick captures" plant in the given grow,
+ * creating it on first use. Used by the chat upload flow when the user
+ * snaps a picture without picking a specific plant — we still need a
+ * plant_id (so the existing analysis pipeline + RLS policies work
+ * unchanged) so we route those uploads to a per-grow inbox plant.
+ *
+ * Authorization: the caller must already have authenticated the grow_id
+ * (we trust the caller; we don't re-check ownership here because the only
+ * call site is inside the chat route after the user has picked a grow that
+ * the loadGrowContextSummary RLS-gated query already returned).
+ */
+export async function getOrCreateQuickCapturePlant(params: {
+  growId: string;
+}): Promise<{ plantId: string } | null> {
+  const db = getDbClient();
+  const { data: existing, error: lookupError } = await db
+    .from("plants")
+    .select("id")
+    .eq("grow_id", params.growId)
+    .eq("name", "Quick captures")
+    .maybeSingle();
+  if (lookupError) {
+    logServerEvent("error", "quick capture plant lookup failed", {
+      growId: params.growId,
+      error: lookupError.message,
+    });
+    return null;
+  }
+  if (existing) {
+    return { plantId: (existing as { id: string }).id };
+  }
+  const { data: created, error: insertError } = await db
+    .from("plants")
+    .insert({
+      grow_id: params.growId,
+      name: "Quick captures",
+      notes:
+        "Auto-created inbox for images uploaded in chat without a specific plant.",
+    })
+    .select("id")
+    .single();
+  if (insertError || !created) {
+    logServerEvent("error", "quick capture plant create failed", {
+      growId: params.growId,
+      error: insertError?.message ?? "no row",
+    });
+    return null;
+  }
+  return { plantId: (created as { id: string }).id };
 }

--- a/apps/web/src/lib/use-live-analysis.ts
+++ b/apps/web/src/lib/use-live-analysis.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createSupabaseBrowserClient } from "@/lib/supabase-client";
+
+/**
+ * Subscribes to Supabase Realtime INSERT events on `plant_analyses` and
+ * `plant_findings` for the user's grows and triggers a Next App Router
+ * `router.refresh()` whenever a new row lands. This is what makes the
+ * `/plants/[id]`, `/dashboard`, and `/grows` pages update on their own
+ * after the chat composer kicks off an analysis on a fresh image — no
+ * manual reload required.
+ *
+ * Implementation notes:
+ * - Postgres-changes filters only support `eq.` (and similar single-value
+ *   ops). They do NOT support `in.()`. We therefore subscribe to one
+ *   channel per grow_id and let RLS enforce read access if anyone tries
+ *   to spoof. For zero growIds we no-op (no subscriptions, no refresh).
+ * - We debounce refreshes with a short trailing window — a single
+ *   analysis can produce N findings rows in quick succession and we only
+ *   need one server re-render to pick them all up.
+ * - The supabase_realtime publication must include these tables; that
+ *   ALTER PUBLICATION call lives in `supabase/migrations/006_chat_attachments.sql`.
+ */
+export function useLiveAnalysis({ growIds }: { growIds: string[] }) {
+  const router = useRouter();
+  const [lastEventAt, setLastEventAt] = useState<number | null>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (growIds.length === 0) return;
+    const supabase = createSupabaseBrowserClient();
+
+    const scheduleRefresh = () => {
+      setLastEventAt(Date.now());
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        router.refresh();
+      }, 300);
+    };
+
+    const channels = growIds.map((growId) => {
+      const channel = supabase
+        .channel(`live-analysis:${growId}`)
+        .on(
+          "postgres_changes",
+          {
+            event: "INSERT",
+            schema: "public",
+            table: "plant_analyses",
+            filter: `grow_id=eq.${growId}`,
+          },
+          scheduleRefresh,
+        )
+        .on(
+          "postgres_changes",
+          {
+            event: "INSERT",
+            schema: "public",
+            table: "plant_findings",
+            // plant_findings has no grow_id column; we just listen for
+            // any insert and let the upstream debounce + RLS handle the
+            // rest. RLS ensures we only receive findings for plants in
+            // grows the user can read.
+          },
+          scheduleRefresh,
+        )
+        .subscribe();
+      return channel;
+    });
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      for (const ch of channels) {
+        void supabase.removeChannel(ch);
+      }
+    };
+  }, [growIds, router]);
+
+  return { lastEventAt };
+}

--- a/supabase/migrations/006_chat_attachments.sql
+++ b/supabase/migrations/006_chat_attachments.sql
@@ -1,0 +1,83 @@
+-- 006_chat_attachments.sql
+-- Adds the join table for chat-message attachments (images uploaded inline in
+-- the assistant chat) and enables Postgres-changes realtime on the analysis
+-- tables so other pages can refresh live when a new analysis lands.
+--
+-- Design notes:
+--   * One row per (chat_message, image). Chat MVP enforces at most one image
+--     attachment per user message at the application layer; the schema does
+--     not enforce that so future "compare these two photos" turns can attach
+--     multiple without a migration.
+--   * `analysis_id` is nullable + ON DELETE SET NULL because the analysis row
+--     may be created asynchronously (timeout fallback path) or may be cleaned
+--     up later without us wanting to lose the attachment record itself.
+--   * RLS read = owner of the parent chat_thread (mirrors chat_messages
+--     exactly, intentionally — the rubber-duck called this out as a
+--     potential leak vector if we got it wrong).
+--   * No user-facing INSERT policy: writes go through service-role from the
+--     chat route, same posture as chat_messages.
+
+create table chat_message_attachments (
+  id          uuid primary key default gen_random_uuid(),
+  message_id  uuid not null references chat_messages(id) on delete cascade,
+  kind        text not null check (kind in ('image')),
+  plant_id    uuid not null references plants(id) on delete cascade,
+  image_id    uuid not null references plant_images(id) on delete cascade,
+  analysis_id uuid references plant_analyses(id) on delete set null,
+  storage_path text not null,
+  created_at  timestamptz not null default now()
+);
+
+alter table chat_message_attachments enable row level security;
+
+create policy "chat_message_attachments: thread owner read"
+  on chat_message_attachments for select
+  using (
+    exists (
+      select 1
+      from chat_messages cm
+      join chat_threads ct on ct.id = cm.thread_id
+      where cm.id = chat_message_attachments.message_id
+        and ct.user_id = auth.uid()
+    )
+  );
+
+create index idx_chat_message_attachments_message_id
+  on chat_message_attachments(message_id);
+create index idx_chat_message_attachments_plant_id
+  on chat_message_attachments(plant_id);
+create index idx_chat_message_attachments_image_id
+  on chat_message_attachments(image_id);
+
+-- ─── Realtime publication ────────────────────────────────────────────────────
+-- Supabase Realtime watches the supabase_realtime publication. Tables added to
+-- it AFTER the publication exists are NOT auto-included unless we explicitly
+-- add them. The chat-driven analysis flow needs other open pages (plant
+-- detail, dashboard, grow) to refresh when a new analysis row or finding
+-- lands, so we add those tables here.
+--
+-- Wrapped in a DO block because re-running the migration on an environment
+-- where the table is already published would otherwise throw.
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'plant_analyses'
+  ) then
+    execute 'alter publication supabase_realtime add table public.plant_analyses';
+  end if;
+
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'plant_findings'
+  ) then
+    execute 'alter publication supabase_realtime add table public.plant_findings';
+  end if;
+
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime' and schemaname = 'public' and tablename = 'plant_images'
+  ) then
+    execute 'alter publication supabase_realtime add table public.plant_images';
+  end if;
+end$$;


### PR DESCRIPTION
## What

End-to-end image attachment in the assistant chat: upload, analyze, persist as plant timeline events, and live-update the dashboard / grows / plants pages when new analyses land.

## Highlights
- POST /api/chat accepts attachments[] (max 1 per turn), runs analysis racing an 8s timeout, and feeds both the raw image (multimodal) and structured analysis JSON to Gemini.
- New chat_message_attachments table (migration 006) with realtime publication for plant_analyses, plant_findings, plant_images.
- /api/uploads/sign echoes chatThreadId and rejects video with a typed reason.
- /api/grows/[growId]/quick-capture-plant resolves a per-grow 'Quick captures' plant for ad-hoc chat uploads.
- Chat client: paperclip button, drag-drop, preview pill, attachment indicator in user bubbles, file-only sends.
- get_analysis_history chat tool + image-attached prompt guidance.
- useLiveAnalysis + <LiveAnalysisRefresher /> wired into /dashboard, /grows, /plants, /plants/[plantId].

## Verification
- pnpm tsc --noEmit ✅
- pnpm lint ✅
- pnpm build ✅
- pnpm vitest run ✅ (345/345)

## Follow-ups (not in this PR)
- Inline image thumbnails in chat bubbles (signed download endpoint)
- Video support (frame extraction)
- Async fallback: if 8s timeout fires, enqueue analysis_jobs row so late results still land