### PR TITLE
ci(supabase): one-click migration apply via workflow_dispatch

### DIFF
--- a/.github/workflows/db-migrations.yml
+++ b/.github/workflows/db-migrations.yml
@@ -1,0 +1,155 @@
+name: Database migrations
+
+# Applies pending Supabase migrations to the linked project. Two paths:
+#
+#   * dry_run = true (default)      → `supabase db diff` shows what
+#                                     WOULD apply. No writes.
+#   * dry_run = false               → `supabase db push` applies the
+#                                     pending migrations forward.
+#
+# Operator-triggered only. There is no `push:` trigger here on purpose
+# — auto-applying a migration on every merge to main means a bad
+# migration lands without a review moment, with no rollback (Postgres
+# DDL inside `supabase db push` runs in a transaction per file but
+# successful files don't roll back). Keeping this as `workflow_dispatch`
+# preserves the explicit go-ahead step that the rollback runbook and
+# deployment docs already assume, while removing the friction of needing
+# a local Supabase CLI + secrets — anyone with workflow_dispatch
+# permission can apply with one click.
+#
+# Required repository secrets:
+#   * SUPABASE_ACCESS_TOKEN   — personal / CI token from Supabase
+#                                Dashboard → Account → Access Tokens.
+#   * SUPABASE_PROJECT_REF    — production project ref (the bit before
+#                                `.supabase.co` in the DB host).
+#   * SUPABASE_DB_PASSWORD    — DB password (required by
+#                                `supabase db push`; the CLI prompts
+#                                for it interactively otherwise).
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry-run only — show pending migrations, do not apply"
+        required: false
+        type: boolean
+        default: true
+      project_ref:
+        description: "Override Supabase project ref (defaults to SUPABASE_PROJECT_REF secret)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: db-migrations-${{ github.event.inputs.project_ref || 'default' }}
+  cancel-in-progress: false
+
+jobs:
+  migrate:
+    name: Apply Supabase migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve project ref
+        id: project
+        shell: bash
+        run: |
+          REF="${{ github.event.inputs.project_ref }}"
+          if [ -z "$REF" ]; then
+            REF="${{ secrets.SUPABASE_PROJECT_REF }}"
+          fi
+          if [ -z "$REF" ]; then
+            echo "::error::SUPABASE_PROJECT_REF secret missing and no project_ref input provided"
+            exit 1
+          fi
+          # Mask the ref in logs since it is effectively the DB host.
+          echo "::add-mask::$REF"
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Link to project
+        run: supabase link --project-ref "${{ steps.project.outputs.ref }}"
+
+      - name: Diff pending migrations (always runs)
+        id: diff
+        shell: bash
+        run: |
+          # `supabase db diff --linked` compares the remote schema
+          # against the local migrations directory and prints what
+          # WOULD change. Non-zero exit only on tool error, not on
+          # "migrations are pending" — so we always print and continue.
+          set -o pipefail
+          supabase db diff --linked --schema public,storage \
+            | tee /tmp/migration-diff.txt
+          echo "diff-path=/tmp/migration-diff.txt" >> "$GITHUB_OUTPUT"
+
+      - name: Apply migrations
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          echo "::notice::Applying pending migrations to $(supabase status --output json | jq -r '.PROJECT_REF // \"linked project\"')"
+          supabase db push --linked
+
+      - name: Verify migration list after apply
+        if: github.event.inputs.dry_run != 'true'
+        run: supabase migration list --linked
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Supabase migrations"
+            echo ""
+            echo "* **Mode:** ${{ github.event.inputs.dry_run == 'true' && 'dry-run (no writes)' || 'apply (writes)' }}"
+            echo "* **Project ref:** \`${{ steps.project.outputs.ref }}\`"
+            echo "* **Triggered by:** @${{ github.actor }}"
+            echo ""
+            if [ -s /tmp/migration-diff.txt ]; then
+              echo "<details><summary>Diff output</summary>"
+              echo ""
+              echo '```sql'
+              cat /tmp/migration-diff.txt
+              echo '```'
+              echo "</details>"
+            else
+              echo "_No diff output captured._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open issue on apply failure
+        if: failure() && github.event.inputs.dry_run != 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Supabase migration apply failed`,
+              body: [
+                `**Triggered by:** @${context.actor}`,
+                `**Workflow run:** ${runUrl}`,
+                "",
+                "The migration apply step exited non-zero. The schema is in an indeterminate state — some files may have applied, later ones may not. Inspect the run logs to identify the last applied migration, then either:",
+                "",
+                "1. Fix-forward by committing a new corrective migration and re-running this workflow, or",
+                "2. Follow `docs/runbooks/rollback.md` to revert.",
+                "",
+                "Do not amend an existing migration file — the migration history is append-only by contract."
+              ].join("\n"),
+              labels: ["bug", "production", "database"]
+            });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -225,12 +225,26 @@ promotion gate.
 ## Supabase Setup
 
 1. Create a new Supabase project
-2. Run migrations:
+2. Run migrations. Two paths:
+
+   **From GitHub Actions (recommended for production).** The
+   [`Database migrations`](../.github/workflows/db-migrations.yml)
+   workflow applies pending migrations via `workflow_dispatch` so any
+   maintainer can ship them with one click without installing the
+   Supabase CLI locally. It defaults to dry-run; flip the `dry_run`
+   input to `false` to actually apply. Requires three repo secrets:
+   `SUPABASE_ACCESS_TOKEN`, `SUPABASE_PROJECT_REF`, and
+   `SUPABASE_DB_PASSWORD`. Failures open a tracking issue
+   automatically.
+
+   **From a workstation (initial bring-up or recovery).**
+
    ```bash
    supabase login
    supabase link --project-ref <your-project-ref>
    supabase db push
    ```
+
 3. In Supabase Storage → create bucket `plant-images` (private)
 4. Enable Email Auth (or your preferred provider) in Supabase Auth settings
 5. Copy the project URL and keys to Vercel environment variables

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,6 +7,7 @@
 **Goal:** A grower can sign up, create a grow, add plants, upload photos, get real AI analysis, and chat about their grow.
 
 ### Web (apps/web)
+
 - [ ] Supabase Auth integration (sign up, sign in, sign out)
 - [ ] Grow creation form
 - [ ] Plant creation form
@@ -18,6 +19,7 @@
 - [ ] Basic responsive layout / mobile compatibility
 
 ### Analysis Service (apps/analysis)
+
 - [ ] Fetch image from Supabase Storage using service role key
 - [ ] GPT-4o Vision call with grow context
 - [ ] Parse structured findings from GPT response
@@ -25,11 +27,13 @@
 - [ ] Health score computation
 
 ### Database
-- [ ] Apply Supabase migrations to production
+
+- [ ] Apply Supabase migrations to production (now one-click via the `Database migrations` GitHub Action — see `docs/deployment.md`)
 - [ ] Verify RLS policies work end-to-end
 - [ ] Set up `plant-images` storage bucket
 
 ### Infrastructure
+
 - [ ] Vercel deployment live
 - [ ] Railway deployment live
 - [ ] CI green on main
@@ -41,6 +45,7 @@
 **Goal:** PhenoSage feels like a polished professional tool. Analysis is accurate and trusted. Tracking is effortless.
 
 ### Features
+
 - [ ] Health score trend graph over time
 - [ ] Finding resolution tracking (mark as resolved)
 - [ ] Grow event log (water, feed, top, LST, etc.)
@@ -54,12 +59,14 @@
 - [ ] Export grow history (PDF or CSV)
 
 ### Analysis Service
+
 - [ ] Refined prompts with few-shot examples
 - [ ] Strain-aware analysis context
 - [ ] Confidence scores per finding
 - [ ] Image quality validation (reject blurry/dark images)
 
 ### Infrastructure
+
 - [ ] Email notifications (Resend or SendGrid)
 - [ ] Supabase Realtime for live findings updates
 - [ ] Error monitoring (Sentry)
@@ -72,6 +79,7 @@
 **Goal:** PhenoSage is the definitive AI platform for serious cannabis cultivators.
 
 ### Features
+
 - [ ] pgvector semantic search over grow history
 - [ ] "Ask about any past grow" AI memory
 - [ ] Automated grow advisor: suggests feed schedule adjustments
@@ -82,6 +90,7 @@
 - [ ] API access for advanced users
 
 ### Infrastructure
+
 - [ ] pgvector enabled for semantic search
 - [ ] Background job queue (Railway worker) for heavy analysis
 - [ ] CDN-optimized image serving


### PR DESCRIPTION
## Why

Per the audit follow-up after merging #147: `docs/deployment.md:111-115` documents migration apply as a manual CLI dance, and `docs/roadmap.md:28` has been carrying "Apply Supabase migrations to production" as unchecked since project start. The result: schema changes ship in code but lag in production. Migration 011 from #147 is in this state right now — committed but unapplied.

## What this PR adds

`.github/workflows/db-migrations.yml` — a `workflow_dispatch` trigger any maintainer can fire from the Actions tab. Two modes:

- **`dry_run = true` (default)** — runs `supabase db diff --linked`, prints the pending changes to the workflow summary, no writes. Safe to run as often as you like to inspect drift.
- **`dry_run = false`** — runs `supabase db push --linked`. Followed by `supabase migration list --linked` to confirm the new state. Failure handler creates a labelled tracking issue with a pointer to `docs/runbooks/rollback.md`.

Optional `project_ref` input lets you target a staging project for a one-off without touching the secret.

## Why `workflow_dispatch` and not `push: main`

Auto-applying on every push to main is the obvious next step but the wrong default here:

1. Migrations are forward-only by repo contract. A half-applied migration leaves the schema in an indeterminate state with no automatic rollback path.
2. `docs/runbooks/rollback.md` assumes a human in the loop before any apply.
3. Some migrations need coordination with the Railway analysis service or feature flags; an auto-apply on merge would beat the coordination window.

`workflow_dispatch` preserves the explicit go-ahead moment while removing the friction that drives the current "applies got forgotten" failure mode. One click from the Actions UI replaces install-CLI + log-in + link + push. Future automation (claude, copilot, on-call humans) can apply without local Supabase credentials.

If your team decides the speed/safety tradeoff later swings the other way, the same job body can be moved under a `push:` trigger.

## Operator setup (one-time)

Three repo secrets:

- `SUPABASE_ACCESS_TOKEN` — Supabase Dashboard → Account → Access Tokens
- `SUPABASE_PROJECT_REF` — production project ref (auto-masked in logs)
- `SUPABASE_DB_PASSWORD` — DB password (else the CLI prompts interactively, which deadlocks a non-TTY runner)

Recommended: also turn on required reviewers for the `production` environment in Settings → Environments. The workflow declares `environment: production`, so any rule you set there gates the apply.

## Safety rails

- `environment: production` so org-level required-reviewer rules apply.
- `concurrency:` keyed on project ref prevents two parallel applies from racing.
- `add-mask` on the project ref so it doesn't appear in logs.
- Failure handler opens a labelled issue (`bug`, `production`, `database`) with the run URL and the rollback runbook reference. No silent failures.
- `migration list` step after apply gives a confirmation that the new migration name is now in the remote state.

## Docs

- `docs/deployment.md` now lists both paths (workflow vs CLI) with guidance on when to use each.
- `docs/roadmap.md` checkbox annotated with the new path so the next person checking that item knows where to click.

## Out of scope (deliberately)

- **PR-time validation** (`supabase db lint` or ephemeral apply on a branch project) — useful but needs a separate Supabase project and non-trivial fixture wiring. Open as a follow-up if you want the additional safety.
- **Auto-apply on push to main** — see "Why workflow_dispatch" above.

## Validation

- `pnpm run validate` — ✓
- `pnpm run security:routes` — ✓ (14 route files)
- `python3 -c "yaml.safe_load(...)"` — ✓ (workflow parses)

## Test plan

- [x] Repo guardrails green
- [x] Workflow YAML parses
- [ ] **Manual (post-merge)**: add the three secrets, then run `Database migrations` from the Actions tab with `dry_run = true` and confirm the diff output names migration 011 as pending.
- [ ] **Manual**: re-run with `dry_run = false` and confirm `supabase migration list --linked` shows `011_grows_integrity` applied. This activates the duplicate-name UNIQUE index and the `grow_members` owner-trigger that PR #147 added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_