### PR TITLE
feat(chat): find_grow + find_plant fuzzy entity resolution

### DIFF
--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -34,7 +34,7 @@ type ListResult = {
 //   .from(t).select(...).order(...).order(...).limit(...).eq(...).in(...)
 // The final awaited value is `result`. Chain methods are all idempotent
 // (return the same chainable proxy) so callers can mix and match.
-type SelectChainKey = "select" | "order" | "limit" | "eq" | "in";
+type SelectChainKey = "select" | "order" | "limit" | "eq" | "in" | "or";
 type SelectChain = Record<SelectChainKey, ReturnType<typeof vi.fn>> &
   PromiseLike<ListResult>;
 
@@ -43,11 +43,12 @@ function makeSelectChainMock(result: ListResult) {
     eq: [],
     in: [],
     limit: [],
+    or: [],
     order: [],
     select: [],
   };
   const chain = {} as SelectChain;
-  const KEYS: SelectChainKey[] = ["select", "order", "limit", "eq", "in"];
+  const KEYS: SelectChainKey[] = ["select", "order", "limit", "eq", "in", "or"];
   for (const key of KEYS) {
     chain[key] = vi.fn((...args: unknown[]) => {
       calls[key].push(args);
@@ -2084,5 +2085,197 @@ describe("chat-tools — trigger_plant_analysis", () => {
 
     expect(result).toEqual({ error: "not authenticated", ok: false });
     expect(runAndPersistPlantAnalysis).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat-tools — find_grow", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires only query", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "find_grow",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["query"] });
+  });
+
+  it("ILIKE-searches name + description and excludes archived by default", async () => {
+    const { client, calls, from } = makeSelectChainMock({
+      data: [{ id: "g-1", name: "North Tent A" }],
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "find_grow",
+      { query: "north" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(from).toHaveBeenCalledWith("grows");
+    expect(calls.or[0]?.[0]).toBe(
+      "name.ilike.%north%,description.ilike.%north%",
+    );
+    expect(calls.eq).toContainEqual(["is_archived", false]);
+    expect(calls.limit[0]?.[0]).toBe(5);
+  });
+
+  it("includes archived when includeArchived=true", async () => {
+    const { client, calls } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "find_grow",
+      { query: "spring", includeArchived: true },
+      CTX_AUTHED,
+    );
+
+    expect(calls.eq).toEqual([]);
+  });
+
+  it("caps limit at 15 even when a higher value is requested", async () => {
+    const { client, calls } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool("find_grow", { query: "x", limit: 9999 }, CTX_AUTHED);
+
+    expect(calls.limit[0]?.[0]).toBe(15);
+  });
+
+  it("escapes %, _ and \\ in the user query so wildcards stay literal", async () => {
+    const { client, calls } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool("find_grow", { query: "50% _ \\room" }, CTX_AUTHED);
+
+    expect(calls.or[0]?.[0]).toBe(
+      "name.ilike.%50\\% \\_ \\\\room%,description.ilike.%50\\% \\_ \\\\room%",
+    );
+  });
+
+  it("returns the supabase error message when the query fails", async () => {
+    const { client } = makeSelectChainMock({
+      data: null,
+      error: { message: "syntax error" },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "find_grow",
+      { query: "x" },
+      CTX_AUTHED,
+    );
+
+    expect(result).toEqual({ ok: false, error: "syntax error" });
+  });
+
+  it("rejects an empty query without touching the database", async () => {
+    const { client, from } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "find_grow",
+      { query: "" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(from).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat-tools — find_plant", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires only query", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "find_plant",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["query"] });
+  });
+
+  it("ILIKE-searches name + strain + batch_label and excludes archived by default", async () => {
+    const { client, calls, from } = makeSelectChainMock({
+      data: [{ id: "p-1", name: "Mother" }],
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "find_plant",
+      { query: "mother" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(from).toHaveBeenCalledWith("plants");
+    expect(calls.or[0]?.[0]).toBe(
+      "name.ilike.%mother%,strain.ilike.%mother%,batch_label.ilike.%mother%",
+    );
+    expect(calls.eq).toContainEqual(["is_archived", false]);
+  });
+
+  it("scopes to a grow when growId is supplied", async () => {
+    const { client, calls } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "find_plant",
+      { query: "NL", growId: "g-1" },
+      CTX_AUTHED,
+    );
+
+    expect(calls.eq).toContainEqual(["grow_id", "g-1"]);
+    expect(calls.eq).toContainEqual(["is_archived", false]);
+  });
+
+  it("caps limit at 15 even when a higher value is requested", async () => {
+    const { client, calls } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool("find_plant", { query: "x", limit: 100 }, CTX_AUTHED);
+
+    expect(calls.limit[0]?.[0]).toBe(15);
+  });
+
+  it("includes archived when includeArchived=true", async () => {
+    const { client, calls } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool(
+      "find_plant",
+      { query: "old", includeArchived: true },
+      CTX_AUTHED,
+    );
+
+    expect(calls.eq).toEqual([]);
+  });
+
+  it("rejects an empty query without touching the database", async () => {
+    const { client, from } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "find_plant",
+      { query: "" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    expect(from).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -709,6 +709,69 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "find_grow",
+      description:
+        "Resolve a free-text reference to a grow ('north tent', 'the spring run', 'soil hydro') into one or more candidate grow ids. Use as the FIRST step when the user mentions a grow conversationally so you can avoid an awkward 'which grow?' round-trip. Case-insensitive substring match on grow name + description, ordered by most recently updated. Returns up to `limit` candidates; if exactly one matches, the model can confidently proceed.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Free-text reference from the user (1-120 chars). Examples: 'north tent', 'spring 2026', 'flower room'.",
+          },
+          includeArchived: {
+            type: "boolean",
+            description:
+              "Set true to include archived grows. Default false — most resolution queries should ignore archived rows.",
+          },
+          limit: {
+            type: "number",
+            description:
+              "Max candidates to return. Default 5, max 15. Smaller is better — narrow the search if you get too many.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "find_plant",
+      description:
+        "Resolve a free-text reference to a plant ('the mother', 'plant 3', 'NL 01', 'phenotype A') into one or more candidate plant ids. Use as the FIRST step when the user mentions a plant conversationally. Case-insensitive substring match across plants.name, strain, and batch_label; optionally scoped to a grow. Ordered by most recently updated. Returns up to `limit` candidates with their grow id so follow-up tools can be called immediately.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Free-text reference from the user (1-120 chars). Examples: 'the mother', 'NL 01', 'phenotype A', 'plant 3'.",
+          },
+          growId: {
+            type: "string",
+            description:
+              "Optional grow ID to constrain the search. Use this when you already know which grow the user is talking about.",
+          },
+          includeArchived: {
+            type: "boolean",
+            description: "Set true to include archived plants. Default false.",
+          },
+          limit: {
+            type: "number",
+            description: "Max candidates. Default 5, max 15.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -975,6 +1038,27 @@ const FINDING_SEVERITIES = [
   "high",
   "critical",
 ] as const;
+
+const FindGrowArgs = z.object({
+  query: z.string().min(1).max(120),
+  includeArchived: z.boolean().optional(),
+  limit: z.number().optional(),
+});
+
+const FindPlantArgs = z.object({
+  query: z.string().min(1).max(120),
+  growId: z.string().min(1).optional(),
+  includeArchived: z.boolean().optional(),
+  limit: z.number().optional(),
+});
+
+// PostgREST `ilike` requires us to escape the % and _ wildcards so a user
+// query like "50%" matches the literal characters rather than acting as a
+// wildcard. Belt-and-braces — also caps the query length to keep the LIKE
+// pattern bounded.
+function escapeIlikePattern(input: string): string {
+  return input.slice(0, 120).replace(/[%_\\]/g, (m) => `\\${m}`);
+}
 
 const GetPlantTimelineArgs = z.object({
   plantId: z.string().min(1),
@@ -1749,6 +1833,45 @@ export async function executeChatTool(
               error: "analysis pipeline failed; try again in a moment",
             };
           }
+        }
+
+        case "find_grow": {
+          const args = FindGrowArgs.parse(rawArgs);
+          const limit = numClamp(args.limit, 5, 15);
+          const pattern = `%${escapeIlikePattern(args.query)}%`;
+          let q = supabase
+            .from("grows")
+            .select(
+              "id,name,description,stage,medium,light_type,start_date,is_archived,updated_at",
+            )
+            .or(`name.ilike.${pattern},description.ilike.${pattern}`)
+            .order("updated_at", { ascending: false })
+            .limit(limit);
+          if (!args.includeArchived) q = q.eq("is_archived", false);
+          const { data, error } = await q;
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
+        }
+
+        case "find_plant": {
+          const args = FindPlantArgs.parse(rawArgs);
+          const limit = numClamp(args.limit, 5, 15);
+          const pattern = `%${escapeIlikePattern(args.query)}%`;
+          let q = supabase
+            .from("plants")
+            .select(
+              "id,grow_id,name,strain,batch_label,notes,is_archived,updated_at",
+            )
+            .or(
+              `name.ilike.${pattern},strain.ilike.${pattern},batch_label.ilike.${pattern}`,
+            )
+            .order("updated_at", { ascending: false })
+            .limit(limit);
+          if (args.growId) q = q.eq("grow_id", args.growId);
+          if (!args.includeArchived) q = q.eq("is_archived", false);
+          const { data, error } = await q;
+          if (error) return { ok: false, error: error.message };
+          return { ok: true, data: data ?? [] };
         }
 
         default:


### PR DESCRIPTION
## Why

Today, when the user says *"check on the mother"* or *"how's north tent doing?"*, the bot's only path is to call `list_grows` / `list_plants` and guess from the result. That's an extra round-trip for every conversational reference and a frequent disambiguation prompt. These two read tools resolve a free-text reference directly into candidate ids ordered by recency, so the model can proceed without the round trip.

## What changed

### `find_grow`
- Case-insensitive substring (ILIKE) over `grows.name + grows.description`.
- Required: `query`. Optional: `includeArchived` (default false), `limit` (default 5, max 15).
- Ordered by `updated_at DESC` — recently-touched grows come first.

### `find_plant`
- Same pattern, ILIKE across `plants.name + plants.strain + plants.batch_label`.
- Required: `query`. Optional: `growId` (constrain to one grow), `includeArchived`, `limit`.

Both use the user-scoped Supabase client, so RLS still hides other users' data — no new write paths, no new RLS policies.

## Safety note

The user's raw query is escaped via `escapeIlikePattern()` before being concatenated into the PostgREST `.or()` filter. This escapes `%`, `_`, and `\\` so input like `"50%"` matches the literal characters instead of acting as a SQL wildcard. The function also truncates at 120 chars (matched by the Zod schema) to bound the LIKE pattern length.

## Tests

13 new cases in `chat-tools.test.ts` (106 total, up from 93). The `SelectChain` mock gained an `"or"` key so the chain stays exhaustive for ILIKE-OR queries.

Coverage:
- Tool-definition shape (required: `query` only)
- Happy-path ILIKE on the expected column set
- Archive scoping default vs `includeArchived` flag
- `growId` scoping for `find_plant`
- Limit cap at 15
- **Wildcard escaping** for input like `"50% _ \\room"`
- Supabase error pass-through
- Empty-query rejection without touching the database

**Full suite: 495/495** (was 482). `pnpm run validate`, `pnpm run security:routes`, `pnpm --filter web build` all green.

## Updated capability matrix

The chat assistant now has **23 tools** covering the full daily operating loop. Each conversational reference now has a fast resolution path:

| User says | Tool path |
|---|---|
| "the mother" / "plant 3" / "NL 01" | **`find_plant`** ✨ → write/read tool |
| "north tent" / "the spring run" | **`find_grow`** ✨ → write/read tool |
| (already knows ID) | direct write/read tool |

## Out of scope / follow-ups
- **Trigram / pg_trgm fuzzy ranking.** Today's matcher is substring-only; a misspelling like "moter" won't find "mother". Adding `pg_trgm` + similarity scoring would handle typos, but it's a schema change with extension installation — separate PR.
- **Plant aliases.** A `plant_aliases` table would let the user teach the bot "the back-left one is Mother". Schema change; deferred.

## Test plan
- [x] Unit: 106/106 in `chat-tools.test.ts`
- [x] Full: 495/495 in `pnpm turbo run test type-check lint`
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual: from `/assistant`, ask "log a watering on the mother" and verify the bot resolves the plant via `find_plant` and inserts a `grow_events` row attributed to it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_