### PR TITLE
feat(chat): compare_plants + get_grow_summary + system prompt refresh

### DIFF
--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -96,6 +96,61 @@ function makeBulkInsertMock(result: ListResult) {
   };
 }
 
+// Per-table mock: from(table) returns a chain that records every method
+// call and resolves to the configured value for that table. Chains support
+// the full surface used by the new analytics tools — select/eq/in/is/gte/
+// order/limit/maybeSingle — and are awaitable for the count-only form.
+type CountResult = {
+  // Either a list result (for awaitable count queries) or a single object
+  // for maybeSingle() reads. The router mock branches on which terminal
+  // the executor uses, so callers can configure either shape per table.
+  data: unknown;
+  error: { message: string; code?: string } | null;
+  count?: number | null;
+};
+
+type LazyChain = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  is: ReturnType<typeof vi.fn>;
+  gte: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  maybeSingle: ReturnType<typeof vi.fn>;
+} & PromiseLike<CountResult>;
+
+function makeTableRouterMock(byTable: Record<string, CountResult>) {
+  const calls: Record<string, { method: string; args: unknown[] }[]> = {};
+  const from = vi.fn((table: string) => {
+    const result = byTable[table] ?? {
+      data: null,
+      error: { message: `no mock for table ${table}` },
+    };
+    calls[table] = calls[table] ?? [];
+    const log =
+      (method: string) =>
+      (...args: unknown[]) => {
+        calls[table]!.push({ method, args });
+        return chain;
+      };
+    const chain = {} as LazyChain;
+    chain.select = vi.fn(log("select"));
+    chain.eq = vi.fn(log("eq"));
+    chain.in = vi.fn(log("in"));
+    chain.is = vi.fn(log("is"));
+    chain.gte = vi.fn(log("gte"));
+    chain.order = vi.fn(log("order"));
+    chain.limit = vi.fn(log("limit"));
+    chain.maybeSingle = vi
+      .fn()
+      .mockResolvedValue({ data: result.data, error: result.error });
+    chain.then = Promise.resolve(result).then.bind(Promise.resolve(result));
+    return chain;
+  });
+  return { client: { from }, from, calls };
+}
+
 // .update(payload).eq(col, val).select(...).maybeSingle()
 function makeUpdateEqMaybeSingleMock(result: SingleResult) {
   const maybeSingle = vi.fn().mockResolvedValue(result);
@@ -2277,5 +2332,280 @@ describe("chat-tools — find_plant", () => {
 
     expect(result.ok).toBe(false);
     expect(from).not.toHaveBeenCalled();
+  });
+});
+
+describe("chat-tools — compare_plants", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires plantIds only", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "compare_plants",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["plantIds"] });
+  });
+
+  it("rejects fewer than 2 plantIds", async () => {
+    const { client, from } = makeTableRouterMock({});
+    createSupabaseServerClient.mockResolvedValue(client);
+    const result = await executeChatTool(
+      "compare_plants",
+      { plantIds: ["p-1"] },
+      CTX_AUTHED,
+    );
+    expect(result.ok).toBe(false);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("rejects more than 4 plantIds", async () => {
+    const { client, from } = makeTableRouterMock({});
+    createSupabaseServerClient.mockResolvedValue(client);
+    const result = await executeChatTool(
+      "compare_plants",
+      { plantIds: ["p-1", "p-2", "p-3", "p-4", "p-5"] },
+      CTX_AUTHED,
+    );
+    expect(result.ok).toBe(false);
+    expect(from).not.toHaveBeenCalled();
+  });
+
+  it("returns per-plant summary with counts from each table", async () => {
+    const { client } = makeTableRouterMock({
+      plants: {
+        data: { id: "p-1", name: "Mother", strain: "NL" },
+        error: null,
+      },
+      plant_analyses: {
+        data: { id: "a-1", overall_health_score: 0.9, summary: "ok" },
+        error: null,
+      },
+      grow_events: { data: [], error: null, count: 7 },
+      plant_observations: { data: [], error: null, count: 3 },
+      plant_findings: { data: [], error: null, count: 1 },
+      grow_tasks: { data: [], error: null, count: 2 },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "compare_plants",
+      { plantIds: ["p-1", "p-2"] },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as {
+        plants: Array<{ counts: Record<string, number> }>;
+      };
+      expect(data.plants).toHaveLength(2);
+      expect(data.plants[0]?.counts).toEqual({
+        events: 7,
+        observations: 3,
+        unresolvedFindings: 1,
+        openTasks: 2,
+      });
+    }
+  });
+
+  it("clamps sinceDays to a max of 90", async () => {
+    const { client } = makeTableRouterMock({
+      plants: { data: null, error: null },
+      plant_analyses: { data: null, error: null },
+      grow_events: { data: [], error: null, count: 0 },
+      plant_observations: { data: [], error: null, count: 0 },
+      plant_findings: { data: [], error: null, count: 0 },
+      grow_tasks: { data: [], error: null, count: 0 },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "compare_plants",
+      { plantIds: ["p-1", "p-2"], sinceDays: 9999 },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as { sinceDays: number };
+      expect(data.sinceDays).toBe(90);
+    }
+  });
+
+  it("degrades gracefully when one of the per-plant reads fails", async () => {
+    const { client } = makeTableRouterMock({
+      plants: { data: null, error: { message: "rls" } },
+      plant_analyses: { data: null, error: null },
+      grow_events: { data: [], error: null, count: 0 },
+      plant_observations: { data: [], error: null, count: 0 },
+      plant_findings: { data: [], error: null, count: 0 },
+      grow_tasks: { data: [], error: null, count: 0 },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "compare_plants",
+      { plantIds: ["p-1", "p-2"] },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as { plants: Array<{ plant: unknown }> };
+      expect(data.plants[0]?.plant).toBeNull();
+    }
+  });
+});
+
+describe("chat-tools — get_grow_summary", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    logServerEvent.mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is exposed in the tool list and requires growId only", () => {
+    const def = CHAT_TOOL_DEFINITIONS.find(
+      (t) => t.function.name === "get_grow_summary",
+    );
+    expect(def).toBeDefined();
+    expect(def?.function.parameters).toMatchObject({ required: ["growId"] });
+  });
+
+  it("returns 'not found' when the grow lookup is null", async () => {
+    const { client } = makeTableRouterMock({
+      grows: { data: null, error: null },
+      plants: { data: [], error: null },
+      plant_findings: { data: [], error: null },
+      grow_tasks: { data: [], error: null },
+      grow_events: { data: null, error: null },
+      plant_observations: { data: null, error: null },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "get_grow_summary",
+      { growId: "missing" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok)
+      expect(result.error).toMatch(/not found or not accessible/i);
+  });
+
+  it("aggregates plant count, finding severities, and task priorities", async () => {
+    const startDate = new Date(Date.now() - 21 * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    const { client } = makeTableRouterMock({
+      grows: {
+        data: {
+          id: "g-1",
+          name: "North Tent",
+          stage: "vegetative",
+          medium: "soil",
+          light_type: "led",
+          start_date: startDate,
+        },
+        error: null,
+      },
+      plants: {
+        data: [
+          { id: "p-1", name: "P1" },
+          { id: "p-2", name: "P2" },
+          { id: "p-3", name: "P3" },
+        ],
+        error: null,
+      },
+      plant_findings: {
+        data: [
+          { id: "f-1", severity: "high", resolved_at: null },
+          { id: "f-2", severity: "high", resolved_at: null },
+          { id: "f-3", severity: "low", resolved_at: null },
+        ],
+        error: null,
+      },
+      grow_tasks: {
+        data: [
+          { id: "t-1", priority: "urgent", status: "open" },
+          { id: "t-2", priority: "medium", status: "in_progress" },
+        ],
+        error: null,
+      },
+      grow_events: {
+        data: {
+          id: "e-9",
+          event_type: "feed",
+          occurred_at: "2026-05-12T00:00:00Z",
+        },
+        error: null,
+      },
+      plant_observations: {
+        data: { id: "o-9", observed_at: "2026-05-13T00:00:00Z" },
+        error: null,
+      },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "get_grow_summary",
+      { growId: "g-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as {
+        plantCount: number;
+        unresolvedFindingCount: number;
+        findingsBySeverity: Record<string, number>;
+        openTaskCount: number;
+        tasksByPriority: Record<string, number>;
+        daysSinceStart: number | null;
+      };
+      expect(data.plantCount).toBe(3);
+      expect(data.unresolvedFindingCount).toBe(3);
+      expect(data.findingsBySeverity).toEqual({ high: 2, low: 1 });
+      expect(data.openTaskCount).toBe(2);
+      expect(data.tasksByPriority).toEqual({ urgent: 1, medium: 1 });
+      expect(data.daysSinceStart).toBeGreaterThanOrEqual(20);
+      expect(data.daysSinceStart).toBeLessThanOrEqual(22);
+    }
+  });
+
+  it("returns null daysSinceStart when start_date is missing", async () => {
+    const { client } = makeTableRouterMock({
+      grows: {
+        data: { id: "g-1", name: "Anon", start_date: null },
+        error: null,
+      },
+      plants: { data: [], error: null },
+      plant_findings: { data: [], error: null },
+      grow_tasks: { data: [], error: null },
+      grow_events: { data: null, error: null },
+      plant_observations: { data: null, error: null },
+    });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    const result = await executeChatTool(
+      "get_grow_summary",
+      { growId: "g-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const data = result.data as { daysSinceStart: number | null };
+      expect(data.daysSinceStart).toBeNull();
+    }
   });
 });

--- a/apps/web/src/lib/server/chat-prompt.ts
+++ b/apps/web/src/lib/server/chat-prompt.ts
@@ -42,13 +42,31 @@ Stage cheat-sheet you may rely on:
 - Late flower: VPD 1.2–1.5 kPa, PPFD 700–1000, RH 40–50%, suppress botrytis risk.
 
 # Tool use
-You have tools to look up the grower's actual data — grows, plants, findings, observations, events, image analysis, and the actionable task worklist. Use them when:
+You have a structured toolbox covering reads, fuzzy entity resolution, and writes against the grower's actual data. Use it when:
 - The user references "my grow", "the tent", "my plants", a stage, or a strain you don't know about yet in this conversation.
 - The user asks "what happened last week / since last time / over time".
 - The user asks "what do I need to do" / "what's outstanding" / "anything urgent" — call \`list_open_tasks\`.
 - You're about to give advice that depends on the grower's stage, medium, light, or known findings.
 
 Call a tool *before* speculating about *the user's specific setup*. If a tool returns nothing, say so plainly and ask for the missing detail. Never invent data about their grow.
+
+## Resolution-first pattern
+When the user mentions an entity conversationally ("the mother", "north tent", "plant 3", "NL 01"), your FIRST tool call should be a fuzzy resolver:
+
+- \`find_grow\` — substring search over grow name + description.
+- \`find_plant\` — substring search over plant name + strain + batch_label, optionally scoped to a grow.
+
+Only call \`list_grows\` / \`list_plants\` when the user asks to enumerate, not to disambiguate.
+
+## Read tools at a glance
+- Roster: \`list_grows\`, \`list_plants\`.
+- Resolution: \`find_grow\`, \`find_plant\`.
+- Snapshots: \`get_grow_summary\` (whole-grow one-shot), \`get_plant_timeline\` (unified plant feed).
+- Activity: \`get_recent_findings\`, \`get_recent_observations\`, \`get_grow_events\`.
+- Analysis: \`get_latest_analysis\`, \`get_analysis_history\`, \`compare_plants\` (cross-plant longitudinal).
+- Worklist: \`list_open_tasks\`.
+
+Prefer \`get_grow_summary\` as the cheap first read when the user opens a session ("how's the tent doing?"). Prefer \`compare_plants\` over multiple \`get_plant_timeline\` calls for cross-plant questions.
 
 # General knowledge vs grow-specific advice (IMPORTANT)
 General cultivation knowledge does NOT require any grow context, grow ID, or tool call. Answer directly, with the same depth and structure you'd use for a peer cultivator. This includes:
@@ -63,30 +81,45 @@ General cultivation knowledge does NOT require any grow context, grow ID, or too
 Do NOT refuse a general question because no grow ID was supplied, and do NOT demand the user create or select a grow before answering. Offer at the end that you can tailor the answer further if they share specifics (stage, EC, pH, age, medium). Only require the grow context when the user is explicitly asking about THEIR grow / plants / findings / history.
 
 # Proactive worklist surfacing
-High and critical AI findings automatically spawn a task in \`grow_tasks\` (see the "Open tasks" section of the grower context loaded into every turn). Treat these as the grower's actionable worklist. Discipline:
+High and critical findings (AI-generated or grower-recorded via \`record_image_finding\`) automatically spawn a task in \`grow_tasks\` via a database trigger. Manual tasks can also be created through \`create_grow_task\`. Discipline:
 
-- When the user opens a session with "what's going on" / "anything urgent" / "what should I do today", lead with the **urgent + high** open tasks — name them, name the plant, point at the originating finding.
+- When the user opens a session with "what's going on" / "anything urgent" / "what should I do today", lead with the **urgent + high** open tasks — name them, name the plant, point at the originating finding when there is one.
 - When the user asks an off-topic question and there are no urgent tasks, do NOT lecture them about the worklist. Surface tasks only when topically relevant or explicitly asked.
 - When the user mentions completing an action that matches a task ("I flushed the deficiency"), call \`update_task_status\` with status='done' AND \`mark_finding_resolved\` for the linked finding if there is one (the task carries \`finding_id\` — pull it from \`list_open_tasks\` first).
 - Tasks have status open / in_progress / done / dismissed and priority low / medium / high / urgent. Use \`update_task_status\` to flip between them; the database stamps \`completed_at\` automatically.
-- Never fabricate tasks. The trigger creates them from real findings; the chat tool can update existing ones; manual creation from the chat (without a finding) is not yet supported and you should not attempt it.
 
-# Write tools (recording + reconciling grower actions)
-You can *record* and *reconcile* what the grower did:
-- \`log_grow_event\` — water / feed / top / fim / lst / defoliate / transplant / ipm / harvest / observation / note / other
-- \`log_plant_observation\` — height + free-text
-- \`mark_finding_resolved\` — flip an AI finding's \`resolved_at\` (set to now, or clear it to re-open)
-- \`update_grow_stage\` — transition the whole grow to a new stage (germination → seedling → vegetative → pre_flower → flower → late_flower → harvest → dry_cure). NOTE: stage is per-grow, not per-plant; this affects every plant in the grow.
+# Write tools — onboarding, recording, updating
+Conceptually four buckets:
 
-Discipline:
+## Create (onboarding + new state)
+- \`create_grow\` — start a new grow. Always confirm name + stage + medium + lightType before calling.
+- \`create_plants\` — bulk-create plants in a grow. count > 1 auto-numbers the names ("Plant 01", "Plant 02"); names are immutable from the bulk path so suggest renames via \`update_plant\` after.
+- \`create_grow_task\` — capture a grower-initiated reminder ("remind me to flush Friday"). Auto-tasks from high/critical findings still come through the trigger; this is for manual ones only.
 
-1. **Only write when the grower explicitly told you they DID it.** "I just fed plant 3 with FloraNova at 800 EC" → log it. "I flushed the deficiency on #2 yesterday and it looks better now" → log a feed event (water/flush) AND mark the matching nutrient_deficiency finding resolved. "Should I feed?" → do NOT log; answer the question.
-2. **Resolve the target before logging.** If you don't know which grow / plant / finding they mean, use a read tool (\`list_grows\`, \`list_plants\`, \`get_recent_findings\`) or ask. Never write against a guessed id.
-3. **Confirm in your reply.** After a successful write, briefly tell the user what was recorded (e.g. "Logged a feed event for Blue Dream #3 at 14:32 (evt_xxx) and marked the nitrogen-deficiency finding resolved. Let me know if I should fix anything.") so they can catch a wrong category, wrong plant, or wrong finding.
-4. **Pick the most specific event_type.** Use \`other\` only when nothing fits. \`feed\` covers nutrient applications; \`water\` is plain water; \`ipm\` is anything pest-related (sprays, predators, traps).
+## Record (what just happened)
+- \`log_grow_event\` — water / feed / top / fim / lst / defoliate / transplant / ipm / harvest / observation / note / other.
+- \`log_plant_observation\` — height + free-text on a specific plant.
+- \`record_image_finding\` — file a structured plant_findings row when the user describes a definite plant-health issue. Tagged source='user_reported'. High/critical severity auto-spawns a task via the trigger.
+
+## Update (correct or evolve)
+- \`update_grow\` — rename, edit description / medium / lightType / targetHarvestDate, or archive.
+- \`update_plant\` — rename, set strain / batch_label / notes, or archive. Critical for fixing a bulk \`create_plants\` typo.
+- \`update_grow_stage\` — stage transitions (germination → seedling → vegetative → pre_flower → flower → late_flower → harvest → dry_cure). Per-grow, affects every plant.
+- \`mark_finding_resolved\` — flip a finding's \`resolved_at\`. Cannot edit severity / category / description.
+- \`update_task_status\` — open / in_progress / done / dismissed.
+
+## Trigger (heavy actions)
+- \`trigger_plant_analysis\` — run the Gemini vision pipeline on a plant photo and persist the result. Synchronous; warn the user it'll take 5-30s before invoking.
+
+## Discipline
+
+1. **Only write when the grower explicitly told you they DID it.** "I just fed plant 3 with FloraNova at 800 EC" → log it. "Should I feed?" → do NOT log; answer the question.
+2. **Resolve the target before any write.** Use \`find_grow\` / \`find_plant\` for conversational references; use a read tool for ids. Never write against a guessed id.
+3. **Confirm in your reply.** After a successful write, briefly tell the user what was recorded so they can catch a wrong category, wrong plant, or wrong finding.
+4. **Pick the most specific event_type.** Use \`other\` only when nothing fits. \`feed\` covers nutrient applications; \`water\` is plain water; \`ipm\` is anything pest-related.
 5. **Never batch-fabricate past actions.** If they say "I've been watering daily for a week", do NOT log seven events — confirm whether they want a single backfill note instead.
-6. **\`mark_finding_resolved\` is for resolution, not deletion.** You cannot edit a finding's severity / category / description — the database forbids it. If a finding looks wrong, tell the user and have them flag it; do not try to "fix" it.
-7. **\`update_grow_stage\` is a one-line action with big downstream effects** (analysis prompts, advice, alert cadence all change). Confirm the stage transition with the user before calling unless they were unambiguous ("flip the tent to flower" is unambiguous; "I think it's about ready to flower" is not). Only the grow OWNER can transition; collaborators get a permission error you should surface plainly.
+6. **\`record_image_finding\` is for definite diagnoses, not casual notes.** Casual observations go through \`log_plant_observation\`. A finding is a structured claim that will surface as a task if severity is high or critical.
+7. **\`update_grow_stage\` is a one-line action with big downstream effects** (analysis prompts, advice, alert cadence all change). Confirm the stage transition with the user before calling unless they were unambiguous. Only the grow OWNER can transition; collaborators get a permission error you should surface plainly.
 8. **Stop and ask if intent is ambiguous.** Two write-tool calls in a single turn should be rare; more than three is almost always wrong.
 
 If a write tool returns "you do not have access" or "you do not have permission", do NOT retry with a different id — surface the error to the user; it usually means they referenced the wrong target or aren't authorized for that operation.

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -772,6 +772,50 @@ export const CHAT_TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    type: "function" as const,
+    function: {
+      name: "compare_plants",
+      description:
+        "Side-by-side comparison of 2-4 plants over a recent window. Returns each plant's latest analysis summary (health score, summary, comparison_summary) plus event / observation / open-task / unresolved-finding counts since `sinceDays`. Use for cross-plant longitudinal questions: 'how does plant 3 compare to plant 4 this week', 'which of the seedlings is lagging', 'is the LED tent doing better than the HPS tent overall'. Cheaper than calling get_plant_timeline for each plant — one call returns the comparable summary fields.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantIds: {
+            type: "array",
+            items: { type: "string" },
+            description: "2-4 plant ids to compare. Required.",
+          },
+          sinceDays: {
+            type: "number",
+            description:
+              "Activity window for the counts (events, observations, findings). Default 14, max 90.",
+          },
+        },
+        required: ["plantIds"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_grow_summary",
+      description:
+        "Whole-grow snapshot in one call — grow metadata (stage, medium, light, days since start), plant count, open-task count broken down by priority, unresolved-finding count broken down by severity, and the most recent event / observation timestamps. Use to answer 'how's the north tent doing overall?' or as a fast first read before deeper investigation. Replaces several separate read tool chains.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description: "Grow ID to summarise. Required.",
+          },
+        },
+        required: ["growId"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -1038,6 +1082,15 @@ const FINDING_SEVERITIES = [
   "high",
   "critical",
 ] as const;
+
+const ComparePlantsArgs = z.object({
+  plantIds: z.array(z.string().min(1)).min(2).max(4),
+  sinceDays: z.number().optional(),
+});
+
+const GetGrowSummaryArgs = z.object({
+  growId: z.string().min(1),
+});
 
 const FindGrowArgs = z.object({
   query: z.string().min(1).max(120),
@@ -1872,6 +1925,229 @@ export async function executeChatTool(
           const { data, error } = await q;
           if (error) return { ok: false, error: error.message };
           return { ok: true, data: data ?? [] };
+        }
+
+        case "compare_plants": {
+          const args = ComparePlantsArgs.parse(rawArgs);
+          const sinceDays = numClamp(args.sinceDays, 14, 90);
+          const since = new Date(
+            Date.now() - sinceDays * 24 * 60 * 60 * 1000,
+          ).toISOString();
+
+          // Fan out the per-plant reads in parallel. Each plant gets:
+          //   - plant row (name, strain, grow_id)
+          //   - latest plant_analyses row
+          //   - event count in window
+          //   - observation count in window
+          //   - unresolved finding count in window
+          //   - open task count
+          // Promise.allSettled so one RLS denial or missing row degrades
+          // that plant's summary rather than failing the whole call.
+          const perPlant = await Promise.all(
+            args.plantIds.map(async (plantId) => {
+              const [
+                plantRes,
+                analysisRes,
+                eventCountRes,
+                observationCountRes,
+                findingCountRes,
+                taskCountRes,
+              ] = await Promise.allSettled([
+                supabase
+                  .from("plants")
+                  .select("id,grow_id,name,strain,batch_label,is_archived")
+                  .eq("id", plantId)
+                  .maybeSingle(),
+                supabase
+                  .from("plant_analyses")
+                  .select(
+                    "id,overall_health_score,summary,comparison_summary,analyzed_at,model_version",
+                  )
+                  .eq("plant_id", plantId)
+                  .order("analyzed_at", { ascending: false })
+                  .limit(1)
+                  .maybeSingle(),
+                supabase
+                  .from("grow_events")
+                  .select("id", { count: "exact", head: true })
+                  .eq("plant_id", plantId)
+                  .gte("occurred_at", since),
+                supabase
+                  .from("plant_observations")
+                  .select("id", { count: "exact", head: true })
+                  .eq("plant_id", plantId)
+                  .gte("observed_at", since),
+                supabase
+                  .from("plant_findings")
+                  .select("id", { count: "exact", head: true })
+                  .eq("plant_id", plantId)
+                  .is("resolved_at", null)
+                  .gte("created_at", since),
+                supabase
+                  .from("grow_tasks")
+                  .select("id", { count: "exact", head: true })
+                  .eq("plant_id", plantId)
+                  .in("status", ["open", "in_progress"]),
+              ]);
+
+              const pickCount = (
+                r: PromiseSettledResult<{ count: number | null }>,
+              ): number =>
+                r.status === "fulfilled" ? (r.value.count ?? 0) : 0;
+
+              const plant =
+                plantRes.status === "fulfilled" ? plantRes.value.data : null;
+              const analysis =
+                analysisRes.status === "fulfilled"
+                  ? analysisRes.value.data
+                  : null;
+
+              return {
+                plantId,
+                plant,
+                latestAnalysis: analysis,
+                counts: {
+                  events: pickCount(eventCountRes),
+                  observations: pickCount(observationCountRes),
+                  unresolvedFindings: pickCount(findingCountRes),
+                  openTasks: pickCount(taskCountRes),
+                },
+              };
+            }),
+          );
+
+          return {
+            ok: true,
+            data: {
+              sinceDays,
+              since,
+              plants: perPlant,
+            },
+          };
+        }
+
+        case "get_grow_summary": {
+          const args = GetGrowSummaryArgs.parse(rawArgs);
+
+          const [
+            growRes,
+            plantsRes,
+            findingsRes,
+            tasksRes,
+            latestEventRes,
+            latestObservationRes,
+          ] = await Promise.allSettled([
+            supabase
+              .from("grows")
+              .select(
+                "id,name,description,stage,medium,light_type,start_date,target_harvest_date,is_archived",
+              )
+              .eq("id", args.growId)
+              .maybeSingle(),
+            supabase
+              .from("plants")
+              .select("id,name,strain,is_archived")
+              .eq("grow_id", args.growId)
+              .eq("is_archived", false),
+            supabase
+              .from("plant_findings")
+              .select("id,severity,resolved_at")
+              .eq("grow_id", args.growId)
+              .is("resolved_at", null),
+            supabase
+              .from("grow_tasks")
+              .select("id,priority,status")
+              .eq("grow_id", args.growId)
+              .in("status", ["open", "in_progress"]),
+            supabase
+              .from("grow_events")
+              .select("id,event_type,occurred_at")
+              .eq("grow_id", args.growId)
+              .order("occurred_at", { ascending: false })
+              .limit(1)
+              .maybeSingle(),
+            supabase
+              .from("plant_observations")
+              .select("id,observed_at")
+              .eq("grow_id", args.growId)
+              .order("observed_at", { ascending: false })
+              .limit(1)
+              .maybeSingle(),
+          ]);
+
+          const grow =
+            growRes.status === "fulfilled" ? growRes.value.data : null;
+          if (!grow) {
+            return {
+              ok: false,
+              error:
+                "grow not found or not accessible — confirm growId and that the user owns or is a member of the grow",
+            };
+          }
+
+          const plants =
+            (plantsRes.status === "fulfilled" ? plantsRes.value.data : null) ??
+            [];
+          const findings =
+            (findingsRes.status === "fulfilled"
+              ? findingsRes.value.data
+              : null) ?? [];
+          const tasks =
+            (tasksRes.status === "fulfilled" ? tasksRes.value.data : null) ??
+            [];
+
+          const findingsBySeverity = findings.reduce<Record<string, number>>(
+            (acc, row) => {
+              const sev = (row as { severity: string }).severity ?? "unknown";
+              acc[sev] = (acc[sev] ?? 0) + 1;
+              return acc;
+            },
+            {},
+          );
+          const tasksByPriority = tasks.reduce<Record<string, number>>(
+            (acc, row) => {
+              const pri = (row as { priority: string }).priority ?? "unknown";
+              acc[pri] = (acc[pri] ?? 0) + 1;
+              return acc;
+            },
+            {},
+          );
+
+          const latestEvent =
+            latestEventRes.status === "fulfilled"
+              ? latestEventRes.value.data
+              : null;
+          const latestObservation =
+            latestObservationRes.status === "fulfilled"
+              ? latestObservationRes.value.data
+              : null;
+
+          // daysSinceStart mirrors the daysSinceStart calculation used in
+          // the analysis context so the model's numeric anchor stays
+          // consistent across surfaces.
+          const startDate = (grow as { start_date: string | null }).start_date;
+          const daysSinceStart =
+            startDate && !Number.isNaN(Date.parse(startDate))
+              ? Math.max(
+                  0,
+                  Math.floor((Date.now() - Date.parse(startDate)) / 86_400_000),
+                )
+              : null;
+
+          return {
+            ok: true,
+            data: {
+              grow,
+              daysSinceStart,
+              plantCount: plants.length,
+              unresolvedFindingCount: findings.length,
+              findingsBySeverity,
+              openTaskCount: tasks.length,
+              tasksByPriority,
+              latestEvent,
+              latestObservation,
+            },
+          };
         }
 
         default:


### PR DESCRIPTION
## Why

This is the wrap-up for the chatbot upgrade theme. After #139–#143 the assistant could create, read, update, archive, record findings, run analyses, and resolve entities fuzzily. This PR adds the two cross-cutting reads that turn the toolbox into a coherent operating surface — and rewrites the system prompt so the model actually knows how to use it.

## What changed

### `compare_plants` (read)
- Side-by-side cross-plant summary for **2-4 plants** over a `sinceDays` window (default 14, max 90).
- Per plant returns: identity row, latest `plant_analyses` row, plus event / observation / unresolved-finding / open-task **counts** since the window start.
- `Promise.allSettled` fan-out so a single RLS denial or empty table degrades that plant's section rather than failing the entire call.
- **One call replaces the 4-6 separate tool calls** the model used to make for "how do plants 3 and 4 compare this week?".

### `get_grow_summary` (read)
- **One-shot whole-grow snapshot**: grow row + `daysSinceStart` + `plantCount` + unresolved findings broken down by severity + open tasks broken down by priority + latest event / observation timestamps.
- Returns *"not found or not accessible"* when the grow lookup is `null` so the model can disambiguate instead of guessing.
- Becomes the **cheap first-read** for "how's the north tent doing?" sessions.

### System prompt refresh (`chat-prompt.ts`)
- **Adds a "Resolution-first pattern" section**: tells the model to call `find_grow` / `find_plant` *before* `list_grows` / `list_plants` for conversational references.
- **Catalogs all 12 read tools** by purpose (Roster / Resolution / Snapshots / Activity / Analysis / Worklist) so the model picks the cheap snapshot tools before fanning out.
- **Replaces the four-tool write list with a four-bucket taxonomy** covering all 11 write tools + 1 trigger: Create / Record / Update / Trigger.
- **Removes the stale** *"manual task creation is not yet supported"* line that contradicted `create_grow_task`.

## Tests

10 new cases in `chat-tools.test.ts` (116 total, up from 106). New `makeTableRouterMock` helper routes `from(table)` to a per-table configured result so the parallel `Promise.allSettled` fan-out is testable.

Coverage:
- `compare_plants`: tool-definition shape, 2/4 `plantIds` bounds, per-plant counts aggregation, `sinceDays` max-90 clamp, graceful degradation when a plant read fails.
- `get_grow_summary`: tool-definition shape, null-grow → not-found, severity / priority breakdown aggregation, null `start_date` → `daysSinceStart = null`.

**Full suite: 505/505** (was 495). `pnpm run validate`, `pnpm run security:routes`, `pnpm --filter web build` all green.

## Final agentic capability surface (25 tools)

| Bucket | Tools |
|---|---|
| Resolution | `find_grow`, `find_plant` |
| Roster | `list_grows`, `list_plants` |
| Snapshots | **`get_grow_summary`** ✨, `get_plant_timeline` |
| Activity | `get_recent_findings`, `get_recent_observations`, `get_grow_events` |
| Analysis | `get_latest_analysis`, `get_analysis_history`, **`compare_plants`** ✨ |
| Worklist | `list_open_tasks` |
| Create | `create_grow`, `create_plants`, `create_grow_task` |
| Record | `log_grow_event`, `log_plant_observation`, `record_image_finding` |
| Update | `update_grow`, `update_plant`, `update_grow_stage`, `mark_finding_resolved`, `update_task_status` |
| Trigger | `trigger_plant_analysis` |

A user can now run an entire grow cycle — onboarding, daily ops, diagnostics, longitudinal review, harvest — without ever leaving chat.

## Out of scope / follow-ups
- **Action receipt UI cards.** Tool results stream as natural language today; structured inline cards would be nice signal but require chat-client.tsx surgery — separate UI PR.
- **Voice / multi-turn confirmation patterns.** UX-side work.
- **`pg_trgm` trigram search** for `find_*` (handles typos like "moter" → "mother"). Schema change, deferred.
- **Async analysis job** (queue + poll) instead of synchronous `trigger_plant_analysis` blocking. Future iteration.

## Test plan
- [x] Unit: 116/116 in `chat-tools.test.ts`
- [x] Full: 505/505 in `pnpm turbo run test type-check lint`
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual: from `/assistant`, ask "give me a summary of the north tent" and "compare plant 3 and plant 4 over the last week" — verify each returns a single, structured tool result the bot can narrate from.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_