### PR TITLE
feat(chat): write tools — mark_finding_resolved + update_grow_stage

### DIFF
--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -26,6 +26,16 @@ function makeInsertMock(result: SingleResult) {
   return { client: { from }, from, insert, select, single };
 }
 
+// .update(payload).eq(col, val).select(...).maybeSingle()
+function makeUpdateEqMaybeSingleMock(result: SingleResult) {
+  const maybeSingle = vi.fn().mockResolvedValue(result);
+  const select = vi.fn(() => ({ maybeSingle }));
+  const eq = vi.fn(() => ({ select }));
+  const update = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ update }));
+  return { client: { from }, eq, from, maybeSingle, select, update };
+}
+
 // Note: `supabase` is intentionally omitted (not set to undefined) because
 // the project's `exactOptionalPropertyTypes: true` rejects explicit-undefined
 // assignment to optional fields. Tool executor falls back to constructing a
@@ -326,6 +336,287 @@ describe("chat-tools — log_plant_observation", () => {
 
     expect(result).toEqual({
       error: "you do not have access to this plant",
+      ok: false,
+    });
+  });
+});
+
+describe("chat-tools — mark_finding_resolved", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("is exposed in the tool list and requires findingId + resolved", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "mark_finding_resolved",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters?.required).toEqual([
+      "findingId",
+      "resolved",
+    ]);
+  });
+
+  it("sets resolved_at to now when resolved=true and no resolvedAt supplied", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
+
+    const { client, from, update, eq, select } = makeUpdateEqMaybeSingleMock({
+      data: {
+        category: "nutrient_deficiency",
+        grow_id: "grow-1",
+        id: "finding-1",
+        plant_id: "plant-3",
+        resolved_at: "2026-05-14T12:00:00.000Z",
+        severity: "medium",
+        title: "Nitrogen deficiency",
+      },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "mark_finding_resolved",
+      { findingId: "finding-1", resolved: true },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      data: expect.objectContaining({
+        id: "finding-1",
+        resolved_at: "2026-05-14T12:00:00.000Z",
+      }),
+      ok: true,
+    });
+    expect(from).toHaveBeenCalledWith("plant_findings");
+    expect(update).toHaveBeenCalledWith({
+      resolved_at: "2026-05-14T12:00:00.000Z",
+    });
+    expect(eq).toHaveBeenCalledWith("id", "finding-1");
+    expect(select).toHaveBeenCalled();
+
+    const audit = logServerEvent.mock.calls.at(-1)?.[2];
+    expect(audit).toMatchObject({
+      ok: true,
+      rowId: "finding-1",
+      tool: "mark_finding_resolved",
+      write: true,
+    });
+  });
+
+  it("clears resolved_at when resolved=false (re-open)", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: { id: "finding-1", resolved_at: null },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "mark_finding_resolved",
+      { findingId: "finding-1", resolved: false },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({ resolved_at: null });
+  });
+
+  it("ignores resolvedAt when resolved=false", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: { id: "finding-1", resolved_at: null },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "mark_finding_resolved",
+      {
+        findingId: "finding-1",
+        resolved: false,
+        resolvedAt: "2026-05-13T08:00:00.000Z",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({ resolved_at: null });
+  });
+
+  it("rejects a future resolvedAt and does not call the database", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-14T12:00:00.000Z"));
+    const future = new Date("2026-05-14T12:05:00.000Z").toISOString();
+
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "mark_finding_resolved",
+      { findingId: "finding-1", resolved: true, resolvedAt: future },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns 'not found or not accessible' when zero rows match", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "mark_finding_resolved",
+      { findingId: "missing", resolved: true },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      error: "finding not found or not accessible",
+      ok: false,
+    });
+  });
+
+  it("translates an RLS denial into a permission error", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: {
+        code: "42501",
+        message: "permission denied for table plant_findings",
+      },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "mark_finding_resolved",
+      { findingId: "f", resolved: true },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      error:
+        "you do not have permission to update this finding (owner or collaborator only)",
+      ok: false,
+    });
+  });
+
+  it("rejects when the user is not authenticated", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "mark_finding_resolved",
+      { findingId: "f", resolved: true },
+      { requestId: "req-x", userId: null },
+    );
+
+    expect(result).toEqual({ error: "not authenticated", ok: false });
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat-tools — update_grow_stage", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+
+  it("is exposed in the tool list and requires growId + stage", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "update_grow_stage",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters?.required).toEqual(["growId", "stage"]);
+  });
+
+  it("updates grows.stage and returns the new row", async () => {
+    const { client, from, update, eq } = makeUpdateEqMaybeSingleMock({
+      data: { id: "grow-1", name: "Tent A", stage: "flower" },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow_stage",
+      { growId: "grow-1", stage: "flower" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      data: { id: "grow-1", name: "Tent A", stage: "flower" },
+      ok: true,
+    });
+    expect(from).toHaveBeenCalledWith("grows");
+    expect(update).toHaveBeenCalledWith({ stage: "flower" });
+    expect(eq).toHaveBeenCalledWith("id", "grow-1");
+  });
+
+  it("rejects an invalid stage without touching the database", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow_stage",
+      { growId: "grow-1", stage: "blooming" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns 'not found or not accessible' when zero rows match", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow_stage",
+      { growId: "missing", stage: "flower" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      error: "grow not found or not accessible",
+      ok: false,
+    });
+  });
+
+  it("translates an RLS denial into an owner-only permission error", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: {
+        code: "42501",
+        message: "row-level security blocks update",
+      },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow_stage",
+      { growId: "g", stage: "flower" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      error:
+        "you do not have permission to change this grow's stage (owners only)",
       ok: false,
     });
   });

--- a/apps/web/src/lib/server/chat-prompt.ts
+++ b/apps/web/src/lib/server/chat-prompt.ts
@@ -49,17 +49,25 @@ You have tools to look up the grower's actual data — grows, plants, findings, 
 
 Call a tool *before* speculating. If a tool returns nothing, say so plainly and ask for the missing detail. Never invent data.
 
-# Write tools (logging grower actions)
-You can also *record* what the grower did, using \`log_grow_event\` (water / feed / top / fim / lst / defoliate / transplant / ipm / harvest / observation / note / other) and \`log_plant_observation\` (height + free-text). Discipline:
+# Write tools (recording + reconciling grower actions)
+You can *record* and *reconcile* what the grower did:
+- \`log_grow_event\` — water / feed / top / fim / lst / defoliate / transplant / ipm / harvest / observation / note / other
+- \`log_plant_observation\` — height + free-text
+- \`mark_finding_resolved\` — flip an AI finding's \`resolved_at\` (set to now, or clear it to re-open)
+- \`update_grow_stage\` — transition the whole grow to a new stage (germination → seedling → vegetative → pre_flower → flower → late_flower → harvest → dry_cure). NOTE: stage is per-grow, not per-plant; this affects every plant in the grow.
 
-1. **Only log what the grower explicitly told you they DID.** "I just fed plant 3 with FloraNova at 800 EC" → log it. "Should I feed?" → do NOT log; answer the question.
-2. **Resolve the target before logging.** If you don't know which grow or plant they mean, use a read tool (\`list_grows\`, \`list_plants\`) or ask. Never log against a guessed id.
-3. **Confirm in your reply.** After a successful write, briefly tell the user what was recorded (e.g. "Logged a feed event for Blue Dream #3 at 14:32 — id evt_xxx. Let me know if I should fix anything.") so they can catch a wrong category or wrong plant.
+Discipline:
+
+1. **Only write when the grower explicitly told you they DID it.** "I just fed plant 3 with FloraNova at 800 EC" → log it. "I flushed the deficiency on #2 yesterday and it looks better now" → log a feed event (water/flush) AND mark the matching nutrient_deficiency finding resolved. "Should I feed?" → do NOT log; answer the question.
+2. **Resolve the target before logging.** If you don't know which grow / plant / finding they mean, use a read tool (\`list_grows\`, \`list_plants\`, \`get_recent_findings\`) or ask. Never write against a guessed id.
+3. **Confirm in your reply.** After a successful write, briefly tell the user what was recorded (e.g. "Logged a feed event for Blue Dream #3 at 14:32 (evt_xxx) and marked the nitrogen-deficiency finding resolved. Let me know if I should fix anything.") so they can catch a wrong category, wrong plant, or wrong finding.
 4. **Pick the most specific event_type.** Use \`other\` only when nothing fits. \`feed\` covers nutrient applications; \`water\` is plain water; \`ipm\` is anything pest-related (sprays, predators, traps).
-5. **Never batch-log past actions the user didn't actually mention.** If they say "I've been watering daily for a week", do NOT fabricate seven events — confirm whether they want a single backfill note instead.
-6. **Stop and ask if intent is ambiguous.** Two write-tool calls in a single turn should be rare; more than three is almost always wrong.
+5. **Never batch-fabricate past actions.** If they say "I've been watering daily for a week", do NOT log seven events — confirm whether they want a single backfill note instead.
+6. **\`mark_finding_resolved\` is for resolution, not deletion.** You cannot edit a finding's severity / category / description — the database forbids it. If a finding looks wrong, tell the user and have them flag it; do not try to "fix" it.
+7. **\`update_grow_stage\` is a one-line action with big downstream effects** (analysis prompts, advice, alert cadence all change). Confirm the stage transition with the user before calling unless they were unambiguous ("flip the tent to flower" is unambiguous; "I think it's about ready to flower" is not). Only the grow OWNER can transition; collaborators get a permission error you should surface plainly.
+8. **Stop and ask if intent is ambiguous.** Two write-tool calls in a single turn should be rare; more than three is almost always wrong.
 
-If a write tool returns an error like "you do not have access", do NOT retry with a different id — surface the error to the user; it usually means they referenced the wrong grow/plant.
+If a write tool returns "you do not have access" or "you do not have permission", do NOT retry with a different id — surface the error to the user; it usually means they referenced the wrong target or aren't authorized for that operation.
 
 # Image-attached turns
 When the user attaches a plant image, you can:

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -231,6 +231,70 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "mark_finding_resolved",
+      description:
+        "Mark an AI-generated plant finding as resolved (or re-open it). Use when the user confirms they've addressed an issue ('I flushed the deficiency yesterday and it looks better' → mark the matching nutrient_deficiency finding resolved) or wants to re-open one they thought was fixed. Resolution sets `resolved_at` to now (or a supplied timestamp); re-opening clears it. You can only modify this field — severity, category, and description are immutable.",
+      parameters: {
+        type: "object",
+        properties: {
+          findingId: {
+            type: "string",
+            description:
+              "Finding ID to update. Required. If you don't know it, call get_recent_findings first.",
+          },
+          resolved: {
+            type: "boolean",
+            description:
+              "true to mark resolved (sets resolved_at), false to re-open (clears resolved_at). Required.",
+          },
+          resolvedAt: {
+            type: "string",
+            description:
+              "ISO 8601 timestamp the issue was actually resolved. Omit to use now. Ignored when resolved=false. Cannot be in the future.",
+          },
+        },
+        required: ["findingId", "resolved"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_grow_stage",
+      description:
+        "Transition the entire grow to a new growth stage. Use when the user says they switched the room/tent — 'I flipped the tent to flower yesterday', 'moved everyone to veg'. Stage is a property of the GROW, not individual plants (schema constraint today), so this affects every plant in that grow. Only grow OWNERS can change stage today (collaborators get a permission error). Returns the updated stage.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description: "Grow ID to update. Required.",
+          },
+          stage: {
+            type: "string",
+            enum: [
+              "germination",
+              "seedling",
+              "vegetative",
+              "pre_flower",
+              "flower",
+              "late_flower",
+              "harvest",
+              "dry_cure",
+            ],
+            description:
+              "New stage. Use 'pre_flower' for the stretch / first-pistils transition, 'late_flower' for the final 2-3 weeks before harvest, 'dry_cure' for post-harvest dry+cure.",
+          },
+        },
+        required: ["growId", "stage"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -315,12 +379,36 @@ const LogPlantObservationArgs = z
     message: "supply at least one of heightCm or notes",
   });
 
+const GROW_STAGES = [
+  "germination",
+  "seedling",
+  "vegetative",
+  "pre_flower",
+  "flower",
+  "late_flower",
+  "harvest",
+  "dry_cure",
+] as const;
+
+const MarkFindingResolvedArgs = z.object({
+  findingId: z.string().min(1),
+  resolved: z.boolean(),
+  resolvedAt: isoDatetimeNotFuture.optional(),
+});
+
+const UpdateGrowStageArgs = z.object({
+  growId: z.string().min(1),
+  stage: z.enum(GROW_STAGES),
+});
+
 // Tools whose names start the model down a write path. The executor logs
 // arg keys (never values) for these so we have an audit trail without
 // retaining free-text user content in the request log.
 const WRITE_TOOLS = new Set<string>([
   "log_grow_event",
   "log_plant_observation",
+  "mark_finding_resolved",
+  "update_grow_stage",
 ]);
 
 type ChatToolContext = {
@@ -566,6 +654,75 @@ export async function executeChatTool(
               error: denied
                 ? "you do not have access to this plant"
                 : `could not log observation: ${error.message}`,
+            };
+          }
+          return { ok: true, data };
+        }
+
+        case "mark_finding_resolved": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = MarkFindingResolvedArgs.parse(rawArgs);
+          const resolvedAt = args.resolved
+            ? (args.resolvedAt ?? new Date().toISOString())
+            : null;
+          const { data, error } = await supabase
+            .from("plant_findings")
+            .update({ resolved_at: resolvedAt })
+            .eq("id", args.findingId)
+            .select("id,plant_id,grow_id,category,severity,title,resolved_at")
+            .maybeSingle();
+          if (error) {
+            const denied =
+              error.code === "42501" ||
+              /permission denied|row-level security/i.test(error.message);
+            return {
+              ok: false,
+              error: denied
+                ? "you do not have permission to update this finding (owner or collaborator only)"
+                : `could not update finding: ${error.message}`,
+            };
+          }
+          if (!data) {
+            // The UPDATE silently affected zero rows — either the finding
+            // does not exist or RLS hid it from this user. Return a uniform
+            // not-found message; the model should NOT leak the existence
+            // of inaccessible rows.
+            return {
+              ok: false,
+              error: "finding not found or not accessible",
+            };
+          }
+          return { ok: true, data };
+        }
+
+        case "update_grow_stage": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = UpdateGrowStageArgs.parse(rawArgs);
+          const { data, error } = await supabase
+            .from("grows")
+            .update({ stage: args.stage })
+            .eq("id", args.growId)
+            .select("id,name,stage")
+            .maybeSingle();
+          if (error) {
+            const denied =
+              error.code === "42501" ||
+              /permission denied|row-level security/i.test(error.message);
+            return {
+              ok: false,
+              error: denied
+                ? "you do not have permission to change this grow's stage (owners only)"
+                : `could not update grow stage: ${error.message}`,
+            };
+          }
+          if (!data) {
+            return {
+              ok: false,
+              error: "grow not found or not accessible",
             };
           }
           return { ok: true, data };

--- a/supabase/migrations/007_plant_findings_user_resolve.sql
+++ b/supabase/migrations/007_plant_findings_user_resolve.sql
@@ -1,0 +1,94 @@
+-- Migration: 007_plant_findings_user_resolve
+--
+-- Lets a grow owner or collaborator mark an AI-generated finding as resolved
+-- (or unresolve it) from the app — previously the chat tool / UI had no way
+-- to touch plant_findings because the original schema only granted SELECT to
+-- grow members, leaving writes to the service role.
+--
+-- Safety posture:
+--   * RLS UPDATE policy is scoped to owner + collaborator (viewers stay read-only).
+--   * A BEFORE UPDATE trigger restricts user-initiated changes to the
+--     `resolved_at` column only, so a user opening their browser console and
+--     calling supabase.from('plant_findings').update({ severity: 'low' }) is
+--     rejected even though they are a grow member. Service role (the AI
+--     analysis service, daily cron, anything authenticated without a JWT)
+--     bypasses the trigger so it can still overwrite findings.
+--   * No data migration — existing rows are unaffected; only future UPDATE
+--     calls hit the new policy + trigger.
+--
+-- Rollback (do NOT run unless explicitly approved):
+--   drop trigger if exists plant_findings_user_update_guard_trigger on plant_findings;
+--   drop function if exists plant_findings_user_update_guard();
+--   drop policy if exists "plant_findings: grow contributor resolve" on plant_findings;
+
+-- ─── UPDATE policy ────────────────────────────────────────────────────────────
+-- Mirrors the SELECT policy's grow-membership check but restricts to roles
+-- that can contribute (owner, collaborator). Viewers remain read-only.
+create policy "plant_findings: grow contributor resolve"
+  on plant_findings for update
+  using (
+    exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = plant_findings.grow_id
+        and (
+          g.owner_id = auth.uid()
+          or gm.role in ('owner', 'collaborator')
+        )
+    )
+  )
+  with check (
+    exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = plant_findings.grow_id
+        and (
+          g.owner_id = auth.uid()
+          or gm.role in ('owner', 'collaborator')
+        )
+    )
+  );
+
+-- ─── Column-restriction trigger ───────────────────────────────────────────────
+-- Authoritative source for "users may only change resolved_at on plant_findings".
+-- Triggers fire AFTER RLS, so by the time we get here we already know the row
+-- is accessible to this user. We only need to validate which columns changed.
+--
+-- auth.uid() returns NULL when the request is made with the service role key
+-- (no Supabase JWT context), so we skip the guard for service-role traffic —
+-- that's how the analysis service inserts/refreshes findings.
+create or replace function plant_findings_user_update_guard()
+returns trigger
+language plpgsql
+security invoker  -- run as the caller; we explicitly check auth.uid() below
+as $$
+begin
+  if auth.uid() is null then
+    -- Service role / no-JWT context: trust the caller (it's our own server code).
+    return new;
+  end if;
+
+  if new.plant_id       is distinct from old.plant_id
+     or new.grow_id     is distinct from old.grow_id
+     or new.image_id    is distinct from old.image_id
+     or new.category    is distinct from old.category
+     or new.severity    is distinct from old.severity
+     or new.title       is distinct from old.title
+     or new.description is distinct from old.description
+     or new.recommendation is distinct from old.recommendation
+     or new.created_at  is distinct from old.created_at
+  then
+    raise exception 'plant_findings: only resolved_at may be modified by users'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger plant_findings_user_update_guard_trigger
+  before update on plant_findings
+  for each row
+  execute function plant_findings_user_update_guard();


### PR DESCRIPTION
## Summary

Completes the chat write-tool surface so the copilot can **reconcile** state, not just record actions. Builds on #132 with the same RLS-via-user-scoped-client + audit-log pattern.

### Migration 007 — `plant_findings_user_resolve`

- Adds an UPDATE policy on `plant_findings` for **grow owner + collaborator** (viewers stay read-only). Previously the table had **no user-facing write policy** at all — only the analysis service (service role) could touch it.
- Adds a **BEFORE UPDATE trigger** that restricts user-initiated changes to the `resolved_at` column only. Severity, category, title, description, recommendation, and the foreign keys are **immutable from user code** — so a user opening their browser console and calling `supabase.from('plant_findings').update({ severity: 'low' })` is rejected even though they are a grow member. Service role (`auth.uid() is null`) bypasses the trigger so the analysis service can still overwrite findings.
- No data migration; only future UPDATE calls hit the new policy + trigger.

### Chat tools

- **`mark_finding_resolved(findingId, resolved, resolvedAt?)`** — sets or clears `plant_findings.resolved_at` via `UPDATE … maybeSingle`. Maps zero-row results to `"not found or not accessible"` (uniform not-found semantics — never leaks the existence of an inaccessible row). Maps PostgREST `42501` to `"you do not have permission to update this finding (owner or collaborator only)"`.
- **`update_grow_stage(growId, stage)`** — sets `grows.stage` via `UPDATE … maybeSingle`. Uses the existing `grows: owner write` RLS policy (collaborators get an owner-only permission error). Note: stage is a property of the **grow** today, not individual plants; the tool description tells the model this so it never tries to "update plant 3's stage". A per-plant stage column would be a separate migration.

### System prompt

- Adds the two new tools to the write-tool section with **rule #6** (`mark_finding_resolved` is for resolution, not deletion — cannot edit severity/category/description) and **rule #7** (`update_grow_stage` has big downstream effects; confirm with the user before calling unless intent is unambiguous).

## Test plan

- [x] **`pnpm turbo run test --filter=web` — 386 / 386 pass** (was 373; +13 tests for the two new tools)
- [x] `pnpm turbo run type-check --filter=web` — clean
- [x] `pnpm turbo run lint --filter=web` — clean
- [x] `pnpm --filter web run build` — clean
- [x] `pnpm run validate` — env + routes + imports + code-scanning all pass
- [x] `pnpm run security:routes` — 13 / 13
- [ ] **Manual end-to-end chat test in dev** — not done in this sandbox (no live Supabase / Gemini creds). Recommended before deploy: open `/assistant` for a grow with at least one unresolved finding; say *"I fixed the nitrogen deficiency on plant 3 yesterday"* and verify (a) a feed/water event lands in the timeline, (b) the matching finding's `resolved_at` is set, (c) the model echoes the change. Repeat for an unauthenticated collaborator to confirm the owner-only permission errors surface cleanly.
- [ ] **Production migration application** — `supabase/migrations/007_plant_findings_user_resolve.sql` will need to be applied to the prod Supabase project after merge (`supabase db push` or via the Supabase MCP). The migration is idempotent up to the trigger name; rollback steps are in the file header.

## Tool coverage

After this PR the chat copilot's write surface is:

| Tool | Operation | Migration needed? |
|------|-----------|-------------------|
| `log_grow_event` | INSERT grow_events | no (#132) |
| `log_plant_observation` | INSERT plant_observations | no (#132) |
| `mark_finding_resolved` | UPDATE plant_findings.resolved_at | **yes — 007** |
| `update_grow_stage` | UPDATE grows.stage | no |

That covers the four highest-leverage write operations a grower will want to do from chat. Further write tools (per-plant stage, finding deletion, grow archival) would be deeper schema work — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GkufjdruMTE682vyW5C22)_