### PR TITLE
feat(chat): record_image_finding tool + user-side findings RLS

### DIFF
--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -1658,3 +1658,183 @@ describe("chat-tools — update_plant", () => {
     expect(update).not.toHaveBeenCalled();
   });
 });
+
+describe("chat-tools — record_image_finding", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires plant+grow+category+severity+title", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "record_image_finding",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({
+      required: ["plantId", "growId", "category", "severity", "title"],
+    });
+  });
+
+  it("inserts a row tagged source='user_reported' and returns the new id", async () => {
+    const { client, from, insert } = makeInsertMock({
+      data: {
+        id: "f-1",
+        plant_id: "p-1",
+        grow_id: "g-1",
+        category: "disease",
+        severity: "high",
+        title: "Suspected septoria",
+        source: "user_reported",
+      },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "record_image_finding",
+      {
+        plantId: "p-1",
+        growId: "g-1",
+        category: "disease",
+        severity: "high",
+        title: "Suspected septoria",
+        description: "Brown spots on the middle fans",
+        recommendation: "Defoliate affected leaves and apply copper",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({ id: "f-1", source: "user_reported" }),
+    });
+    expect(from).toHaveBeenCalledWith("plant_findings");
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        plant_id: "p-1",
+        grow_id: "g-1",
+        category: "disease",
+        severity: "high",
+        title: "Suspected septoria",
+        description: "Brown spots on the middle fans",
+        recommendation: "Defoliate affected leaves and apply copper",
+        source: "user_reported",
+      }),
+    );
+  });
+
+  it("trims title and falls back to empty description / null recommendation when omitted", async () => {
+    const { client, insert } = makeInsertMock({
+      data: { id: "f-2", source: "user_reported" },
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "record_image_finding",
+      {
+        plantId: "p-1",
+        growId: "g-1",
+        category: "general",
+        severity: "info",
+        title: "  All good  ",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "All good",
+        description: "",
+        recommendation: null,
+        image_id: null,
+      }),
+    );
+  });
+
+  it("rejects an invalid category without touching the database", async () => {
+    const { client, insert } = makeInsertMock({ data: null, error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "record_image_finding",
+      {
+        plantId: "p-1",
+        growId: "g-1",
+        category: "bogus",
+        severity: "high",
+        title: "X",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid severity without touching the database", async () => {
+    const { client, insert } = makeInsertMock({ data: null, error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "record_image_finding",
+      {
+        plantId: "p-1",
+        growId: "g-1",
+        category: "disease",
+        severity: "fatal",
+        title: "X",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it("translates an RLS denial into a contributor-only permission error", async () => {
+    const { client } = makeInsertMock({
+      data: null,
+      error: { code: "42501", message: "row-level security" },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "record_image_finding",
+      {
+        plantId: "p-1",
+        growId: "g-1",
+        category: "disease",
+        severity: "high",
+        title: "X",
+      },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/owner or collaborator only/i);
+  });
+
+  it("rejects when the user is not authenticated", async () => {
+    const { client, insert } = makeInsertMock({ data: null, error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "record_image_finding",
+      {
+        plantId: "p-1",
+        growId: "g-1",
+        category: "disease",
+        severity: "high",
+        title: "X",
+      },
+      { requestId: "req-x", userId: null },
+    );
+
+    expect(result).toEqual({ error: "not authenticated", ok: false });
+    expect(insert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -595,6 +595,71 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "record_image_finding",
+      description:
+        "File a structured plant_findings row when the user describes a plant-health issue they've observed — typically tied to a photo they just uploaded. Use this for definite diagnoses ('there's brown spots on Plant 4's middle fans, looks like septoria'), not for casual notes (use log_plant_observation for that). The row is tagged source='user_reported' to distinguish it from AI-generated findings, and the existing auto-task trigger will create an open grow_task automatically if severity is high or critical. Owner + collaborator only. Returns the new finding id.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID the finding is about. Required.",
+          },
+          growId: {
+            type: "string",
+            description:
+              "Grow ID the plant belongs to. Required so the row can be RLS-checked.",
+          },
+          category: {
+            type: "string",
+            enum: [
+              "nutrient_deficiency",
+              "nutrient_toxicity",
+              "pest",
+              "disease",
+              "environmental",
+              "training",
+              "general",
+              "positive",
+            ],
+            description:
+              "Finding category. Pick the most specific match. 'general' is the catch-all when nothing fits; 'positive' is for confirming things are going right.",
+          },
+          severity: {
+            type: "string",
+            enum: ["info", "low", "medium", "high", "critical"],
+            description:
+              "How urgent this is. high + critical auto-create an open grow_task via the existing trigger — reserve those for issues that need action soon.",
+          },
+          title: {
+            type: "string",
+            description:
+              "Short, headline-style title (1-200 chars). Examples: 'Early N deficiency on lower fans', 'Suspected spider mites under leaves'.",
+          },
+          description: {
+            type: "string",
+            description:
+              "Longer detail (up to 2000 chars). What was observed, where on the plant, in what context.",
+          },
+          recommendation: {
+            type: "string",
+            description:
+              "Optional suggested action (up to 2000 chars). Becomes the body of the auto-created task when severity is high/critical.",
+          },
+          imageId: {
+            type: "string",
+            description:
+              "Optional plant_image ID this finding refers to. Omit if not tied to a specific image.",
+          },
+        },
+        required: ["plantId", "growId", "category", "severity", "title"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -844,6 +909,35 @@ const UpdateGrowArgs = z
     { message: "supply at least one field to update" },
   );
 
+const FINDING_CATEGORIES = [
+  "nutrient_deficiency",
+  "nutrient_toxicity",
+  "pest",
+  "disease",
+  "environmental",
+  "training",
+  "general",
+  "positive",
+] as const;
+const FINDING_SEVERITIES = [
+  "info",
+  "low",
+  "medium",
+  "high",
+  "critical",
+] as const;
+
+const RecordImageFindingArgs = z.object({
+  plantId: z.string().min(1),
+  growId: z.string().min(1),
+  category: z.enum(FINDING_CATEGORIES),
+  severity: z.enum(FINDING_SEVERITIES),
+  title: z.string().min(1).max(200),
+  description: z.string().max(MAX_NOTES_LENGTH).optional(),
+  recommendation: z.string().max(MAX_NOTES_LENGTH).optional(),
+  imageId: z.string().min(1).optional(),
+});
+
 const UpdatePlantArgs = z
   .object({
     plantId: z.string().min(1),
@@ -877,6 +971,7 @@ const WRITE_TOOLS = new Set<string>([
   "create_grow_task",
   "update_grow",
   "update_plant",
+  "record_image_finding",
 ]);
 
 type ChatToolContext = {
@@ -1465,6 +1560,45 @@ export async function executeChatTool(
               ok: false,
               error:
                 "plant not found or not accessible — confirm plantId and that the user owns the grow",
+            };
+          }
+          return { ok: true, data };
+        }
+
+        case "record_image_finding": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = RecordImageFindingArgs.parse(rawArgs);
+          const row = {
+            plant_id: args.plantId,
+            grow_id: args.growId,
+            image_id: args.imageId ?? null,
+            category: args.category,
+            severity: args.severity,
+            title: args.title.trim(),
+            description: args.description?.trim() || "",
+            recommendation: args.recommendation?.trim() || null,
+            source: "user_reported" as const,
+          };
+          const { data, error } = await supabase
+            .from("plant_findings")
+            .insert(row)
+            .select(
+              "id,plant_id,grow_id,image_id,category,severity,title,description,recommendation,source,created_at",
+            )
+            .single();
+          if (error || !data) {
+            const denied =
+              error?.code === "42501" ||
+              /permission denied|row-level security/i.test(
+                error?.message ?? "",
+              );
+            return {
+              ok: false,
+              error: denied
+                ? "you do not have permission to record findings on this grow (owner or collaborator only)"
+                : `could not record finding: ${error?.message ?? "no row returned"}`,
             };
           }
           return { ok: true, data };

--- a/supabase/migrations/010_user_findings.sql
+++ b/supabase/migrations/010_user_findings.sql
@@ -1,0 +1,119 @@
+-- Migration: 010_user_findings
+--
+-- Lets a grow owner or collaborator file their own structured plant_findings
+-- through the chat assistant (e.g. "I see early N deficiency on the lower
+-- fans of plant 4"). Today the table is service-role-write-only by design,
+-- so the AI analysis service is the only source of findings — this opens a
+-- second source while preserving AI findings as ground-truth-by-default.
+--
+-- Data model:
+--   * New column `source text not null default 'ai'` with a CHECK that
+--     restricts values to ('ai', 'user_reported'). Existing rows backfill
+--     to 'ai' automatically via the default. The analysis service can
+--     keep inserting without touching this column.
+--   * The auto-task trigger from migration 008 already runs SECURITY
+--     DEFINER and is source-agnostic, so user_reported high/critical
+--     findings spawn an open task in grow_tasks exactly like AI findings
+--     do — no changes there.
+--
+-- Safety posture:
+--   * SELECT: any grow member (unchanged from migration 001).
+--   * UPDATE: owner + collaborator can still only flip resolved_at — the
+--     BEFORE UPDATE guard from migration 007 is extended here to add
+--     `source` to the immutable column list, so a user can't reclassify
+--     an AI finding by flipping source to 'user_reported' or vice versa.
+--     Service role still bypasses (auth.uid() is null path).
+--   * INSERT: NEW policy "plant_findings: grow contributor user-report"
+--     lets owner + collaborator insert rows where source = 'user_reported'
+--     only. Viewers remain read-only. AI / service-role traffic bypasses
+--     RLS entirely so the analysis service keeps inserting source='ai'
+--     rows unaffected.
+--
+-- Rollback (do NOT run unless explicitly approved):
+--   -- Restore the migration 007 guard signature first to drop the source check.
+--   create or replace function plant_findings_user_update_guard()
+--   returns trigger
+--   language plpgsql
+--   security invoker
+--   as $$
+--   begin
+--     if auth.uid() is null then return new; end if;
+--     if new.plant_id is distinct from old.plant_id
+--        or new.grow_id is distinct from old.grow_id
+--        or new.image_id is distinct from old.image_id
+--        or new.category is distinct from old.category
+--        or new.severity is distinct from old.severity
+--        or new.title is distinct from old.title
+--        or new.description is distinct from old.description
+--        or new.recommendation is distinct from old.recommendation
+--        or new.created_at is distinct from old.created_at
+--     then
+--       raise exception 'plant_findings: only resolved_at may be modified by users'
+--         using errcode = '42501';
+--     end if;
+--     return new;
+--   end;
+--   $$;
+--   drop policy if exists "plant_findings: grow contributor user-report" on plant_findings;
+--   alter table plant_findings drop column if exists source;
+
+-- ─── source column ────────────────────────────────────────────────────────────
+-- text + check rather than a new enum so we can add future sources without a
+-- second enum migration (cron-derived, third-party imports, etc.).
+alter table plant_findings
+  add column if not exists source text not null default 'ai'
+    check (source in ('ai', 'user_reported'));
+
+-- ─── INSERT policy (user-side) ────────────────────────────────────────────────
+-- Owner + collaborator can insert their own findings, but only with the
+-- 'user_reported' source. AI findings continue to land via service role
+-- (which bypasses RLS).
+create policy "plant_findings: grow contributor user-report"
+  on plant_findings for insert
+  with check (
+    source = 'user_reported'
+    and exists (
+      select 1 from grows g
+      left join grow_members gm
+        on gm.grow_id = g.id and gm.user_id = auth.uid()
+      where g.id = plant_findings.grow_id
+        and (
+          g.owner_id = auth.uid()
+          or gm.role in ('owner', 'collaborator')
+        )
+    )
+  );
+
+-- ─── Extend the column-restriction trigger to cover `source` ─────────────────
+-- Mirrors migration 007's guard but adds `source` to the immutable column
+-- set so a contributor can't flip a finding's provenance after the fact.
+-- Service role still bypasses via the auth.uid() is null path.
+create or replace function plant_findings_user_update_guard()
+returns trigger
+language plpgsql
+security invoker
+as $$
+begin
+  if auth.uid() is null then
+    -- Service role / no-JWT context: trust the caller (our own server code).
+    return new;
+  end if;
+
+  if new.plant_id       is distinct from old.plant_id
+     or new.grow_id     is distinct from old.grow_id
+     or new.image_id    is distinct from old.image_id
+     or new.category    is distinct from old.category
+     or new.severity    is distinct from old.severity
+     or new.title       is distinct from old.title
+     or new.description is distinct from old.description
+     or new.recommendation is distinct from old.recommendation
+     or new.source      is distinct from old.source
+     or new.created_at  is distinct from old.created_at
+  then
+    raise exception 'plant_findings: only resolved_at may be modified by users'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;


### PR DESCRIPTION
## Why

This closes the agentic loop that the user originally asked for: drop a photo + description into chat and have the bot file a structured diagnosis the rest of the system can act on.

After this lands, a single chat message — *"there's brown spots on plant 4's middle fans, looks like septoria, defoliate the affected leaves"* — produces:

1. A `plant_findings` row (category=disease, severity=high, source=user_reported)
2. An auto-created `grow_tasks` row ("Address: Suspected septoria", priority=high) via the existing trigger from migration 008
3. The task immediately appears on the dashboard + `list_open_tasks` tool results

No UI changes, no extra navigation, no separate forms.

## Migration `010_user_findings.sql`

The `plant_findings` table was deliberately service-role-write-only so AI findings would stay ground-truth. This PR adds a parallel user-side write path without diluting that:

- **New column `source text not null default 'ai'`** with `CHECK (source in ('ai', 'user_reported'))`. Existing rows backfill via the default — no data migration.
- **New INSERT RLS policy** `"plant_findings: grow contributor user-report"` — owner + collaborator only (viewer stays read-only). `WITH CHECK` enforces `source = 'user_reported'`. AI findings still flow through service-role traffic which bypasses RLS.
- **Extended UPDATE guard trigger** from migration 007 adds `source` to the immutable-by-users column set, so a contributor can't reclassify an AI finding by flipping its provenance via UPDATE. Service role still bypasses via the `auth.uid() is null` path.

Auto-task trigger from migration 008 is severity-driven and `SECURITY DEFINER`, so it cascades user-reported high/critical findings into `grow_tasks` exactly like AI findings — no changes there.

**Action item:** run `supabase db push` against prod to apply this migration before the feature ships to production chat.

## New tool: `record_image_finding`

- **Required:** `plantId`, `growId`, `category` (8-value enum), `severity` (5-value enum), `title`.
- **Optional:** `description`, `recommendation`, `imageId`.
- Always inserts with `source='user_reported'`.
- RLS denials surface as *"owner or collaborator only"*.
- Added to `WRITE_TOOLS` so invocations are audit-logged with `argKeys` (never values).

## Tests

7 new cases in `chat-tools.test.ts` (81 total, up from 74): tool-definition shape, happy-path insert with full row assertion, default trimming + null fallback for omitted optional fields, invalid category + invalid severity Zod rejection, RLS denial mapping, unauthenticated rejection.

**Full suite: 470/470** (was 463). `pnpm run validate`, `pnpm run security:routes`, `pnpm --filter web build` all green.

## Why this is the unlock

The chat assistant now covers the full agentic surface for the daily operating loop:

| Capability | Tool |
|---|---|
| Set up a new grow with N plants | `create_grow` + `create_plants` |
| Update / archive | `update_grow`, `update_plant`, `update_grow_stage` |
| Log what just happened | `log_grow_event`, `log_plant_observation` |
| **File a diagnosis** | **`record_image_finding`** *(new)* |
| Manage worklist | `create_grow_task`, `list_open_tasks`, `update_task_status`, `mark_finding_resolved` |
| Plus 7 read tools for grounding | `list_grows`, `list_plants`, `get_recent_findings`, etc. |

A user can run a whole grow cycle — onboarding, daily ops, diagnostics, harvest — without ever leaving the chat. Photos still upload via the existing quick-capture flow; this PR makes the structured-diagnosis side first-class.

## Sensitive paths touched

- `supabase/migrations/**` — new numbered file only, no edits to existing migrations.
- `apps/web/src/lib/server/chat-tools.ts` — new tool follows the WRITE_TOOLS audit pattern established in #139, #140.

## Test plan
- [x] Unit: 81/81 in `chat-tools.test.ts`
- [x] Full: 470/470 in `pnpm turbo run test type-check lint`
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual after `supabase db push`: from `/assistant`, ask "record a high-severity nutrient deficiency on Plant 3 in the North Tent grow" and verify (a) a `plant_findings` row lands with `source='user_reported'`, (b) the auto-task appears in `list_open_tasks` results, (c) a `viewer`-role member gets a permission error trying the same call.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_