### PR TITLE
feat(chat): get_plant_timeline + trigger_plant_analysis tools

### DIFF
--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const createSupabaseServerClient = vi.fn();
 const logServerEvent = vi.fn();
+const getPlantTimeline = vi.fn();
+const runAndPersistPlantAnalysis = vi.fn();
 
 vi.mock("../auth", () => ({
   createSupabaseServerClient: (...args: unknown[]) =>
@@ -9,6 +11,11 @@ vi.mock("../auth", () => ({
 }));
 vi.mock("../request-id", () => ({
   logServerEvent: (...args: unknown[]) => logServerEvent(...args),
+}));
+vi.mock("../plants", () => ({
+  getPlantTimeline: (...args: unknown[]) => getPlantTimeline(...args),
+  runAndPersistPlantAnalysis: (...args: unknown[]) =>
+    runAndPersistPlantAnalysis(...args),
 }));
 
 import { CHAT_TOOL_DEFINITIONS, executeChatTool } from "../chat-tools";
@@ -1836,5 +1843,246 @@ describe("chat-tools — record_image_finding", () => {
 
     expect(result).toEqual({ error: "not authenticated", ok: false });
     expect(insert).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat-tools — get_plant_timeline", () => {
+  beforeEach(() => {
+    getPlantTimeline.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires plantId only", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "get_plant_timeline",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["plantId"] });
+  });
+
+  it("returns the timeline items capped at the requested limit", async () => {
+    const items = Array.from({ length: 30 }, (_, i) => ({
+      type: "image",
+      id: `img-${i}`,
+      createdAt: "2026-05-01T00:00:00Z",
+    }));
+    getPlantTimeline.mockResolvedValue({ plantId: "p-1", items });
+
+    const result = await executeChatTool(
+      "get_plant_timeline",
+      { plantId: "p-1", limit: 5 },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({
+        plantId: "p-1",
+        totalCount: 30,
+        returnedCount: 5,
+      }),
+    });
+    if (result.ok) {
+      expect((result.data as { items: unknown[] }).items).toHaveLength(5);
+    }
+  });
+
+  it("defaults to a limit of 20 when omitted", async () => {
+    getPlantTimeline.mockResolvedValue({
+      plantId: "p-1",
+      items: Array.from({ length: 25 }, (_, i) => ({
+        type: "observation",
+        id: `obs-${i}`,
+        observedAt: "2026-05-01T00:00:00Z",
+      })),
+    });
+
+    const result = await executeChatTool(
+      "get_plant_timeline",
+      { plantId: "p-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as { returnedCount: number };
+      expect(data.returnedCount).toBe(20);
+    }
+  });
+
+  it("caps the limit at 50 even when a higher value is requested", async () => {
+    getPlantTimeline.mockResolvedValue({
+      plantId: "p-1",
+      items: Array.from({ length: 200 }, (_, i) => ({ id: `x-${i}` })),
+    });
+
+    const result = await executeChatTool(
+      "get_plant_timeline",
+      { plantId: "p-1", limit: 9999 },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as { returnedCount: number };
+      expect(data.returnedCount).toBe(50);
+    }
+  });
+
+  it("returns 'not found or not accessible' when getPlantTimeline returns null", async () => {
+    getPlantTimeline.mockResolvedValue(null);
+
+    const result = await executeChatTool(
+      "get_plant_timeline",
+      { plantId: "missing" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/not found or not accessible/i);
+  });
+});
+
+describe("chat-tools — trigger_plant_analysis", () => {
+  beforeEach(() => {
+    runAndPersistPlantAnalysis.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires plantId only", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "trigger_plant_analysis",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["plantId"] });
+  });
+
+  it("forwards plantId + requestId and returns a trimmed analysis summary", async () => {
+    runAndPersistPlantAnalysis.mockResolvedValue({
+      context: { plantId: "p-1" },
+      analysisId: "a-1",
+      imageId: "img-9",
+      analysis: {
+        imageId: "img-9",
+        comparedToImageId: "img-7",
+        overallHealthScore: 0.82,
+        summary: "Healthy vegetative growth",
+        comparisonSummary: "More vigor than 5 days ago",
+        analysisMode: "vision",
+        isFallback: false,
+        findings: [{ category: "general", severity: "info" }],
+        analyzedAt: "2026-05-14T12:00:00Z",
+      },
+    });
+
+    const result = await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "p-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      data: expect.objectContaining({
+        analysisId: "a-1",
+        imageId: "img-9",
+        comparedToImageId: "img-7",
+        overallHealthScore: 0.82,
+        summary: "Healthy vegetative growth",
+        findingsCount: 1,
+      }),
+    });
+    expect(runAndPersistPlantAnalysis).toHaveBeenCalledWith({
+      plantId: "p-1",
+      requestId: "req-123",
+    });
+  });
+
+  it("forwards a specific imageId when supplied", async () => {
+    runAndPersistPlantAnalysis.mockResolvedValue({
+      context: { plantId: "p-1" },
+      analysisId: "a-2",
+      imageId: "img-historic",
+      analysis: {
+        imageId: "img-historic",
+        overallHealthScore: 0.5,
+        summary: "x",
+        analyzedAt: "2026-05-01T00:00:00Z",
+      },
+    });
+
+    await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "p-1", imageId: "img-historic" },
+      CTX_AUTHED,
+    );
+
+    expect(runAndPersistPlantAnalysis).toHaveBeenCalledWith({
+      plantId: "p-1",
+      imageId: "img-historic",
+      requestId: "req-123",
+    });
+  });
+
+  it("returns 'not found' when the helper returns null (RLS / unknown plant)", async () => {
+    runAndPersistPlantAnalysis.mockResolvedValue(null);
+
+    const result = await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "missing" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/not found or not accessible/i);
+  });
+
+  it("returns a guidance message when the plant has no images yet", async () => {
+    runAndPersistPlantAnalysis.mockResolvedValue({
+      context: { plantId: "p-1" },
+      analysis: null,
+    });
+
+    const result = await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "p-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/upload a photo first/i);
+  });
+
+  it("converts an analysis-pipeline throw into a graceful error", async () => {
+    runAndPersistPlantAnalysis.mockRejectedValue(new Error("vision API down"));
+
+    const result = await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "p-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/analysis pipeline failed/i);
+    expect(logServerEvent).toHaveBeenCalled();
+  });
+
+  it("rejects when the user is not authenticated", async () => {
+    const result = await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "p-1" },
+      { requestId: "req-x", userId: null },
+    );
+
+    expect(result).toEqual({ error: "not authenticated", ok: false });
+    expect(runAndPersistPlantAnalysis).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { z } from "zod";
 import { createSupabaseServerClient } from "./auth";
+import { getPlantTimeline, runAndPersistPlantAnalysis } from "./plants";
 import { logServerEvent } from "./request-id";
 
 // Tool definitions exposed to OpenAI. The handlers are intentionally
@@ -660,6 +661,54 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_plant_timeline",
+      description:
+        "Return the unified time-ordered timeline of a plant — images, observations, AI findings, and analysis summaries merged in one feed. Use when the user asks a question that needs cross-source history ('how has Plant 3 progressed this week?', 'when did we last water this one?', 'show me everything that's happened to plant 4'). Newest items first. Returns up to `limit` items.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID to read. Required.",
+          },
+          limit: {
+            type: "number",
+            description:
+              "Max items to return. Default 20, max 50. The model should request the smallest useful window to stay within token budget.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "trigger_plant_analysis",
+      description:
+        "Run the AI vision analysis pipeline on a plant photo and persist the result. Use when the user just uploaded a photo and wants immediate diagnostic feedback, or asks 'analyze this again with the new context'. By default analyzes the most recent image; pass imageId to analyze a specific historical image. The call is synchronous and may take 5-30 seconds — narrate that to the user before invoking. Returns the new analysis row (overall_health_score, summary, comparison_summary, findings count). RLS-scoped: the user must own or collaborate on the plant's grow.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID to analyze. Required.",
+          },
+          imageId: {
+            type: "string",
+            description:
+              "Specific image to analyze. Omit to use the most recent image. Useful for re-analyzing a historical capture in light of new context.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -927,6 +976,16 @@ const FINDING_SEVERITIES = [
   "critical",
 ] as const;
 
+const GetPlantTimelineArgs = z.object({
+  plantId: z.string().min(1),
+  limit: z.number().optional(),
+});
+
+const TriggerPlantAnalysisArgs = z.object({
+  plantId: z.string().min(1),
+  imageId: z.string().min(1).optional(),
+});
+
 const RecordImageFindingArgs = z.object({
   plantId: z.string().min(1),
   growId: z.string().min(1),
@@ -972,6 +1031,7 @@ const WRITE_TOOLS = new Set<string>([
   "update_grow",
   "update_plant",
   "record_image_finding",
+  "trigger_plant_analysis",
 ]);
 
 type ChatToolContext = {
@@ -1602,6 +1662,93 @@ export async function executeChatTool(
             };
           }
           return { ok: true, data };
+        }
+
+        case "get_plant_timeline": {
+          const args = GetPlantTimelineArgs.parse(rawArgs);
+          const limit = numClamp(args.limit, 20, 50);
+          const timeline = await getPlantTimeline(args.plantId);
+          if (!timeline) {
+            return {
+              ok: false,
+              error:
+                "plant not found or not accessible — confirm plantId and that the user owns the grow",
+            };
+          }
+          // Cap items by the requested limit so a 200-item history doesn't
+          // blow the response budget. Items are already newest-first.
+          const items = timeline.items.slice(0, limit);
+          return {
+            ok: true,
+            data: {
+              plantId: timeline.plantId,
+              totalCount: timeline.items.length,
+              returnedCount: items.length,
+              items,
+            },
+          };
+        }
+
+        case "trigger_plant_analysis": {
+          if (!ctx.userId) {
+            return { ok: false, error: "not authenticated" };
+          }
+          const args = TriggerPlantAnalysisArgs.parse(rawArgs);
+          try {
+            const analyzeParams: Parameters<
+              typeof runAndPersistPlantAnalysis
+            >[0] = {
+              plantId: args.plantId,
+              requestId: ctx.requestId,
+            };
+            if (args.imageId) analyzeParams.imageId = args.imageId;
+            const result = await runAndPersistPlantAnalysis(analyzeParams);
+            if (!result) {
+              return {
+                ok: false,
+                error:
+                  "plant not found or not accessible — confirm plantId and that the user owns the grow",
+              };
+            }
+            if (!result.analysis) {
+              return {
+                ok: false,
+                error:
+                  "no images on this plant yet — upload a photo first, then re-run analysis",
+              };
+            }
+            // Return a trimmed summary so the model can quote it without
+            // re-fetching: score, summary text, comparison context, and
+            // counts of any findings emitted by this run. analysisId is
+            // exposed at the top of runAndPersistPlantAnalysis's return
+            // value, not inside the AnalysisResponse.
+            return {
+              ok: true,
+              data: {
+                analysisId: result.analysisId,
+                imageId: result.analysis.imageId,
+                comparedToImageId: result.analysis.comparedToImageId ?? null,
+                overallHealthScore: result.analysis.overallHealthScore,
+                summary: result.analysis.summary,
+                comparisonSummary: result.analysis.comparisonSummary ?? null,
+                analysisMode: result.analysis.analysisMode ?? null,
+                isFallback: result.analysis.isFallback ?? false,
+                findingsCount: result.analysis.findings?.length ?? 0,
+                analyzedAt: result.analysis.analyzedAt,
+              },
+            };
+          } catch (err) {
+            logServerEvent("error", "chat trigger_plant_analysis failed", {
+              requestId: ctx.requestId,
+              userId: ctx.userId,
+              plantId: args.plantId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            return {
+              ok: false,
+              error: "analysis pipeline failed; try again in a moment",
+            };
+          }
         }
 
         default:


### PR DESCRIPTION
## Why

After #141, the bot can create, read, update, archive every core entity, log events, and record structured findings. The next leverage points are: (1) **conversational longitudinal intelligence** — letting the bot answer "how is plant 3 doing this week" with one tool call instead of merging four; (2) **on-demand diagnosis** — letting the bot re-run the Gemini vision pipeline when the user just uploaded a photo or asks for a fresh read.

This PR adds those two tools by wrapping existing server helpers — no schema changes, no new routes, no rate-limit duplication.

## What changed

### `get_plant_timeline`
- Wraps `getPlantTimeline` (which already merges `plant_images`, `plant_observations`, `plant_findings`, `plant_analyses` into a single time-sorted feed and applies RLS via `getAuthorizedPlantContext`).
- Required: `plantId`. Optional: `limit` (default 20, max 50).
- Returns `{ plantId, totalCount, returnedCount, items }` so the model can decide whether to widen the window.
- `null` from the helper becomes a structured `"not found or not accessible"` error so the model can disambiguate and re-fetch.

### `trigger_plant_analysis`
- Wraps `runAndPersistPlantAnalysis` (Gemini vision pipeline + `plant_analyses` upsert + `plant_findings` replace). Added to `WRITE_TOOLS` so invocations are audit-logged.
- Required: `plantId`. Optional: `imageId` (default: most recent image).
- Returns a trimmed summary: `analysisId`, `imageId`, `comparedToImageId`, `overallHealthScore`, `summary`, `comparisonSummary`, `analysisMode`, `isFallback`, `findingsCount`, `analyzedAt` — enough for the model to narrate without re-fetching.
- Distinct error states: *plant not accessible*, *plant has no images yet*, *pipeline failed* (the last is logged via `logServerEvent` for ops triage).
- Description warns the model the call is synchronous and may take 5-30s, so it narrates before invoking.

## Tests

12 new cases in `chat-tools.test.ts` (93 total, up from 81). For `get_plant_timeline`: tool-definition shape, limit application, default-20, max-50 cap, null → not-found. For `trigger_plant_analysis`: tool-definition shape, requestId forwarded, imageId forwarded, null helper → not-found, `analysis: null` → "upload a photo first" guidance, helper throw → graceful "pipeline failed" with `logServerEvent` call, unauthenticated rejection.

**Full suite: 482/482** (was 463). `pnpm run validate`, `pnpm run security:routes`, `pnpm --filter web build` all green.

## Updated capability matrix

After this PR the assistant covers the full conversational loop for the daily operating cycle (21 tools total):

| Surface | Capability | Tool |
|---|---|---|
| Onboard | Create grow + plants + tasks | `create_grow`, `create_plants`, `create_grow_task` |
| Read | Roster | `list_grows`, `list_plants`, `list_open_tasks` |
| Read | History | `get_recent_findings`, `get_recent_observations`, `get_grow_events`, `get_latest_analysis`, `get_analysis_history`, **`get_plant_timeline`** ✨ |
| Log | What just happened | `log_grow_event`, `log_plant_observation` |
| Diagnose | Structured | `record_image_finding`, **`trigger_plant_analysis`** ✨ |
| Maintain | Update / archive | `update_grow`, `update_plant`, `update_grow_stage`, `mark_finding_resolved`, `update_task_status` |

## Out of scope / follow-ups
- **Cross-plant comparison tool.** Bot can call `get_plant_timeline` once per plant; a dedicated `compare_plants` tool with diff semantics is the next obvious step for longitudinal intelligence.
- **Async analysis job.** Today `trigger_plant_analysis` blocks the chat tool loop for the duration of the Gemini call. A future iteration could enqueue an `analysis_jobs` row (migration 005) and return a job id immediately.
- **Per-tool rate limits.** The chat route already rate-limits at the request level; if model loops start triggering many analyses, we may want a per-tool budget.

## Test plan
- [x] Unit: 93/93 in `chat-tools.test.ts`
- [x] Full: 482/482 in `pnpm turbo run test type-check lint`
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual: from `/assistant`, ask "show me everything that's happened to plant 3 this week" and "re-analyze the latest photo of plant 3"; verify the unified timeline returns and a fresh `plant_analyses` row appears.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_