### PR TITLE
feat(chat): auto-action pipeline — grow_tasks + proactive worklist

### DIFF
--- a/apps/web/src/app/api/chat/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat/__tests__/route.test.ts
@@ -350,6 +350,7 @@ describe("POST /api/chat", () => {
       daysSinceStart: 42,
       plantCount: 4,
       recentFindings: [],
+      openTasks: [],
     });
 
     const res = await POST(jsonRequest({ message: "status?", growId: "g1" }));

--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -18,6 +18,41 @@ type SingleResult = {
   error: { message: string; code?: string } | null;
 };
 
+type ListResult = {
+  data: unknown[] | null;
+  error: { message: string; code?: string } | null;
+};
+
+// Builds a flexible select-chain mock for list-style queries:
+//   .from(t).select(...).order(...).order(...).limit(...).eq(...).in(...)
+// The final awaited value is `result`. Chain methods are all idempotent
+// (return the same chainable proxy) so callers can mix and match.
+type SelectChainKey = "select" | "order" | "limit" | "eq" | "in";
+type SelectChain = Record<SelectChainKey, ReturnType<typeof vi.fn>> &
+  PromiseLike<ListResult>;
+
+function makeSelectChainMock(result: ListResult) {
+  const calls: Record<SelectChainKey, unknown[][]> = {
+    eq: [],
+    in: [],
+    limit: [],
+    order: [],
+    select: [],
+  };
+  const chain = {} as SelectChain;
+  const KEYS: SelectChainKey[] = ["select", "order", "limit", "eq", "in"];
+  for (const key of KEYS) {
+    chain[key] = vi.fn((...args: unknown[]) => {
+      calls[key].push(args);
+      return chain;
+    });
+  }
+  // Make the chain awaitable: callers do `await q` after the last filter.
+  chain.then = Promise.resolve(result).then.bind(Promise.resolve(result));
+  const from = vi.fn(() => chain);
+  return { calls, chain, client: { from }, from };
+}
+
 function makeInsertMock(result: SingleResult) {
   const single = vi.fn().mockResolvedValue(result);
   const select = vi.fn(() => ({ single }));
@@ -619,5 +654,221 @@ describe("chat-tools — update_grow_stage", () => {
         "you do not have permission to change this grow's stage (owners only)",
       ok: false,
     });
+  });
+});
+
+describe("chat-tools — list_open_tasks", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+
+  it("is exposed in the tool list with no required args (growId or plantId at runtime)", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "list_open_tasks",
+    );
+    expect(def).toBeDefined();
+    // OpenAI schema doesn't list either as required, because EITHER is allowed
+    // (zod refine validates at runtime).
+    expect(def?.function.parameters?.required).toBeUndefined();
+  });
+
+  it("filters by grow + open|in_progress when includeCompleted is false (default)", async () => {
+    const tasks = [
+      {
+        created_at: "2026-05-14T00:00:00.000Z",
+        finding_id: "f-1",
+        grow_id: "grow-1",
+        id: "t-1",
+        plant_id: "p-3",
+        priority: "urgent",
+        status: "open",
+        title: "Address: nitrogen deficiency",
+      },
+    ];
+    const { calls, client, from } = makeSelectChainMock({
+      data: tasks,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "list_open_tasks",
+      { growId: "grow-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({ data: tasks, ok: true });
+    expect(from).toHaveBeenCalledWith("grow_tasks");
+    expect(calls.eq).toContainEqual(["grow_id", "grow-1"]);
+    expect(calls.in).toContainEqual(["status", ["open", "in_progress"]]);
+  });
+
+  it("filters by plant when plantId is supplied", async () => {
+    const { calls, client } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "list_open_tasks",
+      { plantId: "plant-3" },
+      CTX_AUTHED,
+    );
+
+    expect(calls.eq).toContainEqual(["plant_id", "plant-3"]);
+  });
+
+  it("includes completed tasks when includeCompleted=true", async () => {
+    const { calls, client } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "list_open_tasks",
+      { growId: "grow-1", includeCompleted: true },
+      CTX_AUTHED,
+    );
+
+    // No status filter when includeCompleted is true.
+    expect(calls.in).toEqual([]);
+  });
+
+  it("rejects when neither growId nor plantId is supplied", async () => {
+    const { calls, client } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool("list_open_tasks", {}, CTX_AUTHED);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/growId|plantId/);
+    }
+    expect(calls.eq).toEqual([]);
+  });
+});
+
+describe("chat-tools — update_task_status", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+
+  it("is exposed in the tool list and requires taskId + status", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "update_task_status",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters?.required).toEqual(["taskId", "status"]);
+  });
+
+  it("flips status and returns the updated row", async () => {
+    const { client, from, update, eq } = makeUpdateEqMaybeSingleMock({
+      data: {
+        completed_at: "2026-05-14T12:00:00.000Z",
+        grow_id: "grow-1",
+        id: "t-1",
+        priority: "urgent",
+        status: "done",
+        title: "Address: nitrogen deficiency",
+      },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_task_status",
+      { status: "done", taskId: "t-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      data: expect.objectContaining({ id: "t-1", status: "done" }),
+      ok: true,
+    });
+    expect(from).toHaveBeenCalledWith("grow_tasks");
+    expect(update).toHaveBeenCalledWith({ status: "done" });
+    expect(eq).toHaveBeenCalledWith("id", "t-1");
+
+    const audit = logServerEvent.mock.calls.at(-1)?.[2];
+    expect(audit).toMatchObject({
+      ok: true,
+      rowId: "t-1",
+      tool: "update_task_status",
+      write: true,
+    });
+  });
+
+  it("rejects an invalid status without touching the database", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_task_status",
+      { status: "blocked", taskId: "t-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("returns 'not found or not accessible' when zero rows match", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_task_status",
+      { status: "done", taskId: "missing" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      error: "task not found or not accessible",
+      ok: false,
+    });
+  });
+
+  it("translates an RLS denial into a contributor-only permission error", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: {
+        code: "42501",
+        message: "row-level security blocks update",
+      },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_task_status",
+      { status: "done", taskId: "t-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      error:
+        "you do not have permission to update this task (owner or collaborator only)",
+      ok: false,
+    });
+  });
+
+  it("rejects when the user is not authenticated", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_task_status",
+      { status: "done", taskId: "t-1" },
+      { requestId: "req-x", userId: null },
+    );
+
+    expect(result).toEqual({ error: "not authenticated", ok: false });
+    expect(update).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/server/chat-context.ts
+++ b/apps/web/src/lib/server/chat-context.ts
@@ -20,6 +20,15 @@ type FindingRow = {
   plants: { name: string } | { name: string }[] | null;
 };
 
+type TaskRow = {
+  id: string;
+  title: string;
+  priority: string;
+  status: string;
+  created_at: string;
+  plants: { name: string } | { name: string }[] | null;
+};
+
 function daysSince(startDate: string | null): number | null {
   if (!startDate) return null;
   const start = new Date(startDate).getTime();
@@ -101,6 +110,40 @@ export async function loadGrowContextSummary(
     };
   });
 
+  // Open + in_progress tasks for this grow, urgent first. Capped at 10
+  // because this loads into every chat turn — anything beyond that goes
+  // through the `list_open_tasks` tool on demand.
+  const { data: tasks, error: tasksErr } = await supabase
+    .from("grow_tasks")
+    .select("id,title,priority,status,created_at,plants(name)")
+    .eq("grow_id", g.id)
+    .in("status", ["open", "in_progress"])
+    .order("priority", { ascending: false })
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  if (tasksErr) {
+    logServerEvent("error", "chat context tasks lookup failed", {
+      error: tasksErr.message,
+      growId,
+    });
+  }
+
+  const openTasks = ((tasks ?? []) as TaskRow[]).map((t) => {
+    const plantsField = t.plants;
+    const plantName = Array.isArray(plantsField)
+      ? (plantsField[0]?.name ?? null)
+      : (plantsField?.name ?? null);
+    return {
+      id: t.id,
+      title: t.title,
+      priority: t.priority,
+      status: t.status,
+      plantName,
+      createdAt: t.created_at,
+    };
+  });
+
   return {
     growId: g.id,
     name: g.name,
@@ -111,5 +154,6 @@ export async function loadGrowContextSummary(
     daysSinceStart: daysSince(g.start_date),
     plantCount: plantCount ?? 0,
     recentFindings,
+    openTasks,
   };
 }

--- a/apps/web/src/lib/server/chat-prompt.ts
+++ b/apps/web/src/lib/server/chat-prompt.ts
@@ -42,12 +42,22 @@ Stage cheat-sheet you may rely on:
 - Late flower: VPD 1.2–1.5 kPa, PPFD 700–1000, RH 40–50%, suppress botrytis risk.
 
 # Tool use
-You have tools to look up the grower's actual data — grows, plants, findings, observations, events, and the latest image analysis. Use them when:
+You have tools to look up the grower's actual data — grows, plants, findings, observations, events, image analysis, and the actionable task worklist. Use them when:
 - The user references "my grow", "the tent", "my plants", a stage, or a strain you don't know about yet in this conversation.
 - The user asks "what happened last week / since last time / over time".
+- The user asks "what do I need to do" / "what's outstanding" / "anything urgent" — call \`list_open_tasks\`.
 - You're about to give advice that depends on stage, medium, light, or known findings.
 
 Call a tool *before* speculating. If a tool returns nothing, say so plainly and ask for the missing detail. Never invent data.
+
+# Proactive worklist surfacing
+High and critical AI findings automatically spawn a task in \`grow_tasks\` (see the "Open tasks" section of the grower context loaded into every turn). Treat these as the grower's actionable worklist. Discipline:
+
+- When the user opens a session with "what's going on" / "anything urgent" / "what should I do today", lead with the **urgent + high** open tasks — name them, name the plant, point at the originating finding.
+- When the user asks an off-topic question and there are no urgent tasks, do NOT lecture them about the worklist. Surface tasks only when topically relevant or explicitly asked.
+- When the user mentions completing an action that matches a task ("I flushed the deficiency"), call \`update_task_status\` with status='done' AND \`mark_finding_resolved\` for the linked finding if there is one (the task carries \`finding_id\` — pull it from \`list_open_tasks\` first).
+- Tasks have status open / in_progress / done / dismissed and priority low / medium / high / urgent. Use \`update_task_status\` to flip between them; the database stamps \`completed_at\` automatically.
+- Never fabricate tasks. The trigger creates them from real findings; the chat tool can update existing ones; manual creation from the chat (without a finding) is not yet supported and you should not attempt it.
 
 # Write tools (recording + reconciling grower actions)
 You can *record* and *reconcile* what the grower did:
@@ -101,6 +111,14 @@ export type GrowContextSummary = {
     plantName: string | null;
     createdAt: string;
   }>;
+  openTasks: Array<{
+    id: string;
+    title: string;
+    priority: string;
+    status: string;
+    plantName: string | null;
+    createdAt: string;
+  }>;
 };
 
 export function renderGrowContextBlock(
@@ -130,6 +148,19 @@ export function renderGrowContextBlock(
   } else {
     lines.push("");
     lines.push("### Recent findings\nNone in the last 30 days.");
+  }
+
+  if (summary.openTasks.length > 0) {
+    lines.push("");
+    lines.push("### Open tasks (worklist)");
+    for (const t of summary.openTasks) {
+      const who = t.plantName ? ` (${t.plantName})` : "";
+      const tag = t.status === "in_progress" ? " [in progress]" : "";
+      lines.push(`- [${t.priority}] ${t.title}${who}${tag} — id ${t.id}`);
+    }
+  } else {
+    lines.push("");
+    lines.push("### Open tasks\nNo open tasks right now.");
   }
 
   return lines.join("\n");

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -295,6 +295,63 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "list_open_tasks",
+      description:
+        "List actionable tasks for a grow or plant. Tasks are auto-created from high/critical AI findings, and may also be created manually. Use to surface what the grower should do next, or to ground a reply in their actual worklist. Returns open + in_progress tasks by default, newest urgent first.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description:
+              "Grow ID to scope to. Either growId or plantId is required.",
+          },
+          plantId: {
+            type: "string",
+            description:
+              "Plant ID to scope to (filters tasks where plant_id matches). Either growId or plantId is required.",
+          },
+          includeCompleted: {
+            type: "boolean",
+            description:
+              "Set true to include done + dismissed tasks too. Default false (only open + in_progress).",
+          },
+          limit: {
+            type: "number",
+            description: "Max tasks. Default 10, max 25.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_task_status",
+      description:
+        "Transition a grow_task to a new status — typically 'done' when the grower says they completed the action, or 'dismissed' when the task no longer applies (e.g. a false-positive finding). Setting status to 'done' or 'dismissed' stamps completed_at; setting it back to 'open' or 'in_progress' clears completed_at. Returns the updated task. Owner + collaborator only.",
+      parameters: {
+        type: "object",
+        properties: {
+          taskId: {
+            type: "string",
+            description: "Task ID to update. Required.",
+          },
+          status: {
+            type: "string",
+            enum: ["open", "in_progress", "done", "dismissed"],
+            description: "New status. Required.",
+          },
+        },
+        required: ["taskId", "status"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -401,6 +458,24 @@ const UpdateGrowStageArgs = z.object({
   stage: z.enum(GROW_STAGES),
 });
 
+const TASK_STATUSES = ["open", "in_progress", "done", "dismissed"] as const;
+
+const ListOpenTasksArgs = z
+  .object({
+    growId: z.string().min(1).optional(),
+    plantId: z.string().min(1).optional(),
+    includeCompleted: z.boolean().optional(),
+    limit: z.number().optional(),
+  })
+  .refine((v) => v.growId !== undefined || v.plantId !== undefined, {
+    message: "supply growId or plantId",
+  });
+
+const UpdateTaskStatusArgs = z.object({
+  taskId: z.string().min(1),
+  status: z.enum(TASK_STATUSES),
+});
+
 // Tools whose names start the model down a write path. The executor logs
 // arg keys (never values) for these so we have an audit trail without
 // retaining free-text user content in the request log.
@@ -409,6 +484,7 @@ const WRITE_TOOLS = new Set<string>([
   "log_plant_observation",
   "mark_finding_resolved",
   "update_grow_stage",
+  "update_task_status",
 ]);
 
 type ChatToolContext = {
@@ -723,6 +799,66 @@ export async function executeChatTool(
             return {
               ok: false,
               error: "grow not found or not accessible",
+            };
+          }
+          return { ok: true, data };
+        }
+
+        case "list_open_tasks": {
+          const args = ListOpenTasksArgs.parse(rawArgs ?? {});
+          const limit = numClamp(args.limit, 10, 25);
+          // Priority enum is stored as a postgres enum, which sorts by
+          // declaration order: low < medium < high < urgent. So DESC order
+          // on the column gives us urgent → high → medium → low naturally,
+          // which is what a worklist UI wants.
+          let q = supabase
+            .from("grow_tasks")
+            .select(
+              "id,grow_id,plant_id,finding_id,title,description,priority,status,due_at,created_at,completed_at",
+            )
+            .order("priority", { ascending: false })
+            .order("created_at", { ascending: false })
+            .limit(limit);
+          if (args.growId) q = q.eq("grow_id", args.growId);
+          if (args.plantId) q = q.eq("plant_id", args.plantId);
+          if (!args.includeCompleted) {
+            q = q.in("status", ["open", "in_progress"]);
+          }
+          const { data, error } = await q;
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
+        }
+
+        case "update_task_status": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = UpdateTaskStatusArgs.parse(rawArgs);
+          // completed_at is stamped/cleared by the BEFORE UPDATE trigger
+          // (grow_tasks_touch_updated_at) — we don't set it here.
+          const { data, error } = await supabase
+            .from("grow_tasks")
+            .update({ status: args.status })
+            .eq("id", args.taskId)
+            .select(
+              "id,grow_id,plant_id,finding_id,title,priority,status,completed_at",
+            )
+            .maybeSingle();
+          if (error) {
+            const denied =
+              error.code === "42501" ||
+              /permission denied|row-level security/i.test(error.message);
+            return {
+              ok: false,
+              error: denied
+                ? "you do not have permission to update this task (owner or collaborator only)"
+                : `could not update task: ${error.message}`,
+            };
+          }
+          if (!data) {
+            return {
+              ok: false,
+              error: "task not found or not accessible",
             };
           }
           return { ok: true, data };

--- a/supabase/migrations/008_grow_tasks.sql
+++ b/supabase/migrations/008_grow_tasks.sql
@@ -1,0 +1,200 @@
+-- Migration: 008_grow_tasks
+--
+-- Closes the loop on "AI does everything else": when the analysis service
+-- writes a high- or critical-severity finding, an actionable task is created
+-- automatically and surfaced to the grower (and the chat copilot) without
+-- them having to read the raw finding first.
+--
+-- Data model:
+--   grow_tasks is a per-grow worklist. Each task may be linked to the
+--   plant_findings row that spawned it (via finding_id, unique → 1:1) so
+--   the AI can cross-reference a task with the diagnostic evidence behind
+--   it. Tasks created manually (by the grower or the chat tool) leave
+--   finding_id NULL.
+--
+-- Auto-creation:
+--   AFTER INSERT trigger on plant_findings inspects the new row's severity
+--   and, when high or critical, inserts a task with priority derived from
+--   severity. ON CONFLICT (finding_id) DO NOTHING keeps re-inserts idempotent
+--   in the unlikely case the analysis service retries.
+--
+-- Safety posture:
+--   * SELECT: any grow member (owner / collaborator / viewer).
+--   * INSERT / UPDATE: owner or collaborator (viewers stay read-only).
+--   * DELETE: owner only.
+--   * Trigger runs SECURITY DEFINER so it works regardless of whether the
+--     parent INSERT was service-role (analysis service) or, in the future,
+--     a user-side call.
+--
+-- Rollback (do NOT run unless explicitly approved):
+--   drop trigger if exists plant_findings_auto_task_trigger on plant_findings;
+--   drop function if exists plant_findings_auto_task();
+--   drop table if exists grow_tasks;
+--   drop type if exists task_status;
+--   drop type if exists task_priority;
+
+-- ─── Enum types ───────────────────────────────────────────────────────────────
+create type task_priority as enum ('low', 'medium', 'high', 'urgent');
+create type task_status   as enum ('open', 'in_progress', 'done', 'dismissed');
+
+-- ─── grow_tasks ───────────────────────────────────────────────────────────────
+create table grow_tasks (
+  id           uuid primary key default gen_random_uuid(),
+  grow_id      uuid not null references grows(id) on delete cascade,
+  plant_id     uuid references plants(id) on delete set null,
+  -- One task per finding at most. NULL when the task was created manually.
+  finding_id   uuid unique references plant_findings(id) on delete set null,
+  title        text not null,
+  description  text,
+  priority     task_priority not null default 'medium',
+  status       task_status   not null default 'open',
+  due_at       timestamptz,
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now(),
+  completed_at timestamptz
+);
+
+alter table grow_tasks enable row level security;
+
+create policy "grow_tasks: grow member read"
+  on grow_tasks for select
+  using (
+    exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = grow_tasks.grow_id
+        and (g.owner_id = auth.uid() or gm.user_id = auth.uid())
+    )
+  );
+
+create policy "grow_tasks: contributor insert"
+  on grow_tasks for insert
+  with check (
+    exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = grow_tasks.grow_id
+        and (
+          g.owner_id = auth.uid()
+          or gm.role in ('owner', 'collaborator')
+        )
+    )
+  );
+
+create policy "grow_tasks: contributor update"
+  on grow_tasks for update
+  using (
+    exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = grow_tasks.grow_id
+        and (
+          g.owner_id = auth.uid()
+          or gm.role in ('owner', 'collaborator')
+        )
+    )
+  )
+  with check (
+    exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = grow_tasks.grow_id
+        and (
+          g.owner_id = auth.uid()
+          or gm.role in ('owner', 'collaborator')
+        )
+    )
+  );
+
+create policy "grow_tasks: owner delete"
+  on grow_tasks for delete
+  using (
+    exists (
+      select 1 from grows g
+      where g.id = grow_tasks.grow_id and g.owner_id = auth.uid()
+    )
+  );
+
+-- ─── updated_at auto-touch ────────────────────────────────────────────────────
+create or replace function grow_tasks_touch_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at := now();
+  -- Stamp completed_at the first time status transitions into a terminal state.
+  if new.status in ('done', 'dismissed') and old.status not in ('done', 'dismissed') then
+    new.completed_at := now();
+  elsif new.status not in ('done', 'dismissed') then
+    new.completed_at := null;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger grow_tasks_touch_updated_at_trigger
+  before update on grow_tasks
+  for each row
+  execute function grow_tasks_touch_updated_at();
+
+-- ─── Auto-task-from-finding trigger ───────────────────────────────────────────
+-- Fires AFTER INSERT on plant_findings. High and critical findings spawn an
+-- open task; lower-severity findings do not (the chat / UI can still create
+-- tasks manually via the contributor INSERT policy). The trigger runs as
+-- SECURITY DEFINER so it works whether the parent insert was a user (future)
+-- or the service role (today).
+create or replace function plant_findings_auto_task()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.severity not in ('high', 'critical') then
+    return new;
+  end if;
+
+  insert into grow_tasks (
+    grow_id, plant_id, finding_id,
+    title, description, priority, status
+  ) values (
+    new.grow_id,
+    new.plant_id,
+    new.id,
+    'Address: ' || new.title,
+    coalesce(new.recommendation, new.description),
+    case
+      when new.severity = 'critical' then 'urgent'::task_priority
+      else 'high'::task_priority
+    end,
+    'open'::task_status
+  )
+  on conflict (finding_id) do nothing;
+
+  return new;
+end;
+$$;
+
+create trigger plant_findings_auto_task_trigger
+  after insert on plant_findings
+  for each row
+  execute function plant_findings_auto_task();
+
+-- ─── Indexes ──────────────────────────────────────────────────────────────────
+-- Most queries scope by grow + status (the "what's open in tent A?" pattern).
+create index idx_grow_tasks_grow_status
+  on grow_tasks(grow_id, status);
+
+-- Plant-scoped task lookups for the plant detail page.
+create index idx_grow_tasks_plant_id
+  on grow_tasks(plant_id)
+  where plant_id is not null;
+
+-- Cross-reference from a finding to its task (rare but useful for ops).
+create index idx_grow_tasks_finding_id
+  on grow_tasks(finding_id)
+  where finding_id is not null;


### PR DESCRIPTION
## Summary

Closes the loop on the *"AI does everything else"* vision. Previously a severity-4 finding from the analysis service just sat in `plant_findings` waiting for the user to notice it. Now it **auto-spawns an actionable task** that the chat copilot surfaces every turn.

### Migration 008 — `grow_tasks`

- New `grow_tasks` table with `task_priority` (`low|medium|high|urgent`) and `task_status` (`open|in_progress|done|dismissed`) enums. Each task may be linked to the `plant_findings` row that spawned it via a unique `finding_id` FK (1:1), with `ON DELETE SET NULL` so deleting a finding doesn't cascade-delete the worklist entry.
- **RLS:** SELECT for any grow member; INSERT + UPDATE for owner or collaborator (viewers stay read-only); DELETE for owner only.
- **BEFORE UPDATE trigger** touches `updated_at` and stamps `completed_at` the first time status transitions into `done` / `dismissed` (clears it when status moves back).
- **AFTER INSERT trigger on `plant_findings`:** when severity is `high` or `critical`, auto-insert a `grow_tasks` row with priority derived from severity (`high → high`, `critical → urgent`). `ON CONFLICT (finding_id) DO NOTHING` keeps re-inserts idempotent. Runs `SECURITY DEFINER` so it works whether the parent insert was service-role (analysis service today) or user-side (future).
- Three indexes: `(grow_id, status)` for the worklist UI, `plant_id` partial for plant-detail pages, `finding_id` partial for ops cross-reference.

### Chat tools

- **`list_open_tasks(growId?, plantId?, includeCompleted?, limit?)`** — returns urgent → high → medium → low by priority enum order, newest first within priority. Defaults to `open + in_progress` only.
- **`update_task_status(taskId, status)`** — flips status. `completed_at` is auto-stamped/cleared by the BEFORE UPDATE trigger; the tool only writes `status`. Maps zero-row to `"task not found or not accessible"` (uniform not-found semantics) and PostgREST `42501` to a contributor-only permission error.

### Grow context (loaded every turn)

`GrowContextSummary.openTasks` (capped at 10, urgent-first) is now rendered into the system prompt block alongside recent findings. **The model sees the worklist on every chat turn without needing a tool call.**

### System prompt

New *"Proactive worklist surfacing"* section instructs the model to:

- Lead with **urgent + high** tasks when the user opens with *"what's going on"* / *"anything urgent"*
- Surface tasks only when topically relevant otherwise (no lecturing)
- Pair `update_task_status` with `mark_finding_resolved` when a completed action closes a linked finding (pull `finding_id` from the task row)
- Never fabricate tasks (manual creation from chat is not yet supported)

## Test plan

- [x] **`pnpm turbo run test --filter=web` — 397 / 397 pass** (was 386; +11 tests for the two new tools, +1 fixture fix for existing context test)
- [x] `pnpm turbo run type-check --filter=web` — clean
- [x] `pnpm turbo run lint --filter=web` — clean
- [x] `pnpm --filter web run build` — clean
- [x] `pnpm run validate` — all four sub-checks pass
- [x] `pnpm run security:routes` — 13 / 13
- [ ] **Manual end-to-end in dev** — not done in this sandbox (no live Supabase / Gemini creds). Recommended after deploy: trigger a high-severity finding (upload a plant photo the analyzer will flag) and verify (a) a row appears in `grow_tasks` via the trigger, (b) the chat copilot mentions it in the next turn without being asked, (c) saying *"I fixed it"* causes the AI to call `update_task_status` with `done` and `mark_finding_resolved`.
- [ ] **Migrations to apply to prod Supabase**: `007_plant_findings_user_resolve.sql` (from #133, not yet applied) **and** `008_grow_tasks.sql` (this PR). Both are idempotent up to constraint/trigger names. Rollback steps in each file header.

## End-state — write-tool surface after this PR

| Tool | Operation |
|------|-----------|
| `log_grow_event` | INSERT grow_events |
| `log_plant_observation` | INSERT plant_observations |
| `mark_finding_resolved` | UPDATE plant_findings.resolved_at |
| `update_grow_stage` | UPDATE grows.stage |
| **`update_task_status`** | UPDATE grow_tasks.status (this PR) |

Read-tool surface gains `list_open_tasks`. The chat copilot can now: see open tasks every turn → surface them proactively → record reconciling actions → mark tasks done → mark findings resolved. Full loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018GkufjdruMTE682vyW5C22)_