### PR TITLE
test: cover chat attachments, quick-capture, useLiveAnalysis

### DIFF
--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -8,6 +8,7 @@ const executeChatTool = vi.fn();
 
 vi.mock("@/lib/server/auth", () => ({
   getServerSession: (...args: unknown[]) => getServerSession(...args),
+  createSupabaseServerClient: vi.fn(),
 }));
 
 const getAIClient = vi.fn();
@@ -29,12 +30,35 @@ const assertThreadOwner = vi.fn();
 const createThread = vi.fn();
 const appendMessage = vi.fn();
 const touchThread = vi.fn();
+const appendChatAttachment = vi.fn();
 
 vi.mock("@/lib/server/chat-persistence", () => ({
   assertThreadOwner: (...args: unknown[]) => assertThreadOwner(...args),
   createThread: (...args: unknown[]) => createThread(...args),
   appendMessage: (...args: unknown[]) => appendMessage(...args),
   touchThread: (...args: unknown[]) => touchThread(...args),
+  appendChatAttachment: (...args: unknown[]) => appendChatAttachment(...args),
+}));
+
+const runAndPersistPlantAnalysis = vi.fn();
+vi.mock("@/lib/server/plants", () => ({
+  runAndPersistPlantAnalysis: (...args: unknown[]) =>
+    runAndPersistPlantAnalysis(...args),
+}));
+
+const getAuthorizedPlantContext = vi.fn();
+vi.mock("@/lib/server/plant-access", () => ({
+  getAuthorizedPlantContext: (...args: unknown[]) =>
+    getAuthorizedPlantContext(...args),
+}));
+
+const storageDownload = vi.fn();
+vi.mock("@/lib/server/storage", () => ({
+  getStorageClient: () => ({
+    from: () => ({
+      download: (...args: unknown[]) => storageDownload(...args),
+    }),
+  }),
 }));
 
 import { __resetRateLimitStore } from "@/lib/server/rate-limit";
@@ -120,9 +144,17 @@ describe("POST /api/chat", () => {
     createThread.mockReset();
     appendMessage.mockReset();
     touchThread.mockReset();
+    appendChatAttachment.mockReset();
+    runAndPersistPlantAnalysis.mockReset();
+    getAuthorizedPlantContext.mockReset();
+    storageDownload.mockReset();
     createThread.mockResolvedValue("thread_new");
-    appendMessage.mockResolvedValue(undefined);
+    // appendMessage returns the new message id so the attachments path can
+    // associate chat_message_attachments rows with the user turn. Existing
+    // tests that don't check the return value are unaffected.
+    appendMessage.mockResolvedValue("msg_new");
     touchThread.mockResolvedValue(undefined);
+    appendChatAttachment.mockResolvedValue(undefined);
     getAIClient.mockReturnValue({
       chat: {
         completions: {
@@ -510,5 +542,214 @@ describe("POST /api/chat", () => {
     const opts = lastCall?.[1] as { signal?: AbortSignal } | undefined;
     expect(opts).toBeDefined();
     expect(opts?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  // ─── Attachments path ────────────────────────────────────────────────────
+
+  function imageAttachment(overrides: Partial<Record<string, string>> = {}) {
+    return {
+      kind: "image" as const,
+      plantId: "plant-1",
+      imageId: "img-1",
+      storagePath: "u1/plant-1/img-1.jpg",
+      ...overrides,
+    };
+  }
+
+  function fakeBlob(bytes = "fake-jpg-bytes", mime = "image/jpeg") {
+    return {
+      type: mime,
+      arrayBuffer: async () => new TextEncoder().encode(bytes).buffer,
+    };
+  }
+
+  it("rejects more than one attachment per turn (MVP cap)", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    const res = await POST(
+      jsonRequest({
+        message: "hi",
+        attachments: [imageAttachment(), imageAttachment({ imageId: "img-2" })],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(streamMock).not.toHaveBeenCalled();
+    expect(appendChatAttachment).not.toHaveBeenCalled();
+  });
+
+  it("rejects attachments missing required fields", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    const res = await POST(
+      jsonRequest({
+        message: "hi",
+        attachments: [{ kind: "image", plantId: "p1" }],
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(streamMock).not.toHaveBeenCalled();
+  });
+
+  it("allows an empty message when an attachment is present", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() => textOnlyStream(["leaves look fine"]));
+    getAuthorizedPlantContext.mockResolvedValue({
+      plantId: "plant-1",
+      growId: "g1",
+      name: "Blue Dream",
+    });
+    storageDownload.mockResolvedValue({ data: fakeBlob(), error: null });
+    runAndPersistPlantAnalysis.mockResolvedValue({
+      analysis: { summary: "healthy" },
+      analysisId: "an-1",
+      imageId: "img-1",
+      context: {},
+    });
+
+    const res = await POST(
+      jsonRequest({ message: "", attachments: [imageAttachment()] }),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(streamMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends a multimodal user message (text + image_url) and a system note with the analysis JSON", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() => textOnlyStream(["ack"]));
+    getAuthorizedPlantContext.mockResolvedValue({
+      plantId: "plant-1",
+      growId: "g1",
+      name: "Blue Dream",
+    });
+    storageDownload.mockResolvedValue({ data: fakeBlob(), error: null });
+    runAndPersistPlantAnalysis.mockResolvedValue({
+      analysis: { summary: "minor N deficiency" },
+      analysisId: "an-1",
+      imageId: "img-1",
+      context: {},
+    });
+
+    const res = await POST(
+      jsonRequest({
+        message: "what's wrong?",
+        attachments: [imageAttachment()],
+      }),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+
+    expect(runAndPersistPlantAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({ plantId: "plant-1", imageId: "img-1" }),
+    );
+    expect(appendChatAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "msg_new",
+        kind: "image",
+        plantId: "plant-1",
+        imageId: "img-1",
+        analysisId: "an-1",
+      }),
+    );
+
+    const args = streamMock.mock.calls[0]?.[0] as {
+      messages: Array<{
+        role: string;
+        content:
+          | string
+          | Array<{ type: string; text?: string; image_url?: { url: string } }>;
+      }>;
+    };
+    // The user message should be a multimodal parts array.
+    const userMsg = args.messages[args.messages.length - 1];
+    expect(Array.isArray(userMsg?.content)).toBe(true);
+    const parts = userMsg!.content as Array<{
+      type: string;
+      text?: string;
+      image_url?: { url: string };
+    }>;
+    expect(
+      parts.some((p) => p.type === "text" && p.text === "what's wrong?"),
+    ).toBe(true);
+    const imagePart = parts.find((p) => p.type === "image_url");
+    expect(imagePart?.image_url?.url).toMatch(/^data:image\/jpeg;base64,/);
+
+    // A system note containing the analysis JSON must be present so the
+    // model has structured findings to cross-check against the pixels.
+    const systemNotes = args.messages
+      .filter((m) => m.role === "system")
+      .map((m) => (typeof m.content === "string" ? m.content : ""));
+    expect(systemNotes.some((s) => s.includes("minor N deficiency"))).toBe(
+      true,
+    );
+  });
+
+  it("falls back gracefully when analysis times out (still persists attachment, tells the model)", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() =>
+      textOnlyStream(["I'll inspect visually."]),
+    );
+    getAuthorizedPlantContext.mockResolvedValue({
+      plantId: "plant-1",
+      growId: "g1",
+      name: "Blue Dream",
+    });
+    storageDownload.mockResolvedValue({ data: fakeBlob(), error: null });
+    // Never resolves → the 8s timeout wins. Fake timers keep the test fast.
+    runAndPersistPlantAnalysis.mockImplementation(() => new Promise(() => {}));
+
+    vi.useFakeTimers();
+    const promise = POST(
+      jsonRequest({
+        message: "look at this",
+        attachments: [imageAttachment()],
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(9_000);
+    const res = await promise;
+    vi.useRealTimers();
+
+    expect(res.status).toBe(200);
+    await res.text();
+
+    // Attachment row must still be written (with analysisId=null) so the
+    // image is preserved in the transcript.
+    expect(appendChatAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "msg_new",
+        plantId: "plant-1",
+        imageId: "img-1",
+        analysisId: null,
+      }),
+    );
+
+    const args = streamMock.mock.calls[0]?.[0] as {
+      messages: Array<{ role: string; content: unknown }>;
+    };
+    const systemNotes = args.messages
+      .filter((m) => m.role === "system")
+      .map((m) => (typeof m.content === "string" ? m.content : ""))
+      .join("\n");
+    expect(systemNotes).toMatch(/still running|timed? out|in progress/i);
+  });
+
+  it("marks the attachment as inaccessible when the plant fails authorization", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    streamMock.mockImplementation(() => textOnlyStream(["ok"]));
+    // Plant lookup fails → attachment is recorded as not-accessible and we
+    // do NOT hit storage or analysis.
+    getAuthorizedPlantContext.mockResolvedValue(null);
+
+    const res = await POST(
+      jsonRequest({
+        message: "hi",
+        attachments: [imageAttachment({ plantId: "someone-elses-plant" })],
+      }),
+    );
+    expect(res.status).toBe(200);
+    await res.text();
+
+    expect(runAndPersistPlantAnalysis).not.toHaveBeenCalled();
+    expect(storageDownload).not.toHaveBeenCalled();
+    // No attachment row written for an unauthorized plant.
+    expect(appendChatAttachment).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/grows/[growId]/quick-capture-plant/__tests__/route.test.ts
+++ b/apps/web/src/app/api/grows/[growId]/quick-capture-plant/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const getServerSession = vi.fn();
+const createSupabaseServerClient = vi.fn();
+const getOrCreateQuickCapturePlant = vi.fn();
+
+vi.mock("@/lib/server/auth", () => ({
+  getServerSession: (...a: unknown[]) => getServerSession(...a),
+  createSupabaseServerClient: (...a: unknown[]) =>
+    createSupabaseServerClient(...a),
+}));
+
+vi.mock("@/lib/server/plants", () => ({
+  getOrCreateQuickCapturePlant: (...a: unknown[]) =>
+    getOrCreateQuickCapturePlant(...a),
+}));
+
+import { POST } from "../route";
+
+function call(growId: string) {
+  const req = new NextRequest(
+    `http://localhost/api/grows/${growId}/quick-capture-plant`,
+    { method: "POST" },
+  );
+  return POST(req, { params: Promise.resolve({ growId }) });
+}
+
+/**
+ * Builds a minimal Supabase query-builder mock that resolves the
+ * `from(...).select(...).eq(...).maybeSingle()` chain used by the route.
+ */
+function makeSb({ data, error }: { data: unknown; error: unknown }) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    maybeSingle: async () => ({ data, error }),
+  };
+  return { from: () => builder };
+}
+
+describe("POST /api/grows/[growId]/quick-capture-plant", () => {
+  beforeEach(() => {
+    getServerSession.mockReset();
+    createSupabaseServerClient.mockReset();
+    getOrCreateQuickCapturePlant.mockReset();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = await call("g1");
+    expect(res.status).toBe(401);
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+    expect(getOrCreateQuickCapturePlant).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the user does not own the grow (RLS hides it)", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    createSupabaseServerClient.mockResolvedValue(
+      makeSb({ data: null, error: null }),
+    );
+    const res = await call("someone-elses-grow");
+    expect(res.status).toBe(404);
+    expect(getOrCreateQuickCapturePlant).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the ownership query errors", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    createSupabaseServerClient.mockResolvedValue(
+      makeSb({ data: null, error: { message: "db down" } }),
+    );
+    const res = await call("g1");
+    expect(res.status).toBe(500);
+    expect(getOrCreateQuickCapturePlant).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the helper cannot create the plant", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    createSupabaseServerClient.mockResolvedValue(
+      makeSb({ data: { id: "g1" }, error: null }),
+    );
+    getOrCreateQuickCapturePlant.mockResolvedValue(null);
+    const res = await call("g1");
+    expect(res.status).toBe(500);
+    expect(getOrCreateQuickCapturePlant).toHaveBeenCalledWith({ growId: "g1" });
+  });
+
+  it("returns 200 with the plantId on the happy path", async () => {
+    getServerSession.mockResolvedValue({ user: { id: "u1" } });
+    createSupabaseServerClient.mockResolvedValue(
+      makeSb({ data: { id: "g1" }, error: null }),
+    );
+    getOrCreateQuickCapturePlant.mockResolvedValue({ plantId: "plant-qc-1" });
+    const res = await call("g1");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { plantId: string; requestId: string };
+    expect(body.plantId).toBe("plant-qc-1");
+    expect(body.requestId).toBeTruthy();
+  });
+});

--- a/apps/web/src/lib/__tests__/use-live-analysis.test.tsx
+++ b/apps/web/src/lib/__tests__/use-live-analysis.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+type Handler = (_payload: unknown) => void;
+
+interface FakeChannel {
+  handlers: Map<string, Handler>;
+  on: (
+    _event: string,
+    _opts: Record<string, unknown>,
+    _h: Handler,
+  ) => FakeChannel;
+  subscribe: () => FakeChannel;
+}
+
+const removeChannel = vi.fn();
+const channels: FakeChannel[] = [];
+
+function makeChannel(): FakeChannel {
+  const ch: FakeChannel = {
+    handlers: new Map(),
+    on(event, opts, h) {
+      // Key by table so tests can fire either insert source explicitly.
+      const key = `${event}:${(opts as { table?: string }).table ?? ""}`;
+      this.handlers.set(key, h);
+      return this;
+    },
+    subscribe() {
+      return this;
+    },
+  };
+  return ch;
+}
+
+vi.mock("@/lib/supabase-client", () => ({
+  createSupabaseBrowserClient: () => ({
+    channel: () => {
+      const ch = makeChannel();
+      channels.push(ch);
+      return ch;
+    },
+    removeChannel: (...args: unknown[]) => removeChannel(...args),
+  }),
+}));
+
+import { useLiveAnalysis } from "../use-live-analysis";
+
+function Probe({ growIds }: { growIds: string[] }) {
+  useLiveAnalysis({ growIds });
+  return null;
+}
+
+describe("useLiveAnalysis", () => {
+  beforeEach(() => {
+    refresh.mockReset();
+    removeChannel.mockReset();
+    channels.length = 0;
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does nothing when growIds is empty", () => {
+    render(<Probe growIds={[]} />);
+    expect(channels.length).toBe(0);
+  });
+
+  it("subscribes to one channel per growId", () => {
+    render(<Probe growIds={["g1", "g2", "g3"]} />);
+    expect(channels.length).toBe(3);
+    // Each channel should listen on both plant_analyses and plant_findings.
+    for (const ch of channels) {
+      expect(ch.handlers.has("postgres_changes:plant_analyses")).toBe(true);
+      expect(ch.handlers.has("postgres_changes:plant_findings")).toBe(true);
+    }
+  });
+
+  it("debounces a burst of inserts into a single router.refresh()", () => {
+    render(<Probe growIds={["g1"]} />);
+    const ch = channels[0]!;
+    // Simulate one analysis insert + several findings inserts in quick
+    // succession (typical real-world burst).
+    ch.handlers.get("postgres_changes:plant_analyses")?.({});
+    ch.handlers.get("postgres_changes:plant_findings")?.({});
+    ch.handlers.get("postgres_changes:plant_findings")?.({});
+    ch.handlers.get("postgres_changes:plant_findings")?.({});
+
+    // Before the debounce window elapses, no refresh has fired.
+    expect(refresh).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(299);
+    expect(refresh).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes its channels on unmount", () => {
+    const { unmount } = render(<Probe growIds={["g1", "g2"]} />);
+    expect(channels.length).toBe(2);
+    unmount();
+    expect(removeChannel).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Adds 15 tests locking in the chat image-upload + realtime pipeline from #130.

- chat route attachments path (5 tests): max-1 enforcement, missing-fields rejection, empty-message-with-attachment, multimodal happy path, 8s timeout fallback, unauthorized plant skip
- quick-capture-plant route (5 tests): 401/404/500 branches + happy path
- useLiveAnalysis hook (4 tests): no-op on empty, channels per grow, 300ms debounce, cleanup

360/360 tests pass. tsc + lint clean.