### PR TITLE
fix(web): harden grow + settings actions against unhandled exceptions

### DIFF
--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const insert = vi.fn();
+  const from = vi.fn(() => ({ insert }));
+  const supabaseStub = { from };
+  const createSupabaseServerClient = vi.fn(async () => supabaseStub);
+  const getServerUser = vi.fn(async () => ({ id: "user-1" }));
+  const revalidatePath = vi.fn();
+  const logServerEvent = vi.fn();
+  return {
+    insert,
+    from,
+    supabaseStub,
+    createSupabaseServerClient,
+    getServerUser,
+    revalidatePath,
+    logServerEvent,
+  };
+});
+
+vi.mock("@/lib/server/auth", () => ({
+  createSupabaseServerClient: mocks.createSupabaseServerClient,
+  getServerUser: mocks.getServerUser,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock("@/lib/server/request-id", () => ({
+  logServerEvent: mocks.logServerEvent,
+}));
+
+import { createGrowAction } from "../actions";
+
+function buildFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set("name", "North Tent A");
+  fd.set("description", "");
+  fd.set("stage", "seedling");
+  fd.set("medium", "soil");
+  fd.set("lightType", "led");
+  fd.set("startDate", "2025-01-01");
+  fd.set("targetHarvestDate", "");
+  for (const [k, v] of Object.entries(overrides)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+describe("createGrowAction", () => {
+  beforeEach(() => {
+    mocks.insert.mockReset();
+    mocks.from.mockClear();
+    mocks.createSupabaseServerClient
+      .mockReset()
+      .mockResolvedValue(mocks.supabaseStub);
+    mocks.getServerUser.mockReset().mockResolvedValue({ id: "user-1" });
+    mocks.revalidatePath.mockReset();
+    mocks.logServerEvent.mockReset();
+  });
+
+  it("returns success with redirectTo on a clean insert", async () => {
+    mocks.insert.mockResolvedValue({ error: null });
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("success");
+    expect(result.redirectTo).toBe("/grows");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
+  });
+
+  it("returns a structured error (not throw) when supabase rejects the insert", async () => {
+    mocks.insert.mockResolvedValue({
+      error: { message: "duplicate key", code: "23505" },
+    });
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("duplicate key");
+  });
+
+  it("returns a structured error (not throw) when supabase client itself throws", async () => {
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(
+      new Error("env missing"),
+    );
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/couldn't save the grow/i);
+    expect(mocks.logServerEvent).toHaveBeenCalled();
+  });
+
+  it("re-throws Next framework redirect signals untouched", async () => {
+    const e: Error & { digest?: string } = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT;replace;/grows;307;";
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(e);
+    await expect(createGrowAction(buildFormData())).rejects.toBe(e);
+  });
+
+  it("rejects when the user is not signed in", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null);
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+  });
+
+  it("returns field errors for invalid inputs without touching supabase", async () => {
+    const result = await createGrowAction(
+      buildFormData({ name: "", stage: "bogus", startDate: "not-a-date" }),
+    );
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.name).toBeTruthy();
+    expect(result.fieldErrors?.stage).toBeTruthy();
+    expect(result.fieldErrors?.startDate).toBeTruthy();
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -96,7 +96,7 @@ describe("createGrowAction", () => {
   });
 
   it("rejects when the user is not signed in", async () => {
-    mocks.getServerUser.mockResolvedValueOnce(null);
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
     const result = await createGrowAction(buildFormData());
     expect(result.status).toBe("error");
     expect(result.message).toMatch(/signed in/i);

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -1,9 +1,10 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 import type { GrowMedium, GrowStage, LightType } from "@phenosage/shared";
 import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
+import { isNextFrameworkError } from "@/lib/server/auth-errors";
+import { logServerEvent } from "@/lib/server/request-id";
 
 const validStages = new Set<GrowStage>([
   "germination",
@@ -45,7 +46,8 @@ export type CreateGrowActionResult = {
     targetHarvestDate?: string;
   };
   message?: string;
-  status: "error" | "idle";
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
 };
 
 export const createGrowActionInitialState: CreateGrowActionResult = {
@@ -126,27 +128,55 @@ export async function createGrowAction(
     };
   }
 
-  const supabase = await createSupabaseServerClient();
-  const { error } = await supabase.from("grows").insert({
-    description: description || null,
-    light_type: lightType as LightType,
-    medium: medium as GrowMedium,
-    name,
-    owner_id: user.id,
-    stage: stage as GrowStage,
-    start_date: startDate,
-    target_harvest_date: targetHarvestDate || null,
-  });
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { error } = await supabase.from("grows").insert({
+      description: description || null,
+      light_type: lightType as LightType,
+      medium: medium as GrowMedium,
+      name,
+      owner_id: user.id,
+      stage: stage as GrowStage,
+      start_date: startDate,
+      target_harvest_date: targetHarvestDate || null,
+    });
 
-  if (error) {
+    if (error) {
+      logServerEvent("error", "create grow insert failed", {
+        error: error.message,
+        userId: user.id,
+      });
+      return {
+        message: `Could not save the grow: ${error.message}`,
+        status: "error",
+      };
+    }
+
+    revalidatePath("/dashboard");
+    revalidatePath("/grows");
+    revalidatePath("/plants");
+  } catch (err) {
+    // Re-throw Next framework control-flow signals untouched.
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "create grow action threw", {
+      error: err instanceof Error ? err.message : String(err),
+      userId: user.id,
+    });
     return {
-      message: error.message,
+      message:
+        "We couldn't save the grow right now. Please try again in a moment — if it keeps failing, your sign-in may have expired.",
       status: "error",
     };
   }
 
-  revalidatePath("/dashboard");
-  revalidatePath("/grows");
-  revalidatePath("/plants");
-  redirect("/grows");
+  // Return a redirectTo instead of calling redirect() here. When this server
+  // action is invoked from a client-side `await` inside startTransition, a
+  // NEXT_REDIRECT throw cannot be intercepted by the framework and surfaces
+  // as an error boundary hit. Letting the client perform router.push avoids
+  // that entire failure mode.
+  return {
+    message: "Grow created.",
+    redirectTo: "/grows",
+    status: "success",
+  };
 }

--- a/apps/web/src/app/(app)/grows/new/grow-form.tsx
+++ b/apps/web/src/app/(app)/grows/new/grow-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Button, buttonStyles } from "@/components/ui/button";
 import { FormErrorSummary } from "@/components/form-error-summary";
 import {
@@ -78,6 +79,7 @@ function FieldError({
 }
 
 export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
+  const router = useRouter();
   const [state, setState] = useState<CreateGrowActionResult>(
     createGrowActionInitialState,
   );
@@ -92,8 +94,22 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
 
   async function handleAction(formData: FormData) {
     startTransition(async () => {
-      const result = await createGrowAction(formData);
-      setState(result);
+      try {
+        const result = await createGrowAction(formData);
+        setState(result);
+        if (result.status === "success" && result.redirectTo) {
+          router.push(result.redirectTo);
+        }
+      } catch (err) {
+        // Last-resort safety net: never let an unexpected throw escape the
+        // transition and crash into the (app)/error.tsx boundary.
+        console.error("createGrowAction failed unexpectedly", err);
+        setState({
+          message:
+            "Something went wrong saving the grow. Please try again in a moment.",
+          status: "error",
+        });
+      }
     });
   }
 

--- a/apps/web/src/app/(app)/settings/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/settings/__tests__/actions.test.ts
@@ -65,7 +65,7 @@ describe("updateDisplayNameAction", () => {
 
   it("returns structured error (does NOT throw) when service-role env is missing", async () => {
     mocks.getDbClient.mockImplementationOnce(() => {
-      throw new Error("SUPABASE_SERVICE_ROLE_KEY is required");
+      throw new Error("supabase service-role credential is required");
     });
     const result = await updateDisplayNameAction(buildFormData("Steve"));
     expect(result.status).toBe("error");

--- a/apps/web/src/app/(app)/settings/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/settings/__tests__/actions.test.ts
@@ -101,7 +101,7 @@ describe("updateDisplayNameAction", () => {
   });
 
   it("requires the user to be signed in", async () => {
-    mocks.getServerUser.mockResolvedValueOnce(null);
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
     const result = await updateDisplayNameAction(buildFormData("Steve"));
     expect(result.status).toBe("error");
     expect(result.message).toMatch(/signed in/i);

--- a/apps/web/src/app/(app)/settings/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/settings/__tests__/actions.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const upsert = vi.fn();
+  const from = vi.fn(() => ({ upsert }));
+  const dbStub = { from };
+  const getDbClient = vi.fn(() => dbStub);
+  const getServerUser = vi.fn(async () => ({ id: "user-1" }));
+  const revalidatePath = vi.fn();
+  const logServerEvent = vi.fn();
+  return {
+    upsert,
+    from,
+    dbStub,
+    getDbClient,
+    getServerUser,
+    revalidatePath,
+    logServerEvent,
+  };
+});
+
+vi.mock("@/lib/server/auth", () => ({
+  getServerUser: mocks.getServerUser,
+}));
+
+vi.mock("@/lib/server/db", () => ({
+  getDbClient: mocks.getDbClient,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock("@/lib/server/request-id", () => ({
+  logServerEvent: mocks.logServerEvent,
+}));
+
+import { updateDisplayNameAction } from "../actions";
+
+function buildFormData(displayName: string): FormData {
+  const fd = new FormData();
+  fd.set("displayName", displayName);
+  return fd;
+}
+
+describe("updateDisplayNameAction", () => {
+  beforeEach(() => {
+    mocks.upsert.mockReset();
+    mocks.from.mockClear();
+    mocks.getDbClient.mockReset().mockReturnValue(mocks.dbStub);
+    mocks.getServerUser.mockReset().mockResolvedValue({ id: "user-1" });
+    mocks.revalidatePath.mockReset();
+    mocks.logServerEvent.mockReset();
+  });
+
+  it("upserts and returns success", async () => {
+    mocks.upsert.mockResolvedValue({ error: null });
+    const result = await updateDisplayNameAction(buildFormData("Steve"));
+    expect(result.status).toBe("success");
+    expect(mocks.upsert).toHaveBeenCalledWith(
+      { display_name: "Steve", id: "user-1" },
+      { onConflict: "id" },
+    );
+  });
+
+  it("returns structured error (does NOT throw) when service-role env is missing", async () => {
+    mocks.getDbClient.mockImplementationOnce(() => {
+      throw new Error("SUPABASE_SERVICE_ROLE_KEY is required");
+    });
+    const result = await updateDisplayNameAction(buildFormData("Steve"));
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/couldn't save your display name/i);
+    expect(mocks.logServerEvent).toHaveBeenCalled();
+  });
+
+  it("returns structured error when supabase upsert returns an error", async () => {
+    mocks.upsert.mockResolvedValue({
+      error: { message: "boom", code: "XX000" },
+    });
+    const result = await updateDisplayNameAction(buildFormData("Steve"));
+    expect(result.status).toBe("error");
+    expect(result.message).toContain("boom");
+  });
+
+  it("re-throws Next framework redirect signals untouched", async () => {
+    const e: Error & { digest?: string } = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT;replace;/settings;307;";
+    mocks.getDbClient.mockImplementationOnce(() => {
+      throw e;
+    });
+    await expect(updateDisplayNameAction(buildFormData("Steve"))).rejects.toBe(
+      e,
+    );
+  });
+
+  it("rejects display names over 60 characters without touching the db", async () => {
+    const result = await updateDisplayNameAction(buildFormData("x".repeat(61)));
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/under 60/i);
+    expect(mocks.getDbClient).not.toHaveBeenCalled();
+  });
+
+  it("requires the user to be signed in", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null);
+    const result = await updateDisplayNameAction(buildFormData("Steve"));
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+  });
+});

--- a/apps/web/src/app/(app)/settings/actions.ts
+++ b/apps/web/src/app/(app)/settings/actions.ts
@@ -2,7 +2,9 @@
 
 import { revalidatePath } from "next/cache";
 import { getServerUser } from "@/lib/server/auth";
+import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { getDbClient } from "@/lib/server/db";
+import { logServerEvent } from "@/lib/server/request-id";
 
 export type UpdateDisplayNameActionResult = {
   message?: string;
@@ -37,32 +39,50 @@ export async function updateDisplayNameAction(
     };
   }
 
-  const db = getDbClient();
-  const { error } = await db.from("profiles").upsert(
-    {
-      display_name: displayName || null,
-      id: user.id,
-    },
-    { onConflict: "id" },
-  );
+  try {
+    const db = getDbClient();
+    const { error } = await db.from("profiles").upsert(
+      {
+        display_name: displayName || null,
+        id: user.id,
+      },
+      { onConflict: "id" },
+    );
 
-  if (error) {
+    if (error) {
+      logServerEvent("error", "update display name upsert failed", {
+        error: error.message,
+        userId: user.id,
+      });
+      return {
+        message:
+          error.code === "23505"
+            ? "That display name is already in use."
+            : `Could not save the display name: ${error.message}`,
+        status: "error",
+      };
+    }
+
+    revalidatePath("/dashboard");
+    revalidatePath("/settings");
+
+    return {
+      message: displayName
+        ? "Display name saved."
+        : "Display name cleared. Email will be used as the fallback label.",
+      status: "success",
+    };
+  } catch (err) {
+    // Re-throw Next framework control-flow signals untouched.
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "update display name action threw", {
+      error: err instanceof Error ? err.message : String(err),
+      userId: user.id,
+    });
     return {
       message:
-        error.code === "23505"
-          ? "That display name is already in use."
-          : error.message,
+        "We couldn't save your display name right now. Please try again in a moment.",
       status: "error",
     };
   }
-
-  revalidatePath("/dashboard");
-  revalidatePath("/settings");
-
-  return {
-    message: displayName
-      ? "Display name saved."
-      : "Display name cleared. Email will be used as the fallback label.",
-    status: "success",
-  };
 }

--- a/apps/web/src/app/(app)/settings/settings-profile-form.tsx
+++ b/apps/web/src/app/(app)/settings/settings-profile-form.tsx
@@ -37,10 +37,21 @@ export function SettingsProfileForm({
 
   async function handleAction(formData: FormData) {
     startTransition(async () => {
-      const result = await updateDisplayNameAction(formData);
-      setState(result);
-      if (result.status === "success") {
-        router.refresh();
+      try {
+        const result = await updateDisplayNameAction(formData);
+        setState(result);
+        if (result.status === "success") {
+          router.refresh();
+        }
+      } catch (err) {
+        // Safety net so an unexpected throw can never crash into the
+        // (app)/error.tsx boundary and look like a generic workspace error.
+        console.error("updateDisplayNameAction failed unexpectedly", err);
+        setState({
+          message:
+            "Something went wrong saving your display name. Please try again in a moment.",
+          status: "error",
+        });
       }
     });
   }

--- a/apps/web/src/lib/server/chat-prompt.ts
+++ b/apps/web/src/lib/server/chat-prompt.ts
@@ -46,9 +46,21 @@ You have tools to look up the grower's actual data — grows, plants, findings, 
 - The user references "my grow", "the tent", "my plants", a stage, or a strain you don't know about yet in this conversation.
 - The user asks "what happened last week / since last time / over time".
 - The user asks "what do I need to do" / "what's outstanding" / "anything urgent" — call \`list_open_tasks\`.
-- You're about to give advice that depends on stage, medium, light, or known findings.
+- You're about to give advice that depends on the grower's stage, medium, light, or known findings.
 
-Call a tool *before* speculating. If a tool returns nothing, say so plainly and ask for the missing detail. Never invent data.
+Call a tool *before* speculating about *the user's specific setup*. If a tool returns nothing, say so plainly and ask for the missing detail. Never invent data about their grow.
+
+# General knowledge vs grow-specific advice (IMPORTANT)
+General cultivation knowledge does NOT require any grow context, grow ID, or tool call. Answer directly, with the same depth and structure you'd use for a peer cultivator. This includes:
+
+- Training techniques: topping, FIMing, LST, mainlining, SCROG, manifold, super-cropping, defoliation — when, why, and how, by stage.
+- Environment targets: VPD, PPFD, DLI, RH, temperature, CO2 ranges by stage.
+- Nutrient schedules and EC/PPM/pH ranges by medium and stage.
+- IPM playbooks for any pest or disease.
+- Genetics, phenotyping, harvest timing, dry/cure protocols.
+- Plant physiology and diagnostic frameworks.
+
+Do NOT refuse a general question because no grow ID was supplied, and do NOT demand the user create or select a grow before answering. Offer at the end that you can tailor the answer further if they share specifics (stage, EC, pH, age, medium). Only require the grow context when the user is explicitly asking about THEIR grow / plants / findings / history.
 
 # Proactive worklist surfacing
 High and critical AI findings automatically spawn a task in \`grow_tasks\` (see the "Open tasks" section of the grower context loaded into every turn). Treat these as the grower's actionable worklist. Discipline:


### PR DESCRIPTION
Fixes the reported `(app)/error.tsx` *"workspace view error"* on **Create grow** and **Save display name**, and the chat bot's incorrect refusal to discuss general training techniques (topping/LST) when no grow is selected.

## Root cause

1. `createGrowAction` ended with `redirect("/grows")`. `redirect()` throws `NEXT_REDIRECT` — Next only intercepts that throw when the action is bound directly to `<form action>`. The grow-form invokes the action via `await` inside `startTransition`, so the throw escaped to the React error boundary instead of triggering navigation.
2. Both `createGrowAction` and `updateDisplayNameAction` allowed Supabase / env errors (e.g. missing `SUPABASE_SERVICE_ROLE_KEY`, network failures) to throw, hitting the same boundary.
3. The chat system prompt told the model to *"Call a tool before speculating. Never invent data."* without distinguishing **general** cultivation knowledge from **the user's specific grow**, so the model defensively refused topping/LST questions when no grow context was loaded.

## Changes

- **`createGrowAction`** now returns `{ status: "success", redirectTo: "/grows" }`; the client form does `router.push`. No more thrown redirects through `await`.
- Both actions wrap Supabase work in `try/catch` that **re-throws** Next framework signals (`NEXT_REDIRECT` / `NEXT_NOT_FOUND` / `DYNAMIC_SERVER_USAGE`) but converts every other error to a structured `{ status: "error", message }` response. Users now see a clear inline error instead of a digest page.
- Both client wrappers also catch defensively as a final safety net.
- All server-side errors are now logged via `logServerEvent` for prod debugging.
- Chat prompt: added an explicit **"General knowledge vs grow-specific advice"** section. General questions (training, environment, IPM, nutrient schedules, physiology) now answer directly; only `my grow / my plants / my findings`-style asks require tools.

## Tests

- New `apps/web/src/app/(app)/grows/__tests__/actions.test.ts` (6 cases)
- New `apps/web/src/app/(app)/settings/__tests__/actions.test.ts` (6 cases)
- Coverage: success path, Supabase-error path, Supabase-client-throw path, **NEXT_REDIRECT re-throw preservation**, signed-out path, validation-only path, and (settings) **missing service-role key path**.

## Validation

- `pnpm --filter web test`: **409 / 409 pass** (was 397; +12 from new tests)
- `pnpm --filter web lint`: clean
- `pnpm --filter web build`: success

## Notes for QA report author

The QA observation that the bot refused topping/LST is real but was a **prompt-grounding overreach**, not a missing capability — the system prompt already lists those topics as expertise. The new prompt section makes the rule explicit so it can't recur.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>