### PR TITLE
feat(grows): detail page, archive flow, integrity migration

### DIFF
--- a/apps/web/e2e/authenticated-workspace.spec.ts
+++ b/apps/web/e2e/authenticated-workspace.spec.ts
@@ -53,15 +53,14 @@ test.describe("Authenticated workspace smoke", () => {
         await page.getByLabel("Light type").selectOption("led");
         await page.getByRole("button", { name: "Create grow" }).click();
 
-        // Post-create lands on the grow registry with the new grow
-        // highlighted so the user sees the grow they just created
-        // instead of being force-funneled into a plant-intake form.
-        await page.waitForURL(/\/grows\?growId=[^&]+&just_created=1/);
+        // Post-create lands directly on the grow detail page so the
+        // user sees the grow they just created. The detail page shows
+        // a confirmation banner and an "Add a plant" CTA preselecting
+        // this grow.
+        await page.waitForURL(/\/grows\/[^/?]+\?just_created=1/);
         await expect(
           page.getByText(new RegExp(`Grow .${growName}. is ready`, "i")),
         ).toBeVisible();
-        // The banner's "Add a plant" CTA carries the new grow id and
-        // is the natural next step for an empty grow.
         await page.getByRole("link", { name: "Add a plant" }).first().click();
         await page.waitForURL(/\/plants\/new\?growId=/);
       });

--- a/apps/web/src/app/(app)/grows/[id]/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/[id]/__tests__/actions.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  // The action chains .update(...).eq(...). The eq mock receives the
+  // final args and resolves with { data, error }.
+  const eq = vi.fn();
+  const update = vi.fn(() => ({ eq }));
+  const from = vi.fn(() => ({ update }));
+  const supabaseStub = { from };
+  const createSupabaseServerClient = vi.fn(async () => supabaseStub);
+  const getServerUser = vi.fn(async () => ({ id: "user-1" }));
+  const revalidatePath = vi.fn();
+  const logServerEvent = vi.fn();
+  return {
+    eq,
+    update,
+    from,
+    supabaseStub,
+    createSupabaseServerClient,
+    getServerUser,
+    revalidatePath,
+    logServerEvent,
+  };
+});
+
+vi.mock("@/lib/server/auth", () => ({
+  createSupabaseServerClient: mocks.createSupabaseServerClient,
+  getServerUser: mocks.getServerUser,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock("@/lib/server/request-id", () => ({
+  logServerEvent: mocks.logServerEvent,
+}));
+
+import { toggleGrowArchiveAction } from "../actions";
+
+describe("toggleGrowArchiveAction", () => {
+  beforeEach(() => {
+    mocks.eq.mockReset();
+    mocks.update.mockClear();
+    mocks.from.mockClear();
+    mocks.createSupabaseServerClient
+      .mockReset()
+      .mockResolvedValue(mocks.supabaseStub);
+    mocks.getServerUser.mockReset().mockResolvedValue({ id: "user-1" });
+    mocks.revalidatePath.mockReset();
+    mocks.logServerEvent.mockReset();
+  });
+
+  it("flips is_archived to true and returns a success redirect", async () => {
+    mocks.eq.mockResolvedValue({ error: null });
+    const result = await toggleGrowArchiveAction("grow-1", true);
+
+    expect(mocks.update).toHaveBeenCalledWith({ is_archived: true });
+    expect(mocks.eq).toHaveBeenCalledWith("id", "grow-1");
+    expect(result.status).toBe("success");
+    expect(result.message).toMatch(/archived/i);
+    expect(result.redirectTo).toBe("/grows/grow-1");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows/grow-1");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("flips is_archived to false (restore) with a 'Grow restored' message", async () => {
+    mocks.eq.mockResolvedValue({ error: null });
+    const result = await toggleGrowArchiveAction("grow-1", false);
+    expect(result.status).toBe("success");
+    expect(result.message).toMatch(/restored/i);
+    expect(mocks.update).toHaveBeenCalledWith({ is_archived: false });
+  });
+
+  it("surfaces a clear restore-collision message on 23505", async () => {
+    // Unarchiving a grow whose name collides with another active grow
+    // trips the partial UNIQUE index from migration 011.
+    mocks.eq.mockResolvedValue({
+      error: { code: "23505", message: "duplicate key value" },
+    });
+    const result = await toggleGrowArchiveAction("grow-1", false);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(
+      /another active grow already uses this name/i,
+    );
+  });
+
+  it("surfaces a permission-denied message on RLS rejection", async () => {
+    mocks.eq.mockResolvedValue({
+      error: { code: "42501", message: "permission denied" },
+    });
+    const result = await toggleGrowArchiveAction("grow-1", true);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/only the grow owner/i);
+  });
+
+  it("rejects unauthenticated callers without touching supabase", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
+    const result = await toggleGrowArchiveAction("grow-1", true);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty growId without touching supabase", async () => {
+    const result = await toggleGrowArchiveAction("", true);
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/invalid grow id/i);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("re-throws Next framework redirect signals untouched", async () => {
+    const e: Error & { digest?: string } = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT;replace;/grows;307;";
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(e);
+    await expect(toggleGrowArchiveAction("g", true)).rejects.toBe(e);
+  });
+});

--- a/apps/web/src/app/(app)/grows/[id]/actions.ts
+++ b/apps/web/src/app/(app)/grows/[id]/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
+import { isNextFrameworkError } from "@/lib/server/auth-errors";
+import { logServerEvent } from "@/lib/server/request-id";
+
+export type ToggleArchiveActionResult = {
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const toggleArchiveActionInitialState: ToggleArchiveActionResult = {
+  status: "idle",
+};
+
+// Toggle a grow's `is_archived` flag. Owner-only — enforced by RLS
+// ("grows: owner write" policy from migration 001), so an unauthorised
+// user gets a clean error rather than silently no-op'ing.
+//
+// `nextValue` is passed explicitly (instead of having the server flip
+// based on current state) so the form is idempotent: clicking
+// "Archive" while archived has no surprise effect.
+//
+// Archiving a grow with an active duplicate-name partner is now
+// allowed because the UNIQUE index from migration 011 is partial
+// (WHERE is_archived = false). Un-archiving a grow whose name collides
+// with an active grow will hit 23505 and we surface a clear message.
+export async function toggleGrowArchiveAction(
+  growId: string,
+  nextValue: boolean,
+): Promise<ToggleArchiveActionResult> {
+  const user = await getServerUser();
+  if (!user) {
+    return {
+      message: "You must be signed in to archive a grow.",
+      status: "error",
+    };
+  }
+
+  if (!growId || typeof growId !== "string") {
+    return {
+      message: "Invalid grow id.",
+      status: "error",
+    };
+  }
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { error } = await supabase
+      .from("grows")
+      .update({ is_archived: nextValue })
+      .eq("id", growId);
+
+    if (error) {
+      logServerEvent("error", "toggle grow archive failed", {
+        error: error.message,
+        code: error.code,
+        growId,
+        userId: user.id,
+        nextValue,
+      });
+      if (error.code === "23505") {
+        // Partial unique index trips on un-archive when another active
+        // grow already owns the name. Tell the user how to recover.
+        return {
+          message:
+            "Can't unarchive: another active grow already uses this name. Rename one of them first.",
+          status: "error",
+        };
+      }
+      if (error.code === "42501" || /row-level security/i.test(error.message)) {
+        return {
+          message: "Only the grow owner can change its archive state.",
+          status: "error",
+        };
+      }
+      return {
+        message: "We couldn't update the grow right now. Please try again.",
+        status: "error",
+      };
+    }
+  } catch (err) {
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "toggle grow archive threw", {
+      error: err instanceof Error ? err.message : String(err),
+      growId,
+      userId: user.id,
+    });
+    return {
+      message: "We couldn't update the grow right now. Please try again.",
+      status: "error",
+    };
+  }
+
+  revalidatePath("/grows");
+  revalidatePath(`/grows/${growId}`);
+  revalidatePath("/dashboard");
+
+  return {
+    message: nextValue ? "Grow archived." : "Grow restored.",
+    redirectTo: `/grows/${growId}`,
+    status: "success",
+  };
+}

--- a/apps/web/src/app/(app)/grows/[id]/archive-button.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/archive-button.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import Link from "next/link";
+import { Button, buttonStyles } from "@/components/ui/button";
+import { useActionWithRecovery } from "@/lib/client/action-runner";
+import {
+  toggleArchiveActionInitialState,
+  toggleGrowArchiveAction,
+  type ToggleArchiveActionResult,
+} from "./actions";
+
+// Client island that hosts the archive / restore toggle. The form
+// inherits the same auto-correction pattern as create-grow:
+//   * Transient network errors retry once with backoff.
+//   * Permanent errors surface the message + a manual link to /grows
+//     so the user is never stranded on a stale detail page.
+//   * On success router.push refreshes the page (server action also
+//     revalidatePath's the route so the UI mirrors the new state).
+//
+// Owner-only by RLS — non-owners see the same form but the server
+// action returns a "Only the grow owner can…" message.
+export function ArchiveButton({
+  growId,
+  isArchived,
+}: {
+  growId: string;
+  isArchived: boolean;
+}) {
+  const { state, isPending, run } =
+    useActionWithRecovery<ToggleArchiveActionResult>(
+      toggleArchiveActionInitialState,
+      { fallbackUrl: "/grows" },
+    );
+
+  async function onSubmit() {
+    try {
+      await run(() => toggleGrowArchiveAction(growId, !isArchived));
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.error("toggleGrowArchiveAction failed after retries", err);
+      }
+    }
+  }
+
+  const label = isArchived ? "Restore grow" : "Archive grow";
+  const verbing = isArchived ? "Restoring…" : "Archiving…";
+
+  return (
+    <div className="space-y-2">
+      <form action={onSubmit}>
+        <Button
+          aria-busy={isPending || undefined}
+          disabled={isPending}
+          size="sm"
+          type="submit"
+          variant={isArchived ? "primary" : "surface"}
+        >
+          {isPending ? verbing : label}
+        </Button>
+      </form>
+      {state.status === "error" && state.message ? (
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-danger"
+          role="status"
+        >
+          {state.message}
+          {state.recoveryUrl ? (
+            <>
+              {" "}
+              <Link className="text-accent underline" href={state.recoveryUrl}>
+                Back to grow registry
+              </Link>
+            </>
+          ) : null}
+        </p>
+      ) : null}
+      {state.status === "success" && state.message ? (
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-muted-foreground"
+          role="status"
+        >
+          {state.message}{" "}
+          {state.recoveryUrl ? (
+            <Link
+              className={buttonStyles({ size: "sm", variant: "surface" })}
+              href={state.recoveryUrl}
+            >
+              Refresh
+            </Link>
+          ) : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/grows/[id]/page.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/page.tsx
@@ -1,0 +1,299 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { GrowIcon, PlantIcon } from "@/components/icons";
+import { Badge } from "@/components/ui/badge";
+import { buttonStyles } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import { fetchGrowDetail } from "@/lib/server/workspace-records";
+import { ArchiveButton } from "./archive-button";
+
+export const metadata: Metadata = { title: "Grow detail" };
+
+interface Props {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<{
+    just_created?: string | string[] | undefined;
+  }>;
+}
+
+function firstParam(value: string | string[] | undefined): string {
+  if (Array.isArray(value)) return value[0] ?? "";
+  return value ?? "";
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  return value;
+}
+
+function titleCase(value: string | null | undefined): string {
+  if (!value) return "—";
+  return value
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((part) => part[0]!.toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+// The grow detail page is the post-create landing target and the
+// canonical place to view a single grow. RLS keeps non-members from
+// reading the row — fetchGrowDetail returns null and we 404.
+//
+// Layout:
+//   * Header with the grow name, stage badge, archived badge if set.
+//   * "just_created" banner (mirrors /grows registry banner) so the
+//     create-grow flow has an obvious confirmation on this page too.
+//   * Metadata card (description, medium, light, dates).
+//   * Plant list with link to each plant detail page + "Add a plant"
+//     CTA preselecting this grow.
+//   * Footer with the Archive / Restore action.
+export default async function GrowDetailPage({ params, searchParams }: Props) {
+  const { id } = await params;
+  const detail = await fetchGrowDetail(id);
+  if (!detail) {
+    notFound();
+  }
+  const { grow, plants } = detail;
+
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const justCreated = firstParam(resolvedSearchParams?.just_created) === "1";
+
+  const activePlants = plants.filter((p) => !p.isArchived);
+  const archivedPlants = plants.filter((p) => p.isArchived);
+
+  return (
+    <main className="app-page">
+      <PageHeader
+        actions={
+          <>
+            <Link
+              className={buttonStyles({ size: "md", variant: "surface" })}
+              href="/grows"
+            >
+              Back to registry
+            </Link>
+            <Link
+              className={buttonStyles({ size: "md" })}
+              href={`/plants/new?growId=${grow.id}`}
+            >
+              Add a plant
+            </Link>
+          </>
+        }
+        breadcrumbs={[
+          { href: "/dashboard", label: "Dashboard" },
+          { href: "/grows", label: "Grows" },
+          { label: grow.name },
+        ]}
+        description={
+          grow.description ??
+          "No description yet. Open the chat assistant to fill in medium notes, room constraints, or handoff details."
+        }
+        eyebrow={
+          <div className="flex flex-wrap gap-2">
+            <Badge tone="accent">{titleCase(grow.stage)}</Badge>
+            {grow.isArchived ? <Badge tone="default">Archived</Badge> : null}
+          </div>
+        }
+        title={grow.name}
+      />
+
+      {justCreated ? (
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-success/40 bg-success/10 px-4 py-4 text-sm leading-6 text-foreground"
+          role="status"
+        >
+          <p className="font-medium">
+            Grow &ldquo;{grow.name}&rdquo; is ready.
+          </p>
+          <p className="mt-1 text-muted-foreground">
+            Next step: add a plant so photo uploads, timelines, and assistant
+            context have a home.
+          </p>
+        </div>
+      ) : null}
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              {activePlants.length === 0 ? "No plants yet" : "Plants"}
+            </CardTitle>
+            <CardDescription>
+              Plants anchor every photo timeline, finding, and assistant prompt
+              for this grow.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {activePlants.length === 0 ? (
+              <EmptyState
+                action={
+                  <Link
+                    className={buttonStyles({})}
+                    href={`/plants/new?growId=${grow.id}`}
+                  >
+                    Add the first plant
+                  </Link>
+                }
+                description="Add a plant to unlock image uploads, timelines, and assistant workflows for this grow."
+                icon={<PlantIcon className="h-5 w-5" />}
+                title="Add a plant"
+              />
+            ) : (
+              <ul className="space-y-3">
+                {activePlants.map((plant) => (
+                  <li
+                    key={plant.id}
+                    className="flex flex-wrap items-center justify-between gap-3 rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3"
+                  >
+                    <div className="space-y-1">
+                      <p className="text-base font-semibold text-foreground">
+                        {plant.name}
+                      </p>
+                      <p className="text-sm leading-6 text-muted-foreground">
+                        {plant.strain ?? "Strain pending"}
+                        {plant.batchLabel ? ` · ${plant.batchLabel}` : ""}
+                      </p>
+                    </div>
+                    <Link
+                      className={buttonStyles({
+                        size: "sm",
+                        variant: "surface",
+                      })}
+                      href={`/plants/${plant.id}`}
+                    >
+                      Open
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {archivedPlants.length > 0 ? (
+              <details className="mt-4 rounded-[1.1rem] border border-border/60 bg-background-subtle/40 px-4 py-3">
+                <summary className="cursor-pointer text-sm font-medium text-muted-foreground">
+                  {archivedPlants.length} archived plant
+                  {archivedPlants.length === 1 ? "" : "s"}
+                </summary>
+                <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                  {archivedPlants.map((plant) => (
+                    <li
+                      key={plant.id}
+                      className="flex items-center justify-between gap-3"
+                    >
+                      <span>{plant.name}</span>
+                      <Link
+                        className="text-accent underline"
+                        href={`/plants/${plant.id}`}
+                      >
+                        Open
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              </details>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Grow metadata</CardTitle>
+            <CardDescription>
+              The structural details that anchor every analysis and alert.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-sm">
+              <dt className="text-muted-foreground">Stage</dt>
+              <dd className="text-foreground">{titleCase(grow.stage)}</dd>
+
+              <dt className="text-muted-foreground">Medium</dt>
+              <dd className="text-foreground">{titleCase(grow.medium)}</dd>
+
+              <dt className="text-muted-foreground">Light</dt>
+              <dd className="text-foreground">{titleCase(grow.lightType)}</dd>
+
+              <dt className="text-muted-foreground">Start</dt>
+              <dd className="text-foreground">{formatDate(grow.startDate)}</dd>
+
+              <dt className="text-muted-foreground">Target harvest</dt>
+              <dd className="text-foreground">
+                {formatDate(grow.targetHarvestDate)}
+              </dd>
+
+              <dt className="text-muted-foreground">Status</dt>
+              <dd className="text-foreground">
+                {grow.isArchived ? "Archived" : "Active"}
+              </dd>
+            </dl>
+            <div className="mt-5 border-t border-border/60 pt-4">
+              <ArchiveButton growId={grow.id} isArchived={grow.isArchived} />
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                {grow.isArchived
+                  ? "Restoring a grow brings it back to active state. If another active grow already uses this name, rename one first."
+                  : "Archiving keeps history but hides the grow from active workflows. You can restore it anytime."}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>What this grow unlocks</CardTitle>
+            <CardDescription>
+              Every workflow in PhenoSage is anchored to a grow record.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm leading-6 text-muted-foreground">
+            <div className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3">
+              Photo uploads, timelines, and AI-generated findings attach to
+              plants under this grow.
+            </div>
+            <div className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3">
+              Assistant conversations can be scoped here for grounded
+              recommendations.
+            </div>
+            <div className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3">
+              Daily alert digests roll up findings by grow.
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Quick actions</CardTitle>
+            <CardDescription>The fastest paths from here.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Link
+              className={buttonStyles({ size: "md", variant: "surface" })}
+              href={`/plants/new?growId=${grow.id}`}
+            >
+              <PlantIcon className="h-4 w-4" />
+              Add a plant
+            </Link>
+            <Link
+              className={buttonStyles({ size: "md", variant: "surface" })}
+              href="/assistant"
+            >
+              <GrowIcon className="h-4 w-4" />
+              Open the assistant
+            </Link>
+          </CardContent>
+        </Card>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -69,17 +69,17 @@ describe("createGrowAction", () => {
     mocks.logServerEvent.mockReset();
   });
 
-  it("returns success and redirects into the add-plant flow with the new grow id", async () => {
+  it("returns success and redirects to the new grow's detail page", async () => {
     mocks.single.mockResolvedValue({
       data: { id: "grow-new-123" },
       error: null,
     });
     const result = await createGrowAction(buildFormData());
     expect(result.status).toBe("success");
-    // Redirect now lands on the grow registry with the new grow
-    // highlighted, so the user sees the grow they just created instead
-    // of being force-funneled into a plant-intake form.
-    expect(result.redirectTo).toBe("/grows?growId=grow-new-123&just_created=1");
+    // Redirect now lands on /grows/[id] so the user sees the grow they
+    // just created. useActionWithRecovery's fallbackUrl=/grows covers
+    // the case where the detail page is unreachable.
+    expect(result.redirectTo).toBe("/grows/grow-new-123?just_created=1");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/plants");
     expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard");
@@ -91,9 +91,48 @@ describe("createGrowAction", () => {
       error: null,
     });
     const result = await createGrowAction(buildFormData());
-    expect(result.redirectTo).toBe(
-      "/grows?growId=abc%2Fdef%3Fweird&just_created=1",
+    expect(result.redirectTo).toBe("/grows/abc%2Fdef%3Fweird?just_created=1");
+  });
+
+  it("rejects descriptions longer than 2,000 characters as a fieldError", async () => {
+    const result = await createGrowAction(
+      buildFormData({ description: "x".repeat(2_001) }),
     );
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.description).toMatch(/2000 characters/i);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("accepts descriptions exactly at the 2,000-character limit", async () => {
+    mocks.single.mockResolvedValue({
+      data: { id: "g-ok" },
+      error: null,
+    });
+    const result = await createGrowAction(
+      buildFormData({ description: "x".repeat(2_000) }),
+    );
+    expect(result.status).toBe("success");
+  });
+
+  it("rejects start dates more than a day in the future", async () => {
+    const tooFar = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .slice(0, 10);
+    const result = await createGrowAction(buildFormData({ startDate: tooFar }));
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.startDate).toMatch(/day in the future/i);
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
+  it("allows historical start dates (data-entry catching up after the cycle began)", async () => {
+    mocks.single.mockResolvedValue({
+      data: { id: "g-old" },
+      error: null,
+    });
+    const result = await createGrowAction(
+      buildFormData({ startDate: "2020-01-01" }),
+    );
+    expect(result.status).toBe("success");
   });
 
   it("surfaces a friendly duplicate-name message on 23505 without leaking raw error text", async () => {

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -36,8 +36,19 @@ const validLightTypes = new Set<LightType>([
   "other",
 ]);
 
+// Mirrors the chat tool's MAX_NOTES_LENGTH so both create paths agree
+// on prose size. The DB column is unbounded `text`; cap here to keep
+// list views renderable and lock out paste-bomb fat-fingers.
+const MAX_DESCRIPTION_LENGTH = 2_000;
+
+// Mirrors the chat tool's isoDateNotFarFuture refinement: past start
+// dates are allowed (data-entry catching up is the common case), but
+// the future side is clamped to avoid year-9999 fat-finger inputs.
+const MAX_FUTURE_START_MS = 24 * 60 * 60 * 1000;
+
 export type CreateGrowActionResult = {
   fieldErrors?: {
+    description?: string;
     lightType?: string;
     medium?: string;
     name?: string;
@@ -89,6 +100,10 @@ export async function createGrowAction(
     fieldErrors.name = "Keep the grow name under 120 characters.";
   }
 
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    fieldErrors.description = `Keep the description under ${MAX_DESCRIPTION_LENGTH} characters.`;
+  }
+
   if (!validStages.has(stage as GrowStage)) {
     fieldErrors.stage = "Choose a valid grow stage.";
   }
@@ -105,6 +120,9 @@ export async function createGrowAction(
     fieldErrors.startDate = "Start date is required.";
   } else if (!isIsoDate(startDate)) {
     fieldErrors.startDate = "Use a valid start date.";
+  } else if (Date.parse(startDate) > Date.now() + MAX_FUTURE_START_MS) {
+    fieldErrors.startDate =
+      "Start date can't be more than a day in the future.";
   }
 
   if (targetHarvestDate) {
@@ -185,14 +203,12 @@ export async function createGrowAction(
   // as an error boundary hit. Letting the client perform router.push avoids
   // that entire failure mode.
   //
-  // Land on the grow registry with the new grow highlighted so the user
-  // sees what they just created. The previous redirect to /plants/new
-  // visually buried the success in a plant-intake form, which made the
-  // action feel like it had failed. The registry page recognises the
-  // `just_created=1` flag and shows a recovery-friendly banner with
-  // both "Add a plant" and "View grow registry" CTAs.
+  // Land on the grow detail page so the user immediately sees the grow
+  // they just created with plant intake one click away. The form's
+  // useActionWithRecovery falls back to /grows if /grows/[id] is
+  // unreachable for any reason, so users are never stranded.
   const redirectTo = newGrowId
-    ? `/grows?growId=${encodeURIComponent(newGrowId)}&just_created=1`
+    ? `/grows/${encodeURIComponent(newGrowId)}?just_created=1`
     : "/grows";
   return {
     message: "Grow created.",

--- a/apps/web/src/app/(app)/grows/new/grow-form.tsx
+++ b/apps/web/src/app/(app)/grows/new/grow-form.tsx
@@ -13,6 +13,7 @@ import {
 
 const FIELD_META = {
   name: { label: "Grow name", targetId: "grow-name" },
+  description: { label: "Description", targetId: "grow-description" },
   stage: { label: "Stage", targetId: "grow-stage" },
   medium: { label: "Medium", targetId: "grow-medium" },
   lightType: { label: "Light type", targetId: "grow-light-type" },
@@ -288,15 +289,26 @@ export function GrowForm({ initialStartDate }: { initialStartDate: string }) {
           Description
         </label>
         <textarea
+          aria-describedby={describedBy(
+            "grow-description",
+            Boolean(state.fieldErrors?.description),
+          )}
+          aria-invalid={Boolean(state.fieldErrors?.description) || undefined}
           className={`${inputClassName} min-h-[120px] resize-y`}
           id="grow-description"
+          maxLength={2_000}
           name="description"
           onChange={(event) => setDescription(event.target.value)}
           placeholder="Where this grow lives, the cultivar, or anything you'd want to remember later."
           value={description}
         />
+        <FieldError
+          fieldId="grow-description"
+          message={state.fieldErrors?.description}
+        />
         <p className="mt-2 text-sm text-muted-foreground">
-          Optional. Use this for location, room constraints, or handoff notes.
+          Optional. Use this for location, room constraints, or handoff notes
+          (up to 2,000 characters).
         </p>
       </div>
 

--- a/apps/web/src/app/(app)/grows/page.tsx
+++ b/apps/web/src/app/(app)/grows/page.tsx
@@ -53,11 +53,10 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
     : null;
 
   // `just_created=1` signals the user just completed the new-grow form.
-  // We surface a banner naming the grow so the action's success is
-  // obviously visible — and we tolerate read-after-write lag by
-  // falling back to "Grow created" when the row isn't yet in the
-  // overview slice. Either way the registry below is the user's
-  // confirmation that the grow exists.
+  // The current redirect lands on /grows/[id]?just_created=1, so this
+  // path only fires when the form's recovery CTA (or an old
+  // bookmark) lands here instead. We still surface the banner so the
+  // fallback path is just as confirmation-rich as the happy path.
   const justCreated = firstParam(resolvedParams?.just_created) === "1";
   const justCreatedGrowId = justCreated
     ? firstParam(resolvedParams?.growId)
@@ -124,8 +123,19 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
             uploads and assistant context, or keep exploring the registry.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
+            {justCreatedGrow ? (
+              <Link
+                className={buttonStyles({ size: "sm" })}
+                href={`/grows/${justCreatedGrow.id}`}
+              >
+                Open the grow
+              </Link>
+            ) : null}
             <Link
-              className={buttonStyles({ size: "sm" })}
+              className={buttonStyles({
+                size: "sm",
+                variant: justCreatedGrow ? "surface" : "primary",
+              })}
               href={
                 justCreatedGrow
                   ? `/plants/new?growId=${justCreatedGrow.id}`
@@ -133,12 +143,6 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
               }
             >
               Add a plant
-            </Link>
-            <Link
-              className={buttonStyles({ size: "sm", variant: "surface" })}
-              href="/grows"
-            >
-              View grow registry
             </Link>
           </div>
         </div>
@@ -161,17 +165,28 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
                 {overview.grows.map((grow) => (
                   <div
                     key={grow.id}
-                    className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-4"
+                    className={
+                      "rounded-[1.15rem] border px-4 py-4 transition " +
+                      (grow.isArchived
+                        ? "border-border/50 bg-background-subtle/30 opacity-80"
+                        : "border-border/70 bg-background-subtle/60")
+                    }
                   >
                     <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
                       <div className="space-y-2">
                         <div className="flex flex-wrap items-center gap-2">
-                          <p className="text-base font-semibold text-foreground">
+                          <Link
+                            className="text-base font-semibold text-foreground hover:underline"
+                            href={`/grows/${grow.id}`}
+                          >
                             {grow.name}
-                          </p>
+                          </Link>
                           <Badge tone="accent">
                             {grow.stage ?? "stage pending"}
                           </Badge>
+                          {grow.isArchived ? (
+                            <Badge tone="default">Archived</Badge>
+                          ) : null}
                         </div>
                         <p className="text-sm leading-6 text-muted-foreground">
                           {grow.plantCount} plants · {grow.imageCount} captures
@@ -182,27 +197,40 @@ export default async function GrowsPage({ searchParams }: GrowsPageProps) {
                           {grow.lightType ?? "light profile pending"}
                         </p>
                       </div>
-                      {grow.primaryPlantId ? (
+                      <div className="flex flex-wrap gap-2">
                         <Link
                           className={buttonStyles({
                             size: "sm",
                             variant: "surface",
                           })}
-                          href={`/plants/${grow.primaryPlantId}`}
+                          href={`/grows/${grow.id}`}
                         >
-                          Open {grow.primaryPlantName ?? "plant"}
+                          Open grow
                         </Link>
-                      ) : (
-                        <Link
-                          className={buttonStyles({
-                            size: "sm",
-                            variant: "surface",
-                          })}
-                          href={`/plants/new?growId=${grow.id}`}
-                        >
-                          Add plant
-                        </Link>
-                      )}
+                        {!grow.isArchived ? (
+                          grow.primaryPlantId ? (
+                            <Link
+                              className={buttonStyles({
+                                size: "sm",
+                                variant: "surface",
+                              })}
+                              href={`/plants/${grow.primaryPlantId}`}
+                            >
+                              Open {grow.primaryPlantName ?? "plant"}
+                            </Link>
+                          ) : (
+                            <Link
+                              className={buttonStyles({
+                                size: "sm",
+                                variant: "surface",
+                              })}
+                              href={`/plants/new?growId=${grow.id}`}
+                            >
+                              Add plant
+                            </Link>
+                          )
+                        ) : null}
+                      </div>
                     </div>
                   </div>
                 ))}

--- a/apps/web/src/lib/server/__tests__/workspace-overview.test.ts
+++ b/apps/web/src/lib/server/__tests__/workspace-overview.test.ts
@@ -20,7 +20,13 @@ type QueryResult = {
 function makeSupabaseMock(results: Record<TableName, QueryResult>) {
   const from = vi.fn((table: TableName) => {
     const limit = vi.fn().mockResolvedValue(results[table]);
-    const order = vi.fn(() => ({ limit }));
+    // supabase-js's .order() is chainable. The grows query now stacks
+    // two orderings (archived ASC, updated_at DESC); mirror that so
+    // the mock matches real behaviour.
+    const order: ReturnType<typeof vi.fn> = vi.fn(() => ({
+      limit,
+      order,
+    }));
     const select = vi.fn(() => ({ order }));
     return { select };
   });

--- a/apps/web/src/lib/server/__tests__/workspace-records.test.ts
+++ b/apps/web/src/lib/server/__tests__/workspace-records.test.ts
@@ -20,8 +20,12 @@ type QueryResult = {
 };
 
 function makeSupabaseMock(result: QueryResult) {
+  // supabase-js makes `.order()` chainable so callers can stack
+  // multiple orderings (e.g. archived ASC, then updated_at DESC).
+  // Mirror that here so the test fixture reflects how the real
+  // client behaves.
   const limit = vi.fn().mockResolvedValue(result);
-  const order = vi.fn(() => ({ limit }));
+  const order: ReturnType<typeof vi.fn> = vi.fn(() => ({ limit, order }));
   const select = vi.fn(() => ({ order }));
   const from = vi.fn(() => ({ select }));
 
@@ -56,12 +60,23 @@ describe("workspace-records", () => {
       data: [
         {
           id: "grow-1",
+          is_archived: false,
           light_type: "LED",
           medium: "coco",
           name: "Flower tent",
           stage: "flower",
           start_date: "2026-04-01",
           updated_at: "2026-05-01T00:00:00Z",
+        },
+        {
+          id: "grow-old",
+          is_archived: true,
+          light_type: "HPS",
+          medium: "soil",
+          name: "Winter run",
+          stage: "harvest",
+          start_date: "2025-09-01",
+          updated_at: "2025-12-20T00:00:00Z",
         },
       ],
       error: null,
@@ -71,6 +86,7 @@ describe("workspace-records", () => {
     await expect(listAccessibleGrows()).resolves.toEqual([
       {
         id: "grow-1",
+        isArchived: false,
         lightType: "LED",
         medium: "coco",
         name: "Flower tent",
@@ -78,12 +94,28 @@ describe("workspace-records", () => {
         startDate: "2026-04-01",
         updatedAt: "2026-05-01T00:00:00Z",
       },
+      {
+        id: "grow-old",
+        isArchived: true,
+        lightType: "HPS",
+        medium: "soil",
+        name: "Winter run",
+        stage: "harvest",
+        startDate: "2025-09-01",
+        updatedAt: "2025-12-20T00:00:00Z",
+      },
     ]);
     expect(from).toHaveBeenCalledWith("grows");
     expect(select).toHaveBeenCalledWith(
-      "id,name,stage,medium,light_type,start_date,updated_at",
+      "id,name,stage,medium,light_type,start_date,is_archived,updated_at",
     );
-    expect(order).toHaveBeenCalledWith("updated_at", { ascending: false });
+    // Active grows first (is_archived ASC), then most-recently-updated.
+    expect(order).toHaveBeenNthCalledWith(1, "is_archived", {
+      ascending: true,
+    });
+    expect(order).toHaveBeenNthCalledWith(2, "updated_at", {
+      ascending: false,
+    });
     expect(limit).toHaveBeenCalledWith(100);
   });
 

--- a/apps/web/src/lib/server/workspace-overview.ts
+++ b/apps/web/src/lib/server/workspace-overview.ts
@@ -4,6 +4,7 @@ import { logServerEvent } from "./request-id";
 
 type GrowRow = {
   id: string;
+  is_archived: boolean | null;
   light_type: string | null;
   medium: string | null;
   name: string;
@@ -39,6 +40,7 @@ type FindingRow = {
 export type GrowOverview = {
   id: string;
   imageCount: number;
+  isArchived: boolean;
   lightType: string | null;
   medium: string | null;
   name: string;
@@ -128,7 +130,10 @@ export async function getWorkspaceOverview(): Promise<WorkspaceOverview> {
     await Promise.allSettled([
       supabase
         .from("grows")
-        .select("id,name,stage,medium,light_type,start_date,updated_at")
+        .select(
+          "id,name,stage,medium,light_type,start_date,is_archived,updated_at",
+        )
+        .order("is_archived", { ascending: true })
         .order("updated_at", { ascending: false })
         .limit(12),
       supabase
@@ -218,6 +223,7 @@ export async function getWorkspaceOverview(): Promise<WorkspaceOverview> {
       return {
         id: grow.id,
         imageCount: growImages.length,
+        isArchived: grow.is_archived ?? false,
         lightType: grow.light_type,
         medium: grow.medium,
         name: grow.name,
@@ -230,7 +236,13 @@ export async function getWorkspaceOverview(): Promise<WorkspaceOverview> {
         updatedAt: grow.updated_at,
       } satisfies GrowOverview;
     })
-    .sort(compareUpdatedAtDescending);
+    .sort((a, b) => {
+      // Active grows first, archived last. Within each group preserve
+      // the existing updated_at DESC ordering so the rest of the
+      // dashboard sees the freshest grows at the top.
+      if (a.isArchived !== b.isArchived) return a.isArchived ? 1 : -1;
+      return compareUpdatedAtDescending(a, b);
+    });
 
   // Recent activity should reflect items that still need operator attention.
   // Including resolved findings here misleads the dashboard "open watch

--- a/apps/web/src/lib/server/workspace-records.ts
+++ b/apps/web/src/lib/server/workspace-records.ts
@@ -4,11 +4,35 @@ import { logServerEvent } from "./request-id";
 
 type GrowRow = {
   id: string;
+  is_archived?: boolean;
   light_type: string | null;
   medium: string | null;
   name: string;
   stage: string | null;
   start_date: string | null;
+  updated_at: string;
+};
+
+type GrowDetailRow = {
+  description: string | null;
+  id: string;
+  is_archived: boolean;
+  light_type: string | null;
+  medium: string | null;
+  name: string;
+  owner_id: string;
+  stage: string | null;
+  start_date: string | null;
+  target_harvest_date: string | null;
+  updated_at: string;
+};
+
+type GrowPlantRow = {
+  batch_label: string | null;
+  id: string;
+  is_archived: boolean;
+  name: string;
+  strain: string | null;
   updated_at: string;
 };
 
@@ -31,11 +55,35 @@ type PlantRow = {
 
 export type GrowRecord = {
   id: string;
+  isArchived: boolean;
   lightType: string | null;
   medium: string | null;
   name: string;
   stage: string | null;
   startDate: string | null;
+  updatedAt: string;
+};
+
+export type GrowDetail = {
+  description: string | null;
+  id: string;
+  isArchived: boolean;
+  lightType: string | null;
+  medium: string | null;
+  name: string;
+  ownerId: string;
+  stage: string | null;
+  startDate: string | null;
+  targetHarvestDate: string | null;
+  updatedAt: string;
+};
+
+export type GrowPlantSummary = {
+  batchLabel: string | null;
+  id: string;
+  isArchived: boolean;
+  name: string;
+  strain: string | null;
   updatedAt: string;
 };
 
@@ -76,9 +124,15 @@ export async function listAccessibleGrows(): Promise<GrowRecord[]> {
     return [];
   }
 
+  // Order: active grows first (is_archived=false), then archived,
+  // each group by updated_at DESC. Showing archived rows inline (not
+  // hidden behind a toggle) is a deliberate product call so users
+  // don't lose old data they need to reference. The Archived badge
+  // in the registry makes the state obvious.
   const { data, error } = await supabase
     .from("grows")
-    .select("id,name,stage,medium,light_type,start_date,updated_at")
+    .select("id,name,stage,medium,light_type,start_date,is_archived,updated_at")
+    .order("is_archived", { ascending: true })
     .order("updated_at", { ascending: false })
     .limit(100);
 
@@ -93,6 +147,7 @@ export async function listAccessibleGrows(): Promise<GrowRecord[]> {
 
   return ((data ?? []) as GrowRow[]).map((grow) => ({
     id: grow.id,
+    isArchived: grow.is_archived ?? false,
     lightType: grow.light_type,
     medium: grow.medium,
     name: grow.name,
@@ -100,6 +155,87 @@ export async function listAccessibleGrows(): Promise<GrowRecord[]> {
     startDate: grow.start_date,
     updatedAt: grow.updated_at,
   }));
+}
+
+// Fetch a single grow + its plant summaries. Returns null if the row
+// isn't accessible (RLS, missing, or query failure). Degrading to null
+// — rather than throwing — lets the detail page render a clean
+// "not found" state instead of a 500.
+export async function fetchGrowDetail(
+  growId: string,
+): Promise<{ grow: GrowDetail; plants: GrowPlantSummary[] } | null> {
+  if (!hasSupabaseEnv() || !growId) return null;
+
+  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  try {
+    supabase = await createSupabaseServerClient();
+  } catch (err) {
+    logServerEvent("error", "fetch grow detail client init failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+
+  const { data: growData, error: growError } = await supabase
+    .from("grows")
+    .select(
+      "id,name,description,stage,medium,light_type,start_date,target_harvest_date,is_archived,owner_id,updated_at",
+    )
+    .eq("id", growId)
+    .maybeSingle();
+
+  if (growError || !growData) {
+    if (growError) {
+      logServerEvent("error", "fetch grow detail query failed", {
+        error: growError.message,
+        growId,
+      });
+    }
+    return null;
+  }
+  const grow = growData as GrowDetailRow;
+
+  const { data: plantsData, error: plantsError } = await supabase
+    .from("plants")
+    .select("id,name,strain,batch_label,is_archived,updated_at")
+    .eq("grow_id", growId)
+    .order("is_archived", { ascending: true })
+    .order("updated_at", { ascending: false })
+    .limit(200);
+
+  if (plantsError) {
+    // Plant list is best-effort — surface the grow with an empty plant
+    // list rather than failing the whole page.
+    logServerEvent("error", "fetch grow plants query failed", {
+      error: plantsError.message,
+      growId,
+    });
+  }
+  const plants = ((plantsData ?? []) as GrowPlantRow[]).map((p) => ({
+    batchLabel: p.batch_label,
+    id: p.id,
+    isArchived: p.is_archived,
+    name: p.name,
+    strain: p.strain,
+    updatedAt: p.updated_at,
+  }));
+
+  return {
+    grow: {
+      description: grow.description,
+      id: grow.id,
+      isArchived: grow.is_archived,
+      lightType: grow.light_type,
+      medium: grow.medium,
+      name: grow.name,
+      ownerId: grow.owner_id,
+      stage: grow.stage,
+      startDate: grow.start_date,
+      targetHarvestDate: grow.target_harvest_date,
+      updatedAt: grow.updated_at,
+    },
+    plants,
+  };
 }
 
 export async function listAccessiblePlants(): Promise<PlantRecord[]> {

--- a/supabase/migrations/011_grows_integrity.sql
+++ b/supabase/migrations/011_grows_integrity.sql
@@ -1,0 +1,90 @@
+-- Migration: 011_grows_integrity
+--
+-- Closes two correctness gaps in the grows table that the
+-- create-grow audit (PR #145) surfaced:
+--
+--   1. The server action returns "A grow with that name already exists"
+--      when Postgres reports 23505, but no UNIQUE constraint exists on
+--      (owner_id, name) today — so duplicates create silently and the
+--      friendly error is dead code. This migration adds a partial
+--      UNIQUE index on (owner_id, lower(name)) WHERE is_archived = false.
+--      Case-insensitive (so "North Tent" vs "north tent" collide) and
+--      partial (so archiving a grow frees its name for reuse — the
+--      common case after a harvest cycle ends).
+--
+--   2. The application architecture treats `grow_members` as the source
+--      of truth for membership, but no write path inserts the owner's
+--      row on grow creation. Today this works because every RLS policy
+--      ORs `auth.uid() = owner_id` with the grow_members lookup, but
+--      it breaks the contract for any future write path that needs to
+--      enumerate members (collaborator UIs, batch invite flows, audit
+--      reports) and silently breaks the moment an RLS policy drops the
+--      owner_id shortcut. We close it with a trigger so all write
+--      paths (form action, chat tool's create_grow, any future
+--      service-role import) get the owner_members row automatically.
+--
+-- Safety posture:
+--   * The UNIQUE INDEX is partial — already-archived grows don't
+--     consume name space. New duplicate inserts now fail with 23505,
+--     which the application code already handles.
+--   * The trigger function runs SECURITY DEFINER so the owner row
+--     lands even when the inserting role doesn't have INSERT on
+--     grow_members directly (e.g. service-role imports). RLS bypass
+--     is acceptable here: the trigger only inserts a tightly-scoped
+--     (NEW.id, NEW.owner_id, 'owner') row, never user-supplied data.
+--   * The trigger uses ON CONFLICT DO NOTHING so re-running the
+--     migration on an instance where some grows already have
+--     manually-inserted owner rows (none today) is a no-op.
+--   * Backfill: insert (id, owner_id, 'owner') for every existing
+--     grow that doesn't already have it. Idempotent via NOT EXISTS.
+--
+-- Rollback (do NOT run unless explicitly approved):
+--   drop trigger if exists trg_grows_insert_owner_member on grows;
+--   drop function if exists grow_insert_owner_member();
+--   drop index if exists grows_owner_name_unique;
+--   -- Backfilled grow_members rows are kept on rollback so collaborator
+--   -- assignments stay intact — the trigger is what we're removing,
+--   -- not the data integrity invariant it backfills.
+
+-- ─── 1. Partial UNIQUE index on (owner_id, lower(name)) ───────────────
+-- Partial so archived grows free their name; case-insensitive so the UI
+-- doesn't have to normalise. Build CONCURRENTLY is intentionally NOT
+-- used because supabase migrations run inside a transaction; the
+-- expected row count is small (per-user, dozens at most).
+
+create unique index grows_owner_name_unique
+  on grows (owner_id, lower(name))
+  where is_archived = false;
+
+-- ─── 2. Owner → grow_members trigger ──────────────────────────────────
+
+create or replace function grow_insert_owner_member()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into grow_members (grow_id, user_id, role)
+  values (new.id, new.owner_id, 'owner')
+  on conflict (grow_id, user_id) do nothing;
+  return new;
+end;
+$$;
+
+create trigger trg_grows_insert_owner_member
+  after insert on grows
+  for each row
+  execute function grow_insert_owner_member();
+
+-- ─── 3. Backfill existing grows ───────────────────────────────────────
+-- Every existing grow needs its owner row so the new contract holds
+-- universally. Idempotent — re-running this migration is safe.
+
+insert into grow_members (grow_id, user_id, role)
+select g.id, g.owner_id, 'owner'
+from grows g
+where not exists (
+  select 1 from grow_members gm
+  where gm.grow_id = g.id and gm.user_id = g.owner_id
+);


### PR DESCRIPTION
## Why

Builds on PR #145. The audit identified four follow-ups; this PR ships them in one tight pass:

1. **P1 — Dead-code duplicate-name detection** → migration adds the missing UNIQUE constraint
2. **P2 — Missing `grow_members` owner row** → trigger auto-inserts on every grows INSERT
3. **P3 — Server-side validation gaps** → description cap + start-date bounds (parity with the chat tool)
4. **No grow detail page** → new `/grows/[id]` page hosts the archive flow and is the create-grow landing target

After this PR a user can: create a grow → land on its detail page → add a plant → archive when done → restore later (with clear error if the name now collides). Every step uses `useActionWithRecovery` so transient failures don't strand the user.

## Migration 011 — `grows_integrity`

`supabase/migrations/011_grows_integrity.sql`:

- **Partial UNIQUE** index on `(owner_id, lower(name)) WHERE is_archived = false`. Case-insensitive (UI doesn't have to normalise) and partial (archiving frees the name for reuse — common after a harvest cycle).
- **Owner → grow_members trigger** (`SECURITY DEFINER`, `ON CONFLICT DO NOTHING`) so every write path automatically maintains the membership invariant.
- **Backfill** for existing grows so the new contract holds universally. Idempotent.
- Rollback block in the header.

## Detail page — `/grows/[id]`

- Header: name + stage badge + Archived badge when applicable
- Metadata grid: stage / medium / light / start / target / status
- Plant list: active first, archived collapsed in a `<details>`, "Add a plant" CTA preselects this grow
- Archive/Restore action with helper copy
- `?just_created=1` surfaces a confirmation banner identical in tone to the registry's

## Archive flow

- `toggleGrowArchiveAction(growId, nextValue)` — idempotent (caller passes target value), RLS owner-only
- Surfaces a clear restore-collision message when the partial UNIQUE index blocks an unarchive ("another active grow already uses this name — rename one first")
- `<ArchiveButton>` client island uses `useActionWithRecovery` with `/grows` as the fallback URL

## Registry — archived inline

`overview.grows` now selects + sorts on `is_archived` (active first, then by `updated_at DESC`). Archived grows render with an "Archived" badge, muted styling, and the secondary "Add plant / Open plant" CTA hidden so the registry doesn't encourage adding rows to a finished cycle. Card titles link to `/grows/[id]`.

## Form parity with chat tool

- `description` capped at 2000 chars (matches chat tool's `MAX_NOTES_LENGTH`)
- `startDate` clamped to "not more than 1 day in the future" (matches chat tool's `isoDateNotFarFuture`); past dates still allowed for data-entry catching up

## Redirect

`createGrowAction` now returns `redirectTo: /grows/<id>?just_created=1`. The form keeps `/grows` as `useActionWithRecovery`'s fallbackUrl so a missing detail page can't strand the user.

## Tests

Net **+11 tests** on top of the post-#145 baseline (513 → 524).

- `actions.test.ts` (existing) — redirect target + 4 new cases (description cap reject/accept, future-startDate reject, historical-startDate accept)
- `[id]/__tests__/actions.test.ts` (new) — 7 cases covering archive happy path, restore happy path, 23505 collision, RLS-deny, unauthenticated, empty growId, NEXT_REDIRECT passthrough
- `workspace-overview.test.ts` + `workspace-records.test.ts` — chainable `.order()` mock fixtures, new is_archived ordering / payload
- `authenticated-workspace.spec.ts` — Playwright now waits for `/grows/[id]?just_created=1` and clicks the detail page's "Add a plant" CTA

## Validation

- `pnpm turbo run test type-check lint` — 5/5 ✓ (524 tests)
- `pnpm run validate` — ✓
- `pnpm run security:routes` — ✓ (13 routes)
- `pnpm --filter web build` — ✓ (`/grows/[id]` registered)

## Out of scope (deferred to follow-up PRs)

- Edit-grow UI for non-archive metadata (chat tool's `update_grow` is the only path today)
- Stage-transition UI (chat tool's `update_grow_stage` is the only path today)
- Hard-delete with confirmation (today only via Supabase console; FK cascades cover the data side)
- Grow members UI (the trigger now seeds the owner row so a member-list query returns at least one row, unblocking that PR)

## Test plan

- [x] Unit: 524/524
- [x] Type-check + lint via turbo
- [x] Guardrails: validate + security:routes
- [x] Build: `/grows/[id]` registered
- [ ] Manual: create grow → land on `/grows/[id]?just_created=1` → see banner naming the grow → see metadata grid + (empty) plants card → archive → see "Grow archived" → restore
- [ ] Manual: create grow named "Test", create another named "test" → second submission rejected with friendly duplicate-name message (now backed by the real UNIQUE index, no longer dead code)
- [ ] Manual: archive grow → create new grow with same name → succeeds (partial index respects archived state) → unarchive original → see clear restore-collision message


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_