### PR TITLE
fix(grows): land create-grow on /grows + reusable action recovery hook

### DIFF
--- a/apps/web/e2e/authenticated-workspace.spec.ts
+++ b/apps/web/e2e/authenticated-workspace.spec.ts
@@ -53,12 +53,17 @@ test.describe("Authenticated workspace smoke", () => {
         await page.getByLabel("Light type").selectOption("led");
         await page.getByRole("button", { name: "Create grow" }).click();
 
-        // Post-create now lands directly on the add-plant flow with a
-        // success banner naming the new grow.
-        await page.waitForURL(/\/plants\/new\?growId=[^&]+&just_created=1/);
+        // Post-create lands on the grow registry with the new grow
+        // highlighted so the user sees the grow they just created
+        // instead of being force-funneled into a plant-intake form.
+        await page.waitForURL(/\/grows\?growId=[^&]+&just_created=1/);
         await expect(
           page.getByText(new RegExp(`Grow .${growName}. is ready`, "i")),
         ).toBeVisible();
+        // The banner's "Add a plant" CTA carries the new grow id and
+        // is the natural next step for an empty grow.
+        await page.getByRole("link", { name: "Add a plant" }).first().click();
+        await page.waitForURL(/\/plants\/new\?growId=/);
       });
 
       let plantId = "";

--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -76,9 +76,10 @@ describe("createGrowAction", () => {
     });
     const result = await createGrowAction(buildFormData());
     expect(result.status).toBe("success");
-    expect(result.redirectTo).toBe(
-      "/plants/new?growId=grow-new-123&just_created=1",
-    );
+    // Redirect now lands on the grow registry with the new grow
+    // highlighted, so the user sees the grow they just created instead
+    // of being force-funneled into a plant-intake form.
+    expect(result.redirectTo).toBe("/grows?growId=grow-new-123&just_created=1");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/plants");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard");
@@ -91,7 +92,7 @@ describe("createGrowAction", () => {
     });
     const result = await createGrowAction(buildFormData());
     expect(result.redirectTo).toBe(
-      "/plants/new?growId=abc%2Fdef%3Fweird&just_created=1",
+      "/grows?growId=abc%2Fdef%3Fweird&just_created=1",
     );
   });
 

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -185,11 +185,14 @@ export async function createGrowAction(
   // as an error boundary hit. Letting the client perform router.push avoids
   // that entire failure mode.
   //
-  // Send the operator straight to the add-plant flow with the new grow
-  // pre-selected. The plant page renders a "grow ready" banner with an
-  // explicit "back to grow registry" exit so this isn't a forced path.
+  // Land on the grow registry with the new grow highlighted so the user
+  // sees what they just created. The previous redirect to /plants/new
+  // visually buried the success in a plant-intake form, which made the
+  // action feel like it had failed. The registry page recognises the
+  // `just_created=1` flag and shows a recovery-friendly banner with
+  // both "Add a plant" and "View grow registry" CTAs.
   const redirectTo = newGrowId
-    ? `/plants/new?growId=${encodeURIComponent(newGrowId)}&just_created=1`
+    ? `/grows?growId=${encodeURIComponent(newGrowId)}&just_created=1`
     : "/grows";
   return {
     message: "Grow created.",

--- a/apps/web/src/app/(app)/grows/new/grow-form.tsx
+++ b/apps/web/src/app/(app)/grows/new/grow-form.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Button, buttonStyles } from "@/components/ui/button";
 import { FormErrorSummary } from "@/components/form-error-summary";
+import { useActionWithRecovery } from "@/lib/client/action-runner";
 import {
   createGrowAction,
   createGrowActionInitialState,
@@ -118,11 +118,24 @@ function FieldError({
 }
 
 export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
-  const router = useRouter();
-  const [state, setState] = useState<CreateGrowActionResult>(
+  // useActionWithRecovery handles three failure modes for us:
+  //   1. Transient throws (network blip, ChunkLoadError) are retried
+  //      once with backoff before surfacing an error to the user.
+  //   2. router.push failures don't strand the user — `state.recoveryUrl`
+  //      always points at a known-good page, and the form renders a
+  //      manual "Continue" CTA when navigation didn't take over.
+  //   3. Validation / RLS errors flow through unchanged so field-level
+  //      messages still render.
+  // /grows is the universal fallback because it's the page the action
+  // intends to land on anyway; any successful create is visible there.
+  const {
+    state,
+    isPending,
+    run: runCreateGrow,
+  } = useActionWithRecovery<CreateGrowActionResult>(
     createGrowActionInitialState,
+    { fallbackUrl: "/grows" },
   );
-  const [isPending, startTransition] = useTransition();
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [stage, setStage] = useState<Preset["stage"]>("seedling");
@@ -142,24 +155,16 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
   }
 
   async function handleAction(formData: FormData) {
-    startTransition(async () => {
-      try {
-        const result = await createGrowAction(formData);
-        setState(result);
-        if (result.status === "success" && result.redirectTo) {
-          router.push(result.redirectTo);
-        }
-      } catch (err) {
-        // Last-resort safety net: never let an unexpected throw escape the
-        // transition and crash into the (app)/error.tsx boundary.
-        console.error("createGrowAction failed unexpectedly", err);
-        setState({
-          message:
-            "Something went wrong saving the grow. Please try again in a moment.",
-          status: "error",
-        });
+    try {
+      await runCreateGrow(() => createGrowAction(formData));
+    } catch (err) {
+      // The runner has already updated component state with an
+      // error-shaped result + recoveryUrl. Re-throws here are expected
+      // when retries are exhausted — log for diagnostics, don't crash.
+      if (typeof console !== "undefined") {
+        console.error("createGrowAction failed after retries", err);
       }
-    });
+    }
   }
 
   return (
@@ -169,6 +174,50 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
         fieldErrors={state.fieldErrors}
         fieldMeta={FIELD_META}
       />
+
+      {state.status === "success" && state.recoveryUrl ? (
+        // Defence-in-depth recovery banner. router.push is fired by the
+        // runner on success; if for any reason it didn't navigate (a
+        // chunk error, a blocked transition, the user disabled JS
+        // routing), this CTA is the manual continue. Once navigation
+        // takes effect this component unmounts so the user never
+        // notices it under happy-path conditions.
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-success/40 bg-success/10 px-4 py-4 text-sm leading-6 text-foreground"
+          role="status"
+        >
+          <p className="font-medium">Grow created.</p>
+          <p className="mt-1 text-muted-foreground">
+            If your screen didn&apos;t move on its own, tap below to continue.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link
+              className={buttonStyles({ size: "sm" })}
+              href={state.recoveryUrl}
+            >
+              Continue to grow registry
+            </Link>
+          </div>
+        </div>
+      ) : null}
+
+      {state.status === "error" && state.recoveryUrl ? (
+        // After a permanent error AND retries exhausted, give the user a
+        // fallback page so they're never stranded on a dead form. The
+        // fieldErrors above tell them what to fix; the link below tells
+        // them where to go if they want to bail.
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3 text-sm leading-6 text-muted-foreground"
+        >
+          Need to step away?{" "}
+          <Link className="text-accent underline" href={state.recoveryUrl}>
+            Open the grow registry
+          </Link>{" "}
+          — your form input stays here when you come back.
+        </div>
+      ) : null}
 
       <div
         aria-label="Quick-start presets"

--- a/apps/web/src/app/(app)/grows/page.tsx
+++ b/apps/web/src/app/(app)/grows/page.tsx
@@ -26,6 +26,7 @@ interface GrowsPageProps {
   searchParams?: Promise<{
     growId?: string | string[] | undefined;
     just_added?: string | string[] | undefined;
+    just_created?: string | string[] | undefined;
   }>;
 }
 
@@ -49,6 +50,20 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
   const justAddedGrowId = firstParam(resolvedParams?.growId);
   const justAddedGrowName = justAddedCount
     ? (overview.grows.find((g) => g.id === justAddedGrowId)?.name ?? null)
+    : null;
+
+  // `just_created=1` signals the user just completed the new-grow form.
+  // We surface a banner naming the grow so the action's success is
+  // obviously visible — and we tolerate read-after-write lag by
+  // falling back to "Grow created" when the row isn't yet in the
+  // overview slice. Either way the registry below is the user's
+  // confirmation that the grow exists.
+  const justCreated = firstParam(resolvedParams?.just_created) === "1";
+  const justCreatedGrowId = justCreated
+    ? firstParam(resolvedParams?.growId)
+    : "";
+  const justCreatedGrow = justCreated
+    ? (overview.grows.find((g) => g.id === justCreatedGrowId) ?? null)
     : null;
 
   return (
@@ -90,6 +105,42 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
             Occupancy below is up to date. Open any plant card to start a photo
             timeline.
           </p>
+        </div>
+      ) : null}
+
+      {justCreated ? (
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-success/40 bg-success/10 px-4 py-4 text-sm leading-6 text-foreground"
+          role="status"
+        >
+          <p className="font-medium">
+            {justCreatedGrow
+              ? `Grow "${justCreatedGrow.name}" is ready.`
+              : "Grow created."}
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            It&apos;s in the registry below. Add a first plant to unlock photo
+            uploads and assistant context, or keep exploring the registry.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link
+              className={buttonStyles({ size: "sm" })}
+              href={
+                justCreatedGrow
+                  ? `/plants/new?growId=${justCreatedGrow.id}`
+                  : "/plants/new"
+              }
+            >
+              Add a plant
+            </Link>
+            <Link
+              className={buttonStyles({ size: "sm", variant: "surface" })}
+              href="/grows"
+            >
+              View grow registry
+            </Link>
+          </div>
         </div>
       ) : null}
 

--- a/apps/web/src/lib/__tests__/action-runner.test.tsx
+++ b/apps/web/src/lib/__tests__/action-runner.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+import { useActionWithRecovery } from "../client/action-runner";
+
+type R = {
+  status: "success" | "error" | "idle";
+  redirectTo?: string;
+  message?: string;
+};
+
+const INITIAL: R = { status: "idle" };
+
+describe("useActionWithRecovery", () => {
+  beforeEach(() => {
+    push.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("happy path: surfaces success state and calls router.push with redirectTo", async () => {
+    const { result } = renderHook(() => useActionWithRecovery<R>(INITIAL));
+
+    const action = vi
+      .fn()
+      .mockResolvedValue({ status: "success", redirectTo: "/grows?id=1" });
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(push).toHaveBeenCalledWith("/grows?id=1");
+    expect(result.current.state.status).toBe("success");
+    expect(result.current.state.recoveryUrl).toBe("/grows?id=1");
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it("validation errors bypass retry and surface unchanged", async () => {
+    const { result } = renderHook(() =>
+      useActionWithRecovery<R>(INITIAL, { transientRetries: 3 }),
+    );
+
+    const action = vi.fn().mockResolvedValue({
+      status: "error",
+      message: "Fix the highlighted fields and try again.",
+    });
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+    expect(result.current.state.status).toBe("error");
+    expect(result.current.state.message).toMatch(/highlighted fields/i);
+  });
+
+  it("retries a transient throw and succeeds on the second attempt", async () => {
+    const { result } = renderHook(() =>
+      useActionWithRecovery<R>(INITIAL, {
+        transientRetries: 1,
+        baseRetryDelayMs: 1,
+      }),
+    );
+
+    const action = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({ status: "success", redirectTo: "/grows" });
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(2);
+    expect(push).toHaveBeenCalledWith("/grows");
+    expect(result.current.state.status).toBe("success");
+    expect(result.current.state.attempt).toBe(1);
+  });
+
+  it("non-transient throws are NOT retried — they surface immediately", async () => {
+    const { result } = renderHook(() =>
+      useActionWithRecovery<R>(INITIAL, {
+        transientRetries: 5,
+        baseRetryDelayMs: 1,
+        fallbackUrl: "/grows",
+      }),
+    );
+
+    const action = vi
+      .fn()
+      .mockRejectedValue(new Error("RLS denied: bogus value for stage"));
+
+    await act(async () => {
+      await expect(result.current.run(action)).rejects.toThrow(/RLS denied/);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(result.current.state.status).toBe("error");
+    expect(result.current.state.recoveryUrl).toBe("/grows");
+  });
+
+  it("after retries exhausted, exposes the fallbackUrl as recoveryUrl", async () => {
+    const { result } = renderHook(() =>
+      useActionWithRecovery<R>(INITIAL, {
+        transientRetries: 1,
+        baseRetryDelayMs: 1,
+        fallbackUrl: "/grows",
+      }),
+    );
+
+    const action = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await act(async () => {
+      await expect(result.current.run(action)).rejects.toThrow(
+        /Failed to fetch/,
+      );
+    });
+
+    expect(action).toHaveBeenCalledTimes(2); // initial + 1 retry
+    expect(result.current.state.status).toBe("error");
+    expect(result.current.state.recoveryUrl).toBe("/grows");
+  });
+
+  it("preserves success state even if router.push throws synchronously", async () => {
+    push.mockImplementation(() => {
+      throw new Error("router exploded");
+    });
+    const { result } = renderHook(() =>
+      useActionWithRecovery<R>(INITIAL, { fallbackUrl: "/grows" }),
+    );
+
+    const action = vi
+      .fn()
+      .mockResolvedValue({ status: "success", redirectTo: "/grows?id=1" });
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    // The success state survives the router throw — recoveryUrl is the
+    // user's escape hatch when navigation fails.
+    expect(result.current.state.status).toBe("success");
+    expect(result.current.state.recoveryUrl).toBe("/grows?id=1");
+  });
+
+  it("falls back to the fallbackUrl when the action succeeds without a redirectTo", async () => {
+    const { result } = renderHook(() =>
+      useActionWithRecovery<R>(INITIAL, { fallbackUrl: "/grows" }),
+    );
+
+    const action = vi.fn().mockResolvedValue({ status: "success" });
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+
+    expect(push).not.toHaveBeenCalled();
+    expect(result.current.state.recoveryUrl).toBe("/grows");
+  });
+
+  it("reset() returns state to the initial shape", async () => {
+    const { result } = renderHook(() => useActionWithRecovery<R>(INITIAL));
+
+    const action = vi.fn().mockResolvedValue({
+      status: "error",
+      message: "boom",
+    });
+
+    await act(async () => {
+      await result.current.run(action);
+    });
+    expect(result.current.state.status).toBe("error");
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.state.status).toBe("idle");
+    expect(result.current.state.message).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/client/action-runner.ts
+++ b/apps/web/src/lib/client/action-runner.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+// Shared shape every server action result must satisfy. Each route can
+// extend it with its own message + fieldErrors typing — the runner only
+// reads the status + optional redirectTo.
+export type ServerActionResult = {
+  status: "success" | "error" | "idle";
+  redirectTo?: string;
+  message?: string;
+};
+
+export type RecoveryState<R extends ServerActionResult> = R & {
+  // When the action succeeds with a redirectTo, this URL is preserved
+  // alongside the navigation so the page can render a manual "Continue"
+  // CTA. If router.push succeeds the user navigates away before the CTA
+  // matters; if navigation fails (chunk load error, blocked transition,
+  // user disabled JS routing) the CTA is their escape hatch.
+  recoveryUrl?: string;
+  // Incremented on every retry so callers can show "Retrying… (2/3)" if
+  // they want richer feedback.
+  attempt: number;
+};
+
+export type UseActionWithRecoveryOptions = {
+  // Maximum number of automatic retries on transient errors. Default 1.
+  // Validation / RLS errors are NEVER retried — only thrown errors that
+  // look like network blips.
+  transientRetries?: number;
+  // Base delay in ms; the runner uses exponential backoff
+  // (base * 2^attempt) capped at 4× base.
+  baseRetryDelayMs?: number;
+  // Fallback URL the caller wants exposed via recoveryUrl when the
+  // action's redirectTo is missing. Useful for "if anything goes wrong,
+  // send the user to a known-good page".
+  fallbackUrl?: string;
+};
+
+// Heuristic: which thrown errors look like a transient network / chunk
+// problem worth retrying? Validation errors are NEVER reachable here
+// because the action returns them as a structured result (status:
+// "error"), not a throw.
+function isTransientError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const message = "message" in err ? String(err.message ?? "") : "";
+  const name = "name" in err ? String(err.name ?? "") : "";
+  return (
+    /network|failed to fetch|chunkloaderror|load chunk|aborted/i.test(
+      message,
+    ) || /ChunkLoadError|NetworkError|AbortError/i.test(name)
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Generic action runner with retry-then-recover semantics. Used by any
+// client form that calls a server action and expects either a structured
+// result or a navigation target.
+//
+// Recovery model:
+//   1. Validation errors (status: "error") surface to the UI unchanged —
+//      the form re-renders with field errors, no retry.
+//   2. Thrown errors that look transient are retried with exponential
+//      backoff up to `transientRetries`. On final failure, status is
+//      flipped to "error" with a user-readable message.
+//   3. On success, the runner records `recoveryUrl` BEFORE calling
+//      router.push(). If router.push succeeds the user navigates away
+//      and never sees the recovery CTA. If push fails or hangs, the
+//      caller can render <Link href={state.recoveryUrl}> as an escape
+//      hatch so the user never gets stranded on a stale form.
+export function useActionWithRecovery<R extends ServerActionResult>(
+  initialState: R,
+  options: UseActionWithRecoveryOptions = {},
+) {
+  const { transientRetries = 1, baseRetryDelayMs = 250, fallbackUrl } = options;
+
+  const router = useRouter();
+  const [state, setState] = useState<RecoveryState<R>>({
+    ...initialState,
+    attempt: 0,
+  });
+  const [isPending, setPending] = useState(false);
+  // Track the latest run so a fast double-submit can't cross streams.
+  const runIdRef = useRef(0);
+
+  const run = useCallback(
+    async (action: () => Promise<R>): Promise<R> => {
+      const myRunId = ++runIdRef.current;
+      setPending(true);
+
+      let lastError: unknown;
+      for (let attempt = 0; attempt <= transientRetries; attempt++) {
+        try {
+          const result = await action();
+          // Stale run — newer submission supersedes this one.
+          if (runIdRef.current !== myRunId) return result;
+
+          if (result.status === "success") {
+            const recoveryUrl = result.redirectTo ?? fallbackUrl;
+            setState({
+              ...result,
+              ...(recoveryUrl !== undefined ? { recoveryUrl } : {}),
+              attempt,
+            });
+            setPending(false);
+            // Kick off navigation. Wrapped in a try so a thrown router
+            // failure (rare but possible) doesn't undo the success state
+            // — the recoveryUrl CTA is still rendered.
+            if (result.redirectTo) {
+              try {
+                router.push(result.redirectTo);
+              } catch (navErr) {
+                // The recoveryUrl in state is already set; the form
+                // will surface a manual "Continue" CTA. Log so we can
+                // diagnose post-hoc.
+                if (typeof console !== "undefined") {
+                  console.warn(
+                    "useActionWithRecovery: router.push failed",
+                    navErr,
+                  );
+                }
+              }
+            }
+            return result;
+          }
+
+          // Validation / RLS error: surface unchanged, no retry.
+          setState({ ...result, attempt });
+          setPending(false);
+          return result;
+        } catch (err) {
+          lastError = err;
+          if (
+            runIdRef.current === myRunId &&
+            attempt < transientRetries &&
+            isTransientError(err)
+          ) {
+            const delay = Math.min(
+              baseRetryDelayMs * 2 ** attempt,
+              baseRetryDelayMs * 4,
+            );
+            await sleep(delay);
+            continue;
+          }
+          break;
+        }
+      }
+
+      // All retries exhausted (or the error wasn't transient). Surface a
+      // user-readable failure with the fallbackUrl wired up so the form
+      // can offer a manual continue.
+      if (runIdRef.current === myRunId) {
+        const message =
+          lastError instanceof Error
+            ? lastError.message
+            : "Something went wrong. Please try again in a moment.";
+        const next: RecoveryState<R> = {
+          ...initialState,
+          status: "error",
+          message,
+          attempt: transientRetries,
+        };
+        if (fallbackUrl !== undefined) next.recoveryUrl = fallbackUrl;
+        setState(next);
+        setPending(false);
+      }
+      // Re-throw so callers that want their own try/catch can still see
+      // it. The component-level state has already been updated.
+      throw lastError;
+    },
+    [transientRetries, baseRetryDelayMs, fallbackUrl, initialState, router],
+  );
+
+  const reset = useCallback(() => {
+    runIdRef.current++;
+    setState({ ...initialState, attempt: 0 });
+    setPending(false);
+  }, [initialState]);
+
+  return { state, isPending, run, reset };
+}


### PR DESCRIPTION
## Why

User report: *"creating a grow doesn't properly work"*. My audit traced every layer (UI → action → DB → redirect → tests → chat tool parity). The grow row **was** being written correctly — but the post-create redirect landed users on `/plants/new` where the dominant UI is a "Plant intake" form. The "Grow is ready" banner above that form was small and easy to miss, making the whole flow feel like *"I clicked Create grow, why am I on an Add a plant page?"*

This PR ships the P0 fix and the foundation for an "auto-correct errors" pattern the user asked for explicitly.

## P0 fix — redirect lands on `/grows`

`apps/web/src/app/(app)/grows/actions.ts:191-193` now returns
`redirectTo: /grows?growId=<id>&just_created=1` (previously `/plants/new?...`).

`apps/web/src/app/(app)/grows/page.tsx` recognises `just_created=1` and renders a prominent banner naming the new grow, with two CTAs:

- **Add a plant** → `/plants/new?growId=<id>` (the previous default destination, still one click away)
- **View grow registry** → stays on `/grows`

The banner tolerates read-after-write lag: if the new grow isn't yet in the workspace overview slice, it falls back to "Grow created" rather than failing.

## Auto-correction system — `useActionWithRecovery`

New reusable client hook at `apps/web/src/lib/client/action-runner.ts`. Any form that calls a server action can opt in and get:

1. **Transient retry** — thrown errors matching network/chunk heuristics (`Failed to fetch`, `ChunkLoadError`, `NetworkError`, `AbortError`) are retried with exponential backoff (default 1 retry). Validation / RLS errors are *never* retried — they return as structured results and bypass the retry loop.
2. **Navigation recovery** — on success the runner stores `recoveryUrl` in state **before** calling `router.push`. If `router.push` throws (rare, but possible after a chunk error or blocked transition), the user sees a manual *"Continue to grow registry"* CTA. On the happy path the page unmounts before the CTA matters.
3. **Fallback URL** — if the action succeeds without a `redirectTo`, or fails permanently after retries, `fallbackUrl` is exposed via `state.recoveryUrl` so the form can always offer *"step away to a known-good page"*. The grow form uses `/grows` as its fallback.
4. **Run-id guard** — fast double-submit can't cross streams.

The grow form replaces its inline `useTransition` + try/catch with a single `useActionWithRecovery` call and renders two new recovery branches: success-CTA when `router.push` didn't take over, and error-CTA so users on a permanent-error state are never stranded.

## Test coverage

8 new cases in `apps/web/src/lib/__tests__/action-runner.test.tsx`:
- happy path: success state + `router.push` called with `redirectTo`
- validation errors bypass retry
- transient throw retries then succeeds
- non-transient throws are not retried
- exhausted retries expose `fallbackUrl` as `recoveryUrl`
- `router.push` throwing preserves success state
- success without `redirectTo` falls back to `fallbackUrl`
- `reset()` restores initial state

Existing assertions updated:
- `apps/web/src/app/(app)/grows/__tests__/actions.test.ts` — redirect now lands on `/grows?growId=...&just_created=1`
- `apps/web/e2e/authenticated-workspace.spec.ts` — Playwright waits for `/grows?...`, verifies the banner, clicks "Add a plant" to continue the plant-creation flow

**Full suite: 513/513** (was 505). `pnpm run validate`, `pnpm run security:routes`, `pnpm --filter web build` all green.

## Follow-ups (deferred to scoped PRs)

From the same audit:
- **P1** — Missing `UNIQUE (owner_id, lower(name)) WHERE is_archived = false` on `grows`. The action's `23505` branch is currently dead code — duplicates create silently. Needs migration + DB constraint.
- **P2** — Owner row not inserted in `grow_members` on create. Latent today (every RLS check has `auth.uid() = owner_id` OR) but will silently break any future RLS tightening. Needs a `BEFORE INSERT` or `AFTER INSERT` trigger so all create paths (form, chat tool, future) are covered.
- **P3** — Server-side description length cap (chat tool enforces 2000 chars; form doesn't) + start-date bounds.

`useActionWithRecovery` is the foundation those PRs will reuse — any future create flow gets the recovery + retry behaviour by calling the hook instead of rolling its own `useTransition` / try-catch.

## Test plan
- [x] Unit: 513/513
- [x] Type-check + lint via turbo
- [x] Guardrails: `pnpm run validate` + `pnpm run security:routes`
- [x] Build: `pnpm --filter web build`
- [ ] Manual: from `/grows/new`, fill the form, click Create grow → verify you land on `/grows?growId=...&just_created=1` with the banner naming the new grow and "Add a plant" / "View grow registry" CTAs.
- [ ] Manual: simulate offline → submit → verify the runner retries once before showing an error CTA pointing at `/grows`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_