### PR TITLE
perf: parallelize chat-context, fix createPlant redirect, add hot-path indexes

### DIFF
--- a/apps/web/src/app/(app)/grows/new/grow-form.tsx
+++ b/apps/web/src/app/(app)/grows/new/grow-form.tsx
@@ -303,6 +303,7 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
             }
             className={inputClassName}
             id="target-harvest-date"
+            min={startDate || undefined}
             name="targetHarvestDate"
             onChange={(event) => setTargetHarvestDate(event.target.value)}
             type="date"

--- a/apps/web/src/app/(app)/plants/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/plants/__tests__/actions.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const maybeSingle = vi.fn();
+  const insertSingle = vi.fn();
+
+  const growBuilder = {
+    select: vi.fn(() => growBuilder),
+    eq: vi.fn(() => growBuilder),
+    maybeSingle,
+  };
+  const plantBuilder = {
+    insert: vi.fn(() => plantBuilder),
+    select: vi.fn(() => plantBuilder),
+    single: insertSingle,
+  };
+
+  const from = vi.fn((table: string) => {
+    if (table === "grows") return growBuilder;
+    if (table === "plants") return plantBuilder;
+    throw new Error(`unexpected table ${table}`);
+  });
+  const supabaseStub = { from };
+  const createSupabaseServerClient = vi.fn(async () => supabaseStub);
+  const getServerUser = vi.fn(async () => ({ id: "user-1" }));
+  const revalidatePath = vi.fn();
+  const logServerEvent = vi.fn();
+  return {
+    maybeSingle,
+    insertSingle,
+    growBuilder,
+    plantBuilder,
+    from,
+    supabaseStub,
+    createSupabaseServerClient,
+    getServerUser,
+    revalidatePath,
+    logServerEvent,
+  };
+});
+
+vi.mock("@/lib/server/auth", () => ({
+  createSupabaseServerClient: mocks.createSupabaseServerClient,
+  getServerUser: mocks.getServerUser,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock("@/lib/server/request-id", () => ({
+  logServerEvent: mocks.logServerEvent,
+}));
+
+import { createPlantAction } from "../actions";
+
+function buildFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set("growId", "grow-1");
+  fd.set("name", "Plant Alpha");
+  fd.set("strain", "");
+  fd.set("batchLabel", "");
+  fd.set("notes", "");
+  for (const [k, v] of Object.entries(overrides)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+describe("createPlantAction", () => {
+  beforeEach(() => {
+    mocks.maybeSingle.mockReset();
+    mocks.insertSingle.mockReset();
+    mocks.from.mockClear();
+    mocks.createSupabaseServerClient
+      .mockReset()
+      .mockResolvedValue(mocks.supabaseStub);
+    mocks.getServerUser.mockReset().mockResolvedValue({ id: "user-1" });
+    mocks.revalidatePath.mockReset();
+    mocks.logServerEvent.mockReset();
+  });
+
+  it("returns success with redirectTo on a clean insert", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { id: "grow-1" },
+      error: null,
+    });
+    mocks.insertSingle.mockResolvedValue({
+      data: { id: "plant-9" },
+      error: null,
+    });
+    const result = await createPlantAction(buildFormData());
+    expect(result.status).toBe("success");
+    expect(result.redirectTo).toBe("/plants/plant-9");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/plants");
+  });
+
+  it("returns a structured error when the grow lookup fails", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: null,
+      error: { message: "boom" },
+    });
+    const result = await createPlantAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/couldn't verify the selected grow/i);
+    expect(mocks.logServerEvent).toHaveBeenCalled();
+  });
+
+  it("returns a field error when the grow is not visible to the user", async () => {
+    mocks.maybeSingle.mockResolvedValue({ data: null, error: null });
+    const result = await createPlantAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.growId).toBeTruthy();
+  });
+
+  it("returns a friendly duplicate-name message on 23505", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { id: "grow-1" },
+      error: null,
+    });
+    mocks.insertSingle.mockResolvedValue({
+      data: null,
+      error: { message: "dup", code: "23505" },
+    });
+    const result = await createPlantAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/already exists/i);
+  });
+
+  it("returns a structured error (not throw) when supabase client itself throws", async () => {
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(
+      new Error("env missing"),
+    );
+    const result = await createPlantAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/couldn't save the plant/i);
+    expect(mocks.logServerEvent).toHaveBeenCalled();
+  });
+
+  it("re-throws Next framework redirect signals untouched", async () => {
+    const e: Error & { digest?: string } = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT;replace;/plants/x;307;";
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(e);
+    await expect(createPlantAction(buildFormData())).rejects.toBe(e);
+  });
+
+  it("rejects when the user is not signed in", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
+    const result = await createPlantAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+  });
+
+  it("returns field errors for invalid inputs without touching supabase", async () => {
+    const result = await createPlantAction(
+      buildFormData({ growId: "", name: "" }),
+    );
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.growId).toBeTruthy();
+    expect(result.fieldErrors?.name).toBeTruthy();
+    expect(mocks.maybeSingle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/plants/actions.ts
+++ b/apps/web/src/app/(app)/plants/actions.ts
@@ -1,8 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
+import { isNextFrameworkError } from "@/lib/server/auth-errors";
+import { logServerEvent } from "@/lib/server/request-id";
 
 export type CreatePlantActionResult = {
   fieldErrors?: {
@@ -10,7 +11,8 @@ export type CreatePlantActionResult = {
     name?: string;
   };
   message?: string;
-  status: "error" | "idle";
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
 };
 
 export const createPlantActionInitialState: CreatePlantActionResult = {
@@ -58,49 +60,81 @@ export async function createPlantAction(
     };
   }
 
-  const supabase = await createSupabaseServerClient();
-  const { data: grow, error: growError } = await supabase
-    .from("grows")
-    .select("id")
-    .eq("id", growId)
-    .maybeSingle();
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: grow, error: growError } = await supabase
+      .from("grows")
+      .select("id")
+      .eq("id", growId)
+      .maybeSingle();
 
-  if (growError) {
+    if (growError) {
+      logServerEvent("error", "create plant grow lookup failed", {
+        error: growError.message,
+        userId: user.id,
+        growId,
+      });
+      return {
+        message:
+          "We couldn't verify the selected grow. Please try again in a moment.",
+        status: "error",
+      };
+    }
+
+    if (!grow) {
+      return {
+        fieldErrors: { growId: "Select a grow you can access." },
+        message: "The selected grow is not available.",
+        status: "error",
+      };
+    }
+
+    const { data, error } = await supabase
+      .from("plants")
+      .insert({
+        batch_label: batchLabel || null,
+        grow_id: growId,
+        name,
+        notes: notes || null,
+        strain: strain || null,
+      })
+      .select("id")
+      .single();
+
+    if (error || !data) {
+      logServerEvent("error", "create plant insert failed", {
+        error: error?.message ?? "no row returned",
+        userId: user.id,
+        growId,
+      });
+      return {
+        message:
+          error?.code === "23505"
+            ? "A plant with that name already exists in this grow."
+            : "We couldn't save the plant right now. Please try again in a moment.",
+        status: "error",
+      };
+    }
+
+    revalidatePath("/dashboard");
+    revalidatePath("/grows");
+    revalidatePath("/plants");
+
     return {
-      message: growError.message,
+      message: "Plant created.",
+      redirectTo: `/plants/${data.id}`,
+      status: "success",
+    };
+  } catch (err) {
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "create plant action threw", {
+      error: err instanceof Error ? err.message : String(err),
+      userId: user.id,
+    });
+    return {
+      message:
+        "We couldn't save the plant right now. Please try again in a moment.",
       status: "error",
     };
   }
-
-  if (!grow) {
-    return {
-      fieldErrors: { growId: "Select a grow you can access." },
-      message: "The selected grow is not available.",
-      status: "error",
-    };
-  }
-
-  const { data, error } = await supabase
-    .from("plants")
-    .insert({
-      batch_label: batchLabel || null,
-      grow_id: growId,
-      name,
-      notes: notes || null,
-      strain: strain || null,
-    })
-    .select("id")
-    .single();
-
-  if (error || !data) {
-    return {
-      message: error?.message ?? "Failed to create the plant.",
-      status: "error",
-    };
-  }
-
-  revalidatePath("/dashboard");
-  revalidatePath("/grows");
-  revalidatePath("/plants");
-  redirect(`/plants/${data.id}`);
 }

--- a/apps/web/src/app/(app)/plants/new/plant-form.tsx
+++ b/apps/web/src/app/(app)/plants/new/plant-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { Button, buttonStyles } from "@/components/ui/button";
 import { FormErrorSummary } from "@/components/form-error-summary";
 type GrowRecord = { id: string; name: string; stage: string | null };
@@ -48,6 +49,7 @@ export function PlantForm({
   defaultGrowId: string;
   grows: GrowRecord[];
 }) {
+  const router = useRouter();
   const [state, setState] = useState<CreatePlantActionResult>(
     createPlantActionInitialState,
   );
@@ -60,8 +62,22 @@ export function PlantForm({
 
   async function handleAction(formData: FormData) {
     startTransition(async () => {
-      const result = await createPlantAction(formData);
-      setState(result);
+      try {
+        const result = await createPlantAction(formData);
+        setState(result);
+        if (result.status === "success" && result.redirectTo) {
+          router.push(result.redirectTo);
+        }
+      } catch (err) {
+        // Safety net so an unexpected throw can never crash into the
+        // (app)/error.tsx boundary.
+        console.error("createPlantAction failed unexpectedly", err);
+        setState({
+          message:
+            "Something went wrong saving the plant. Please try again in a moment.",
+          status: "error",
+        });
+      }
     });
   }
 

--- a/apps/web/src/lib/server/chat-context.ts
+++ b/apps/web/src/lib/server/chat-context.ts
@@ -71,23 +71,40 @@ export async function loadGrowContextSummary(
 
   const g = grow as GrowRow;
 
-  const { count: plantCount } = await supabase
-    .from("plants")
-    .select("id", { count: "exact", head: true })
-    .eq("grow_id", g.id)
-    .eq("is_archived", false);
-
   const thirtyDaysAgo = new Date(
     Date.now() - 30 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
-  const { data: findings, error: findingsErr } = await supabase
-    .from("plant_findings")
-    .select("title,category,severity,created_at,plants(name)")
-    .eq("grow_id", g.id)
-    .gte("created_at", thirtyDaysAgo)
-    .order("created_at", { ascending: false })
-    .limit(10);
+  // Run the three independent per-grow queries in parallel. Each one is
+  // already constrained by RLS + indexed (`plants(grow_id)`,
+  // `plant_findings(grow_id, created_at desc)`, `grow_tasks(grow_id, status)`)
+  // so the only thing serial waits were buying us was added latency.
+  const [plantCountResult, findingsResult, tasksResult] = await Promise.all([
+    supabase
+      .from("plants")
+      .select("id", { count: "exact", head: true })
+      .eq("grow_id", g.id)
+      .eq("is_archived", false),
+    supabase
+      .from("plant_findings")
+      .select("title,category,severity,created_at,plants(name)")
+      .eq("grow_id", g.id)
+      .gte("created_at", thirtyDaysAgo)
+      .order("created_at", { ascending: false })
+      .limit(10),
+    supabase
+      .from("grow_tasks")
+      .select("id,title,priority,status,created_at,plants(name)")
+      .eq("grow_id", g.id)
+      .in("status", ["open", "in_progress"])
+      .order("priority", { ascending: false })
+      .order("created_at", { ascending: false })
+      .limit(10),
+  ]);
+
+  const { count: plantCount } = plantCountResult;
+  const { data: findings, error: findingsErr } = findingsResult;
+  const { data: tasks, error: tasksErr } = tasksResult;
 
   if (findingsErr) {
     logServerEvent("error", "chat context findings lookup failed", {
@@ -113,15 +130,6 @@ export async function loadGrowContextSummary(
   // Open + in_progress tasks for this grow, urgent first. Capped at 10
   // because this loads into every chat turn — anything beyond that goes
   // through the `list_open_tasks` tool on demand.
-  const { data: tasks, error: tasksErr } = await supabase
-    .from("grow_tasks")
-    .select("id,title,priority,status,created_at,plants(name)")
-    .eq("grow_id", g.id)
-    .in("status", ["open", "in_progress"])
-    .order("priority", { ascending: false })
-    .order("created_at", { ascending: false })
-    .limit(10);
-
   if (tasksErr) {
     logServerEvent("error", "chat context tasks lookup failed", {
       error: tasksErr.message,

--- a/supabase/migrations/009_chat_and_findings_indexes.sql
+++ b/supabase/migrations/009_chat_and_findings_indexes.sql
@@ -1,0 +1,16 @@
+-- Performance indexes for hot read paths.
+--
+-- chat_threads(user_id, updated_at desc): listThreadsForUser orders by
+--   updated_at desc filtered by user_id. The only existing index is on
+--   grow_id, which doesn't help.
+--
+-- plant_findings(grow_id, created_at desc): chat-context loads the most
+--   recent findings per grow. Existing indexes are (plant_id), (severity),
+--   (plant_id, severity), (image_id), and the embedding index — none cover
+--   this access path.
+
+create index if not exists idx_chat_threads_user_id_updated_at
+  on public.chat_threads (user_id, updated_at desc);
+
+create index if not exists idx_plant_findings_grow_id_created_at
+  on public.plant_findings (grow_id, created_at desc);


### PR DESCRIPTION
Second optimization pass on top of #135.

## Fixes
- **createPlantAction redirect-from-await bug** (same class as the QA report's grow-create error): action now returns `{ status: 'success', redirectTo }`; plant-form does `router.push` from the client. Also wraps in try/catch with `isNextFrameworkError` re-throw, sanitizes raw supabase errors, and `logServerEvent` on failures.
- **target-harvest-date**: input now has `min={startDate}` so the date picker can't pick a target before the start.

## Performance
- **chat-context**: the 3 per-grow read queries (plantCount, findings, tasks) ran sequentially. Now `Promise.all`-ed.
- **New migration 009**: `chat_threads(user_id, updated_at desc)` and `plant_findings(grow_id, created_at desc)`. Both back queries that previously had no covering index.
  - 'âò ï¸ Run `supabase db push` against prod after merge.

## Tests
- 8 new cases covering createPlantAction (success+redirectTo, grow lookup error, grow not found, duplicate, throw, NEXT_REDIRECT re-throw, signed-out, validation-only).
- `417/417` web tests pass. lint, type-check, build, check:env all green.