### PR TITLE
feat(chat): agentic update_grow + update_plant tools

### DIFF
--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -1340,3 +1340,321 @@ describe("chat-tools — create_grow_task", () => {
     expect(insert).not.toHaveBeenCalled();
   });
 });
+
+describe("chat-tools — update_grow", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires only growId", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "update_grow",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["growId"] });
+  });
+
+  it("rejects when no mutable field is supplied", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow",
+      { growId: "g-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("patches only the supplied fields and trims name/description", async () => {
+    const { client, update, eq } = makeUpdateEqMaybeSingleMock({
+      data: {
+        id: "g-1",
+        name: "Renamed",
+        description: "fresh",
+        stage: "vegetative",
+        medium: "coco",
+        light_type: "led",
+        is_archived: false,
+      },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow",
+      {
+        growId: "g-1",
+        name: "  Renamed  ",
+        description: "  fresh  ",
+        medium: "coco",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(update).toHaveBeenCalledWith({
+      name: "Renamed",
+      description: "fresh",
+      medium: "coco",
+    });
+    expect(eq).toHaveBeenCalledWith("id", "g-1");
+  });
+
+  it("clears description and targetHarvestDate when empty string is supplied", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: { id: "g-1" },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "update_grow",
+      { growId: "g-1", description: "", targetHarvestDate: "" },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({
+      description: null,
+      target_harvest_date: null,
+    });
+  });
+
+  it("toggles is_archived when archived flag is supplied", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: { id: "g-1", is_archived: true },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "update_grow",
+      { growId: "g-1", archived: true },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({ is_archived: true });
+  });
+
+  it("returns 'not found or not accessible' when zero rows match", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow",
+      { growId: "missing", name: "X" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/not found or not accessible/i);
+  });
+
+  it("translates an RLS denial into an owner-only permission error", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: { code: "42501", message: "row-level security" },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow",
+      { growId: "g-1", name: "X" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/owner only/i);
+  });
+
+  it("surfaces a friendly duplicate-name message on 23505", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: { code: "23505", message: "duplicate key" },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow",
+      { growId: "g-1", name: "Existing" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/already exists/i);
+  });
+
+  it("rejects when the user is not authenticated", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_grow",
+      { growId: "g-1", name: "X" },
+      { requestId: "req-x", userId: null },
+    );
+
+    expect(result).toEqual({ error: "not authenticated", ok: false });
+    expect(update).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat-tools — update_plant", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires only plantId", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "update_plant",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["plantId"] });
+  });
+
+  it("rejects when no mutable field is supplied", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_plant",
+      { plantId: "p-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("patches only the supplied fields and trims values", async () => {
+    const { client, update, eq } = makeUpdateEqMaybeSingleMock({
+      data: { id: "p-1", name: "Mother", strain: "NL", batch_label: null },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "update_plant",
+      {
+        plantId: "p-1",
+        name: "  Mother  ",
+        strain: "  NL  ",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({ name: "Mother", strain: "NL" });
+    expect(eq).toHaveBeenCalledWith("id", "p-1");
+  });
+
+  it("clears optional text fields when empty string is supplied", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: { id: "p-1" },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "update_plant",
+      { plantId: "p-1", strain: "", batchLabel: "", notes: "" },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({
+      strain: null,
+      batch_label: null,
+      notes: null,
+    });
+  });
+
+  it("toggles is_archived when archived flag is supplied", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: { id: "p-1", is_archived: true },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "update_plant",
+      { plantId: "p-1", archived: true },
+      CTX_AUTHED,
+    );
+
+    expect(update).toHaveBeenCalledWith({ is_archived: true });
+  });
+
+  it("returns 'not found or not accessible' when zero rows match", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_plant",
+      { plantId: "missing", name: "X" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/not found or not accessible/i);
+  });
+
+  it("translates an RLS denial into an owner-only permission error", async () => {
+    const { client } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: { code: "42501", message: "row-level security" },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_plant",
+      { plantId: "p-1", name: "X" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/owner only/i);
+  });
+
+  it("rejects when the user is not authenticated", async () => {
+    const { client, update } = makeUpdateEqMaybeSingleMock({
+      data: null,
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "update_plant",
+      { plantId: "p-1", name: "X" },
+      { requestId: "req-x", userId: null },
+    );
+
+    expect(result).toEqual({ error: "not authenticated", ok: false });
+    expect(update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -502,6 +502,99 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_grow",
+      description:
+        "Update a grow's mutable metadata — rename it, edit the description, fix the medium / light_type, set or clear the target harvest date, or archive / un-archive it. Use when the user wants to correct a mistake ('rename the Test grow to North Tent'), evolve the program ('we switched to coco'), or wrap up the cycle ('archive the spring 2026 run'). Stage transitions go through update_grow_stage, not this tool. Pass only the fields the user actually wants to change — omitted fields are left untouched. At least one mutable field is required. Owner only.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description: "Grow ID to update. Required.",
+          },
+          name: {
+            type: "string",
+            description:
+              "New grow name (1-120 chars). Omit to leave unchanged.",
+          },
+          description: {
+            type: "string",
+            description:
+              "Replacement free-text description (up to 2000 chars). Pass an empty string to clear an existing description; omit to leave unchanged.",
+          },
+          medium: {
+            type: "string",
+            enum: ["soil", "coco", "hydro", "aero", "living_soil", "other"],
+            description: "New cultivation medium. Omit to leave unchanged.",
+          },
+          lightType: {
+            type: "string",
+            enum: ["hps", "cmh", "led", "t5", "sun", "mixed", "other"],
+            description: "New primary light source. Omit to leave unchanged.",
+          },
+          targetHarvestDate: {
+            type: "string",
+            description:
+              "ISO 8601 date (YYYY-MM-DD) the grower is now aiming to harvest. Pass an empty string to clear an existing target; omit to leave unchanged.",
+          },
+          archived: {
+            type: "boolean",
+            description:
+              "true to archive the grow (soft-delete; plants + history stay readable), false to un-archive it. Omit to leave unchanged.",
+          },
+        },
+        required: ["growId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_plant",
+      description:
+        "Update a plant's mutable metadata — rename it, set/replace the strain, batch label, or notes, or archive / un-archive it. Use when the user wants to correct a name from a bulk create ('rename Plant 03 to Mother'), tag a phenotype ('strain is Northern Lights #5'), or retire a plant ('archive Plant 02, it died'). Pass only the fields the user actually wants to change — omitted fields are left untouched. At least one mutable field is required. Owner only.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID to update. Required.",
+          },
+          name: {
+            type: "string",
+            description:
+              "New plant name (1-120 chars). Omit to leave unchanged.",
+          },
+          strain: {
+            type: "string",
+            description:
+              "Replacement cultivar / strain name. Pass an empty string to clear; omit to leave unchanged.",
+          },
+          batchLabel: {
+            type: "string",
+            description:
+              "Replacement batch / tray reference. Pass an empty string to clear; omit to leave unchanged.",
+          },
+          notes: {
+            type: "string",
+            description:
+              "Replacement free-text notes (up to 2000 chars). Pass an empty string to clear; omit to leave unchanged.",
+          },
+          archived: {
+            type: "boolean",
+            description:
+              "true to archive the plant (soft-delete; image history + findings stay readable), false to un-archive it. Omit to leave unchanged.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -719,6 +812,57 @@ function buildBulkPlantNames(prefix: string, count: number): string[] {
   );
 }
 
+// Target-harvest-date accepts either a YYYY-MM-DD string (set) or an empty
+// string (clear). undefined means "leave the existing value untouched".
+const isoDateOrEmpty = z
+  .string()
+  .refine((s) => s === "" || /^\d{4}-\d{2}-\d{2}$/.test(s), {
+    message: "must be YYYY-MM-DD or empty to clear",
+  })
+  .refine((s) => s === "" || !Number.isNaN(Date.parse(s)), {
+    message: "must be a valid date",
+  });
+
+const UpdateGrowArgs = z
+  .object({
+    growId: z.string().min(1),
+    name: z.string().min(1).max(120).optional(),
+    description: z.string().max(MAX_NOTES_LENGTH).optional(),
+    medium: z.enum(GROW_MEDIA).optional(),
+    lightType: z.enum(LIGHT_TYPES).optional(),
+    targetHarvestDate: isoDateOrEmpty.optional(),
+    archived: z.boolean().optional(),
+  })
+  .refine(
+    (v) =>
+      v.name !== undefined ||
+      v.description !== undefined ||
+      v.medium !== undefined ||
+      v.lightType !== undefined ||
+      v.targetHarvestDate !== undefined ||
+      v.archived !== undefined,
+    { message: "supply at least one field to update" },
+  );
+
+const UpdatePlantArgs = z
+  .object({
+    plantId: z.string().min(1),
+    name: z.string().min(1).max(120).optional(),
+    strain: z.string().max(120).optional(),
+    batchLabel: z.string().max(120).optional(),
+    notes: z.string().max(MAX_NOTES_LENGTH).optional(),
+    archived: z.boolean().optional(),
+  })
+  .refine(
+    (v) =>
+      v.name !== undefined ||
+      v.strain !== undefined ||
+      v.batchLabel !== undefined ||
+      v.notes !== undefined ||
+      v.archived !== undefined,
+    { message: "supply at least one field to update" },
+  );
+
 // Tools whose names start the model down a write path. The executor logs
 // arg keys (never values) for these so we have an audit trail without
 // retaining free-text user content in the request log.
@@ -731,6 +875,8 @@ const WRITE_TOOLS = new Set<string>([
   "create_grow",
   "create_plants",
   "create_grow_task",
+  "update_grow",
+  "update_plant",
 ]);
 
 type ChatToolContext = {
@@ -1218,6 +1364,107 @@ export async function executeChatTool(
               error: denied
                 ? "you do not have permission to add tasks to this grow (owner or collaborator only)"
                 : `could not create task: ${error?.message ?? "no row returned"}`,
+            };
+          }
+          return { ok: true, data };
+        }
+
+        case "update_grow": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = UpdateGrowArgs.parse(rawArgs);
+          const patch: Record<string, unknown> = {};
+          if (args.name !== undefined) patch.name = args.name.trim();
+          if (args.description !== undefined) {
+            patch.description =
+              args.description.trim() === "" ? null : args.description.trim();
+          }
+          if (args.medium !== undefined) patch.medium = args.medium;
+          if (args.lightType !== undefined) patch.light_type = args.lightType;
+          if (args.targetHarvestDate !== undefined) {
+            patch.target_harvest_date =
+              args.targetHarvestDate === "" ? null : args.targetHarvestDate;
+          }
+          if (args.archived !== undefined) patch.is_archived = args.archived;
+
+          const { data, error } = await supabase
+            .from("grows")
+            .update(patch)
+            .eq("id", args.growId)
+            .select(
+              "id,name,description,stage,medium,light_type,start_date,target_harvest_date,is_archived",
+            )
+            .maybeSingle();
+          if (error) {
+            const denied =
+              error.code === "42501" ||
+              /permission denied|row-level security/i.test(error.message);
+            return {
+              ok: false,
+              error: denied
+                ? "you do not have permission to update this grow (owner only)"
+                : error.code === "23505"
+                  ? "a grow with that name already exists. Suggest a different name."
+                  : `could not update grow: ${error.message}`,
+            };
+          }
+          if (!data) {
+            return {
+              ok: false,
+              error:
+                "grow not found or not accessible — confirm growId and that the user owns the grow",
+            };
+          }
+          return { ok: true, data };
+        }
+
+        case "update_plant": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = UpdatePlantArgs.parse(rawArgs);
+          const patch: Record<string, unknown> = {};
+          if (args.name !== undefined) patch.name = args.name.trim();
+          if (args.strain !== undefined) {
+            patch.strain =
+              args.strain.trim() === "" ? null : args.strain.trim();
+          }
+          if (args.batchLabel !== undefined) {
+            patch.batch_label =
+              args.batchLabel.trim() === "" ? null : args.batchLabel.trim();
+          }
+          if (args.notes !== undefined) {
+            patch.notes = args.notes.trim() === "" ? null : args.notes.trim();
+          }
+          if (args.archived !== undefined) patch.is_archived = args.archived;
+
+          const { data, error } = await supabase
+            .from("plants")
+            .update(patch)
+            .eq("id", args.plantId)
+            .select(
+              "id,grow_id,name,strain,batch_label,notes,is_archived,updated_at",
+            )
+            .maybeSingle();
+          if (error) {
+            const denied =
+              error.code === "42501" ||
+              /permission denied|row-level security/i.test(error.message);
+            return {
+              ok: false,
+              error: denied
+                ? "you do not have permission to update this plant (owner only)"
+                : error.code === "23505"
+                  ? "a plant with that name already exists in the grow. Suggest a different name."
+                  : `could not update plant: ${error.message}`,
+            };
+          }
+          if (!data) {
+            return {
+              ok: false,
+              error:
+                "plant not found or not accessible — confirm plantId and that the user owns the grow",
             };
           }
           return { ok: true, data };


### PR DESCRIPTION
## Why

After #139 the assistant could create grows, plants, and tasks but couldn't fix anything. A typo in a bulk plant name was a dead-end. "We switched to coco" required leaving chat for the dashboard. "Archive the spring run" wasn't possible at all. This closes the CRUD surface for the two core entities through chat.

## What changed

Two new write tools in `apps/web/src/lib/server/chat-tools.ts`, both added to `WRITE_TOOLS` so invocations are audit-logged with `argKeys` (never values):

### `update_grow`
Optional `name`, `description`, `medium`, `lightType`, `targetHarvestDate`, `archived`. Pass an empty string to clear `description` / `targetHarvestDate`; omit a field to leave it untouched. Zod `refine()` rejects calls with no mutable field. Stage transitions intentionally stay on `update_grow_stage` so that tool's dedicated guardrails (and test coverage) remain authoritative.

### `update_plant`
Optional `name`, `strain`, `batchLabel`, `notes`, `archived`. Same omit-to-leave / empty-string-to-clear semantics. Critical for recovering from a bulk `create_plants` typo without leaving chat.

Both tools:
- Use the user-scoped Supabase client; RLS denials surface as "owner only" messages, 23505 surfaces as a friendly duplicate-name message.
- Use `.update(patch).eq("id", id).select(...).maybeSingle()` and treat a `null` result as "not found or not accessible" so the model can disambiguate and re-fetch instead of guessing.

## Tests

17 new cases in `chat-tools.test.ts` (74 total, up from 57) covering: tool-definition shape, no-op rejection, supplied-fields-only patching with trimming, empty-string clearing, archived flag toggling, "not found" pass-through, RLS denial → "owner only" mapping, 23505 → "already exists" mapping, unauthenticated rejection.

**Full suite: 463/463** (was 446). `pnpm run validate`, `pnpm run security:routes`, `pnpm --filter web build` all green.

## Why this matters for the agentic narrative

After this lands, the bot covers every CRUD operation a user can perform on the two core entities (grow, plant) through pure conversation:

| Operation | Read | Create | Update | Archive |
|-----------|------|--------|--------|---------|
| Grow      | list_grows | create_grow | update_grow + update_grow_stage | update_grow(archived=true) |
| Plant     | list_plants | create_plants | **update_plant** *(new)* | update_plant(archived=true) |

Plus the existing event / observation / task / finding-resolution surface. A user can now onboard, evolve, and wind down a grow cycle without leaving chat.

## Deferred to a separate PR

- **`record_image_finding`** — requires a new migration to add an INSERT RLS policy on `plant_findings` (today the table is service-role-write-only by design). Sensitive path, deserves its own scoped review.
- **Multi-grow batch ops** ("archive all 2025 grows"). Bot can chain single-grow calls; a real batch tool is a future iteration.
- **`delete_*`** vs archive: archive is the right primitive for cultivation history; hard-delete would lose timeline data that's still useful retrospectively.

## Test plan
- [x] Unit: 74/74 in `chat-tools.test.ts`
- [x] Full: 463/463 in `pnpm turbo run test type-check lint`
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual: from `/assistant`, ask "rename Plant 03 to Mother", "archive the Test grow", "we switched the tent to coco" and verify the row updates land in Supabase.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_