### PR TITLE
chore(mcp): add project-scoped Supabase MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "supabase": {
+      "type": "http",
+      "url": "https://mcp.supabase.com/mcp?project_ref=yjemotnclrnlxgcfntaf"
+    }
+  }
+}


### PR DESCRIPTION
## Why

After we shipped migration 011 via the Supabase Dashboard SQL editor, the gap that emerged was that the `supabase_migrations.schema_migrations` history table didn't get a row — so a future `supabase db push` (or the GitHub Action from #148) would re-attempt 011 and fail on the non-idempotent `create unique index` / `create trigger` statements.

The cleanest fix is to give in-session agents direct access to Supabase via MCP, which exposes an `apply_migration` tool that writes both the DDL AND the history row atomically. That removes the manual "did you also record this in schema_migrations?" coordination step for every future migration.

## What this PR adds

`.mcp.json` at the repo root with the Supabase MCP server pointed at the PhenoSage project:

```json
{
  "mcpServers": {
    "supabase": {
      "type": "http",
      "url": "https://mcp.supabase.com/mcp?project_ref=yjemotnclrnlxgcfntaf"
    }
  }
}
```

Generated via the canonical command:

```
claude mcp add --scope project --transport http supabase \
  "https://mcp.supabase.com/mcp?project_ref=yjemotnclrnlxgcfntaf"
```

`--scope project` means the config is committed to the repo, so every maintainer's Claude Code session in this clone gets the server config without per-machine setup. Per-user OAuth tokens are stored in `~/.claude/` and never committed — the file contains no secrets.

## One-time setup per maintainer

After pulling main, run once in your terminal:

```bash
claude /mcp
```

Select `supabase` → Authenticate. The OAuth flow opens in a browser; tokens persist locally.

## What this unlocks

The MCP exposes (incomplete list):

- `list_tables`, `execute_sql`, `list_migrations` — read access for verification
- `apply_migration` — writes DDL + schema_migrations row atomically; the path that would have prevented the gap we hit with 011
- `get_advisors` — security / performance advisories on the schema
- `get_logs` — server-side query/auth/storage logs

For agentic work this means: an agent authoring a migration can author it, run it, verify the advisor returns no new findings, and commit the file — all in one session, with the history table guaranteed consistent.

## Out of scope

- **Read-only mode**: the URL supports `&read_only=true` to restrict to SELECT. Kept read-write here because the primary use case is `apply_migration`, which is a write by definition. Reviewers who want a read-only override can add a local-scoped server alongside this one.
- **The dangling migration 011 history row**: applied separately via SQL editor and recorded with a one-off insert. Captured in the previous conversation.

## Test plan

- [x] `claude mcp add` exited cleanly and wrote a valid `.mcp.json`
- [x] No secrets in the committed config (only the project_ref, which is the public DB host identifier)
- [ ] **Manual (post-merge)**: run `claude /mcp` → Authenticate → confirm `mcp__supabase__list_tables` returns the public schema

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_