### PR TITLE
feat(grows): keep momentum after creating a grow

### DIFF
--- a/apps/web/e2e/authenticated-workspace.spec.ts
+++ b/apps/web/e2e/authenticated-workspace.spec.ts
@@ -53,23 +53,17 @@ test.describe("Authenticated workspace smoke", () => {
         await page.getByLabel("Light type").selectOption("led");
         await page.getByRole("button", { name: "Create grow" }).click();
 
-        await page.waitForURL("**/grows");
-        await expect(page.getByText(growName)).toBeVisible();
+        // Post-create now lands directly on the add-plant flow with a
+        // success banner naming the new grow.
+        await page.waitForURL(/\/plants\/new\?growId=[^&]+&just_created=1/);
+        await expect(
+          page.getByText(new RegExp(`Grow .${growName}. is ready`, "i")),
+        ).toBeVisible();
       });
 
       let plantId = "";
 
-      await test.step("add a plant to the grow and verify it lists on /plants", async () => {
-        const addPlantLink = page
-          .getByRole("link", { name: "Add plant" })
-          .first();
-        await expect(addPlantLink).toHaveAttribute(
-          "href",
-          /\/plants\/new\?growId=/,
-        );
-        await addPlantLink.click();
-        await page.waitForURL("**/plants/new**");
-
+      await test.step("add a plant to the new grow and verify it lists on /plants", async () => {
         await page.getByLabel("Plant name").fill(plantName);
         await page.getByLabel("Strain").fill("Playwright Kush");
         await page.getByLabel("Batch label").fill("SMOKE-BATCH");

--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => {
-  const insert = vi.fn();
+  // The action chains .insert(...).select("id").single().
+  // Build a thenable-style chain by default that yields { data: { id }, error: null }.
+  const single = vi.fn();
+  const select = vi.fn(() => ({ single }));
+  const insert = vi.fn(() => ({ select }));
   const from = vi.fn(() => ({ insert }));
   const supabaseStub = { from };
   const createSupabaseServerClient = vi.fn(async () => supabaseStub);
@@ -9,6 +13,8 @@ const mocks = vi.hoisted(() => {
   const revalidatePath = vi.fn();
   const logServerEvent = vi.fn();
   return {
+    single,
+    select,
     insert,
     from,
     supabaseStub,
@@ -51,7 +57,9 @@ function buildFormData(overrides: Record<string, string> = {}): FormData {
 
 describe("createGrowAction", () => {
   beforeEach(() => {
-    mocks.insert.mockReset();
+    mocks.single.mockReset();
+    mocks.select.mockClear();
+    mocks.insert.mockClear();
     mocks.from.mockClear();
     mocks.createSupabaseServerClient
       .mockReset()
@@ -61,21 +69,51 @@ describe("createGrowAction", () => {
     mocks.logServerEvent.mockReset();
   });
 
-  it("returns success with redirectTo on a clean insert", async () => {
-    mocks.insert.mockResolvedValue({ error: null });
+  it("returns success and redirects into the add-plant flow with the new grow id", async () => {
+    mocks.single.mockResolvedValue({
+      data: { id: "grow-new-123" },
+      error: null,
+    });
     const result = await createGrowAction(buildFormData());
     expect(result.status).toBe("success");
-    expect(result.redirectTo).toBe("/grows");
+    expect(result.redirectTo).toBe(
+      "/plants/new?growId=grow-new-123&just_created=1",
+    );
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/plants");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard");
   });
 
-  it("returns a structured error (not throw) when supabase rejects the insert", async () => {
-    mocks.insert.mockResolvedValue({
-      error: { message: "duplicate key", code: "23505" },
+  it("url-encodes the grow id so unusual characters don't break the redirect", async () => {
+    mocks.single.mockResolvedValue({
+      data: { id: "abc/def?weird" },
+      error: null,
+    });
+    const result = await createGrowAction(buildFormData());
+    expect(result.redirectTo).toBe(
+      "/plants/new?growId=abc%2Fdef%3Fweird&just_created=1",
+    );
+  });
+
+  it("surfaces a friendly duplicate-name message on 23505 without leaking raw error text", async () => {
+    mocks.single.mockResolvedValue({
+      data: null,
+      error: { message: "duplicate key value", code: "23505" },
     });
     const result = await createGrowAction(buildFormData());
     expect(result.status).toBe("error");
-    expect(result.message).toContain("duplicate key");
+    expect(result.message).toMatch(/grow with that name already exists/i);
+    expect(result.message).not.toContain("duplicate key value");
+  });
+
+  it("returns a structured error (not throw) when supabase rejects the insert", async () => {
+    mocks.single.mockResolvedValue({
+      data: null,
+      error: { message: "permission denied", code: "42501" },
+    });
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/couldn't save the grow/i);
   });
 
   it("returns a structured error (not throw) when supabase client itself throws", async () => {
@@ -111,5 +149,11 @@ describe("createGrowAction", () => {
     expect(result.fieldErrors?.stage).toBeTruthy();
     expect(result.fieldErrors?.startDate).toBeTruthy();
     expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("falls back to /grows when the insert returns no row (defensive)", async () => {
+    mocks.single.mockResolvedValue({ data: null, error: null });
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
   });
 });

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -128,29 +128,39 @@ export async function createGrowAction(
     };
   }
 
+  let newGrowId: string | null = null;
   try {
     const supabase = await createSupabaseServerClient();
-    const { error } = await supabase.from("grows").insert({
-      description: description || null,
-      light_type: lightType as LightType,
-      medium: medium as GrowMedium,
-      name,
-      owner_id: user.id,
-      stage: stage as GrowStage,
-      start_date: startDate,
-      target_harvest_date: targetHarvestDate || null,
-    });
+    const { data, error } = await supabase
+      .from("grows")
+      .insert({
+        description: description || null,
+        light_type: lightType as LightType,
+        medium: medium as GrowMedium,
+        name,
+        owner_id: user.id,
+        stage: stage as GrowStage,
+        start_date: startDate,
+        target_harvest_date: targetHarvestDate || null,
+      })
+      .select("id")
+      .single();
 
-    if (error) {
+    if (error || !data) {
       logServerEvent("error", "create grow insert failed", {
-        error: error.message,
+        error: error?.message ?? "no row returned",
         userId: user.id,
       });
       return {
-        message: `Could not save the grow: ${error.message}`,
+        message:
+          error?.code === "23505"
+            ? "A grow with that name already exists. Try a different name."
+            : "We couldn't save the grow right now. Please try again in a moment.",
         status: "error",
       };
     }
+
+    newGrowId = data.id;
 
     revalidatePath("/dashboard");
     revalidatePath("/grows");
@@ -174,9 +184,16 @@ export async function createGrowAction(
   // NEXT_REDIRECT throw cannot be intercepted by the framework and surfaces
   // as an error boundary hit. Letting the client perform router.push avoids
   // that entire failure mode.
+  //
+  // Send the operator straight to the add-plant flow with the new grow
+  // pre-selected. The plant page renders a "grow ready" banner with an
+  // explicit "back to grow registry" exit so this isn't a forced path.
+  const redirectTo = newGrowId
+    ? `/plants/new?growId=${encodeURIComponent(newGrowId)}&just_created=1`
+    : "/grows";
   return {
     message: "Grow created.",
-    redirectTo: "/grows",
+    redirectTo,
     status: "success",
   };
 }

--- a/apps/web/src/app/(app)/grows/new/grow-form.tsx
+++ b/apps/web/src/app/(app)/grows/new/grow-form.tsx
@@ -57,6 +57,45 @@ const lightTypes = [
   { label: "Other", value: "other" },
 ] as const;
 
+type Preset = {
+  description: string;
+  label: string;
+  lightType: (typeof lightTypes)[number]["value"];
+  medium: (typeof growMedia)[number]["value"];
+  stage: (typeof growStages)[number]["value"];
+};
+
+const presets: Preset[] = [
+  {
+    description: "Most common indoor setup. Soil in fabric pots under LED.",
+    label: "Indoor LED · soil",
+    lightType: "led",
+    medium: "soil",
+    stage: "seedling",
+  },
+  {
+    description: "Faster feeding loop in coco coir under LED.",
+    label: "Indoor LED · coco",
+    lightType: "led",
+    medium: "coco",
+    stage: "seedling",
+  },
+  {
+    description: "Recirculating or DWC hydro with LED canopy lighting.",
+    label: "Indoor LED · hydro",
+    lightType: "led",
+    medium: "hydro",
+    stage: "seedling",
+  },
+  {
+    description: "Outdoor or greenhouse soil under natural sun.",
+    label: "Outdoor · sun",
+    lightType: "sun",
+    medium: "soil",
+    stage: "vegetative",
+  },
+];
+
 const inputClassName =
   "mt-2 block w-full rounded-[1.15rem] border border-border/80 bg-surface px-4 py-3 text-sm text-foreground shadow-soft transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35";
 
@@ -86,11 +125,21 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
   const [isPending, startTransition] = useTransition();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
-  const [stage, setStage] = useState("seedling");
-  const [medium, setMedium] = useState("soil");
-  const [lightType, setLightType] = useState("led");
+  const [stage, setStage] = useState<Preset["stage"]>("seedling");
+  const [medium, setMedium] = useState<Preset["medium"]>("soil");
+  const [lightType, setLightType] = useState<Preset["lightType"]>("led");
   const [startDate, setStartDate] = useState(initialStartDate);
   const [targetHarvestDate, setTargetHarvestDate] = useState("");
+  const [activePresetLabel, setActivePresetLabel] = useState<string | null>(
+    null,
+  );
+
+  function applyPreset(preset: Preset) {
+    setStage(preset.stage);
+    setMedium(preset.medium);
+    setLightType(preset.lightType);
+    setActivePresetLabel(preset.label);
+  }
 
   async function handleAction(formData: FormData) {
     startTransition(async () => {
@@ -120,6 +169,42 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
         fieldErrors={state.fieldErrors}
         fieldMeta={FIELD_META}
       />
+
+      <div
+        aria-label="Quick-start presets"
+        className="rounded-[1.15rem] border border-border/70 bg-background-subtle/40 px-4 py-4"
+        role="group"
+      >
+        <p className="text-sm font-medium text-foreground">
+          Quick-start a typical setup
+        </p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          Tap a preset to fill stage, medium, and light — you can still tweak
+          any field before saving.
+        </p>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {presets.map((preset) => {
+            const isActive = activePresetLabel === preset.label;
+            return (
+              <button
+                aria-pressed={isActive}
+                className={
+                  "rounded-full border px-3.5 py-1.5 text-xs font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35 " +
+                  (isActive
+                    ? "border-accent bg-accent/10 text-accent-strong"
+                    : "border-border/80 bg-surface text-foreground hover:border-accent/60")
+                }
+                key={preset.label}
+                onClick={() => applyPreset(preset)}
+                title={preset.description}
+                type="button"
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       <div>
         <label
@@ -158,7 +243,7 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
           id="grow-description"
           name="description"
           onChange={(event) => setDescription(event.target.value)}
-          placeholder="Optional room notes, cultivar program details, or operator context."
+          placeholder="Where this grow lives, the cultivar, or anything you'd want to remember later."
           value={description}
         />
         <p className="mt-2 text-sm text-muted-foreground">
@@ -183,7 +268,10 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
             className={inputClassName}
             id="grow-stage"
             name="stage"
-            onChange={(event) => setStage(event.target.value)}
+            onChange={(event) => {
+              setStage(event.target.value as Preset["stage"]);
+              setActivePresetLabel(null);
+            }}
             value={stage}
           >
             {growStages.map((option) => (
@@ -211,7 +299,10 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
             className={inputClassName}
             id="grow-medium"
             name="medium"
-            onChange={(event) => setMedium(event.target.value)}
+            onChange={(event) => {
+              setMedium(event.target.value as Preset["medium"]);
+              setActivePresetLabel(null);
+            }}
             value={medium}
           >
             {growMedia.map((option) => (
@@ -242,7 +333,10 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
             className={inputClassName}
             id="grow-light-type"
             name="lightType"
-            onChange={(event) => setLightType(event.target.value)}
+            onChange={(event) => {
+              setLightType(event.target.value as Preset["lightType"]);
+              setActivePresetLabel(null);
+            }}
             value={lightType}
           >
             {lightTypes.map((option) => (
@@ -317,9 +411,13 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
       </div>
 
       <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-5">
-        <p className="text-sm leading-6 text-muted-foreground">
-          This creates the grow record immediately and makes it available to the
-          dashboard and plant flows.
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-muted-foreground"
+        >
+          {isPending
+            ? "Saving the grow..."
+            : "Next: add your first plant so image history and assistant context have a home."}
         </p>
         <div className="flex flex-wrap gap-3">
           <Link

--- a/apps/web/src/app/(app)/grows/new/page.tsx
+++ b/apps/web/src/app/(app)/grows/new/page.tsx
@@ -23,7 +23,7 @@ export default function NewGrowPage() {
           { href: "/grows", label: "Grows" },
           { label: "New grow" },
         ]}
-        description="Create the grow record first so plants, captures, findings, and assistant threads all have one stable operating home."
+        description="Set up the grow record — name, stage, medium, light — then we'll take you straight to adding the first plant."
         eyebrow={<Badge tone="accent">Create grow</Badge>}
         title="New grow"
       />

--- a/apps/web/src/app/(app)/plants/new/page.tsx
+++ b/apps/web/src/app/(app)/plants/new/page.tsx
@@ -20,20 +20,23 @@ export const metadata: Metadata = { title: "Add Plant" };
 interface Props {
   searchParams?: Promise<{
     growId?: string | string[] | undefined;
+    just_created?: string | string[] | undefined;
   }>;
+}
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? "";
+  return value ?? "";
 }
 
 export default async function NewPlantPage({ searchParams }: Props) {
   const grows = await listAccessibleGrows();
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
-  const requestedGrowId = resolvedSearchParams?.growId;
-  const requestedGrowIdValue = Array.isArray(requestedGrowId)
-    ? (requestedGrowId[0] ?? "")
-    : (requestedGrowId ?? "");
-  const defaultGrowId =
-    grows.find((grow) => grow.id === requestedGrowIdValue)?.id ??
-    grows[0]?.id ??
-    "";
+  const requestedGrowIdValue = firstParam(resolvedSearchParams?.growId);
+  const justCreated = firstParam(resolvedSearchParams?.just_created) === "1";
+  const matchedGrow = grows.find((grow) => grow.id === requestedGrowIdValue);
+  const defaultGrowId = matchedGrow?.id ?? grows[0]?.id ?? "";
+  const justCreatedGrowName = justCreated ? matchedGrow?.name : undefined;
 
   return (
     <main className="app-page">
@@ -47,6 +50,26 @@ export default async function NewPlantPage({ searchParams }: Props) {
         eyebrow={<Badge tone="accent">Create plant</Badge>}
         title="Add a plant"
       />
+
+      {justCreatedGrowName ? (
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-success/40 bg-success/10 px-4 py-4 text-sm leading-6 text-foreground"
+          role="status"
+        >
+          <p className="font-medium">
+            Grow &ldquo;{justCreatedGrowName}&rdquo; is ready.
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            Add the first plant below to start tracking image history,
+            timelines, and assistant context — or{" "}
+            <Link className="underline" href="/grows">
+              skip back to the grow registry
+            </Link>
+            .
+          </p>
+        </div>
+      ) : null}
 
       {grows.length === 0 ? (
         <Card>


### PR DESCRIPTION
## Summary

Audited the "starting a grow" UX end-to-end and shipped the highest-impact win: stop dead-ending the operator on `/grows` after they just told us they want to start one.

### Problems found
- **Dead-end after create.** `createGrowAction` redirected to `/grows`. The operator's stated intent ("create grow") was answered with an overview page — they then had to scan grow cards to find a tiny "Add plant" link to actually start tracking anything. Worst at the very moment a new user is most likely to bounce.
- **No quick-start.** Every new grow form required manually picking stage/medium/light. Most setups fall into 4 buckets; new growers don't always know what to pick.
- **No grow-side context on `/plants/new`.** Even when arriving there via the existing `?growId=` link, there was no indication a new grow had just been created — silent transition.
- **Jargon-y copy.** "Cultivar program details, or operator context" as a placeholder reads as ops-speak.
- **Raw supabase error text on duplicate names.** `createGrowAction` was the only create-action still leaking the raw `error.message` (`createPlantAction` got fixed in #136).

### Changes
- `createGrowAction` now `.select("id").single()`s the insert and redirects to `/plants/new?growId=<id>&just_created=1` (URL-encoded). It also returns a friendly "A grow with that name already exists." message on `23505` instead of the raw supabase error.
- `/plants/new` reads `just_created=1` and renders an `aria-live="polite"` success banner naming the grow, with an explicit "skip back to the grow registry" exit — this isn't a forced path.
- Grow form gains a **"Quick-start a typical setup"** preset row: *Indoor LED · soil / coco / hydro*, *Outdoor · sun*. One tap fills stage + medium + light; any manual edit clears the active chip with `aria-pressed` reflecting state.
- Description placeholder rewritten in operator-plain language. Footer hint becomes a live status that switches to "Saving the grow…" while pending.
- Page-level description updated to set expectation that the next screen is plant intake.

### Tests
- Updated `actions.test.ts` mock chain for `.insert().select().single()`.
- Added cases for the new redirect path, URL-encoding of the grow id, the friendly duplicate-name message (and that raw supabase text is *not* leaked), and a defensive "no row returned" fallback.
- Updated the gated `E2E_AUTH_SMOKE` Playwright step to expect `/plants/new?growId=…&just_created=1` and assert the banner copy.
- `pnpm turbo run test type-check lint`: **420/420 passing** (was 417).
- `pnpm run validate`, `pnpm run security:routes`, and `pnpm --filter web build` all green.

### Ideas worth a follow-up PR (not in scope here)
1. **Bulk plant create.** Add a "plants in this grow" count to the grow form; on submit, create N rows server-side with `Plant 01`, `Plant 02`… names. Today's flow still asks the operator to add plants one at a time.
2. **Grow detail page (`/grows/[id]`).** Right now grow context only lives on the registry card and the plant detail page. A dedicated detail page would also be a better long-term post-create destination than the add-plant flow once a grow has plants.
3. **Auto target-harvest hint.** Suggest a target harvest date based on stage + medium + light (e.g., LED indoor flower → ~60 days from start).
4. **"Use last grow as template"** preset for repeat operators.

## Test plan
- [x] Unit: `pnpm --filter web test -- src/app/\(app\)/grows/__tests__/actions.test.ts` (9/9)
- [x] Full: `pnpm turbo run test type-check lint` (420/420)
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual smoke: create grow → land on `/plants/new` with banner → add plant → land on `/plants/<id>` (run via `E2E_AUTH_SMOKE=1`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_