### PR TITLE
feat(grows): edit, stage advance, hard-delete on grow detail

### DIFF
--- a/apps/web/src/app/(app)/grows/[id]/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/[id]/__tests__/actions.test.ts
@@ -5,7 +5,15 @@ const mocks = vi.hoisted(() => {
   // final args and resolves with { data, error }.
   const eq = vi.fn();
   const update = vi.fn(() => ({ eq }));
-  const from = vi.fn(() => ({ update }));
+  // delete chain: .delete().eq(...) — separate eq mock so individual
+  // tests can resolve it without affecting the update path.
+  const eqDelete = vi.fn();
+  const del = vi.fn(() => ({ eq: eqDelete }));
+  // select chain: .select(cols).eq(col, val).maybeSingle()
+  const maybeSingle = vi.fn();
+  const eqSelect = vi.fn(() => ({ maybeSingle }));
+  const select = vi.fn(() => ({ eq: eqSelect }));
+  const from = vi.fn(() => ({ update, delete: del, select }));
   const supabaseStub = { from };
   const createSupabaseServerClient = vi.fn(async () => supabaseStub);
   const getServerUser = vi.fn(async () => ({ id: "user-1" }));
@@ -14,6 +22,11 @@ const mocks = vi.hoisted(() => {
   return {
     eq,
     update,
+    eqDelete,
+    del,
+    maybeSingle,
+    eqSelect,
+    select,
     from,
     supabaseStub,
     createSupabaseServerClient,
@@ -36,7 +49,12 @@ vi.mock("@/lib/server/request-id", () => ({
   logServerEvent: mocks.logServerEvent,
 }));
 
-import { toggleGrowArchiveAction } from "../actions";
+import {
+  advanceGrowStageAction,
+  deleteGrowAction,
+  toggleGrowArchiveAction,
+  updateGrowAction,
+} from "../actions";
 
 describe("toggleGrowArchiveAction", () => {
   beforeEach(() => {
@@ -115,5 +133,245 @@ describe("toggleGrowArchiveAction", () => {
     e.digest = "NEXT_REDIRECT;replace;/grows;307;";
     mocks.createSupabaseServerClient.mockRejectedValueOnce(e);
     await expect(toggleGrowArchiveAction("g", true)).rejects.toBe(e);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Helper: mint a FormData with sensible defaults for updateGrowAction.
+// Tests override individual fields via the `overrides` object.
+function makeUpdateForm(
+  overrides: Partial<Record<string, string>> = {},
+): FormData {
+  const fd = new FormData();
+  const base: Record<string, string> = {
+    name: "Tent A",
+    description: "Notes",
+    stage: "vegetative",
+    medium: "soil",
+    lightType: "led",
+    startDate: "2024-01-01",
+    targetHarvestDate: "2024-04-01",
+    ...overrides,
+  };
+  for (const [k, v] of Object.entries(base)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+function resetAllMocks() {
+  mocks.eq.mockReset();
+  mocks.update.mockClear();
+  mocks.eqDelete.mockReset();
+  mocks.del.mockClear();
+  mocks.maybeSingle.mockReset();
+  mocks.eqSelect.mockClear();
+  mocks.select.mockClear();
+  mocks.from.mockClear();
+  mocks.createSupabaseServerClient
+    .mockReset()
+    .mockResolvedValue(mocks.supabaseStub);
+  mocks.getServerUser.mockReset().mockResolvedValue({ id: "user-1" });
+  mocks.revalidatePath.mockReset();
+  mocks.logServerEvent.mockReset();
+}
+
+describe("updateGrowAction", () => {
+  beforeEach(resetAllMocks);
+
+  it("writes the new fields and returns a success redirect", async () => {
+    mocks.eq.mockResolvedValue({ error: null });
+    const result = await updateGrowAction("grow-1", makeUpdateForm());
+
+    expect(mocks.from).toHaveBeenCalledWith("grows");
+    expect(mocks.update).toHaveBeenCalledWith({
+      description: "Notes",
+      light_type: "led",
+      medium: "soil",
+      name: "Tent A",
+      stage: "vegetative",
+      start_date: "2024-01-01",
+      target_harvest_date: "2024-04-01",
+    });
+    expect(mocks.eq).toHaveBeenCalledWith("id", "grow-1");
+    expect(result.status).toBe("success");
+    expect(result.redirectTo).toBe("/grows/grow-1");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows/grow-1");
+  });
+
+  it("collects field-level validation errors without touching supabase", async () => {
+    const fd = makeUpdateForm({
+      name: "",
+      stage: "not-a-stage",
+      startDate: "not-a-date",
+    });
+    const result = await updateGrowAction("grow-1", fd);
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.name).toMatch(/required/i);
+    expect(result.fieldErrors?.stage).toMatch(/valid grow stage/i);
+    expect(result.fieldErrors?.startDate).toMatch(/valid start date/i);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("maps 23505 to a name field error", async () => {
+    mocks.eq.mockResolvedValue({
+      error: { code: "23505", message: "duplicate key value" },
+    });
+    const result = await updateGrowAction("grow-1", makeUpdateForm());
+    expect(result.status).toBe("error");
+    expect(result.fieldErrors?.name).toMatch(/already uses this name/i);
+  });
+
+  it("maps 42501 to an owner-only message", async () => {
+    mocks.eq.mockResolvedValue({
+      error: { code: "42501", message: "permission denied" },
+    });
+    const result = await updateGrowAction("grow-1", makeUpdateForm());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/only the grow owner/i);
+  });
+
+  it("rejects unauthenticated callers without touching supabase", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
+    const result = await updateGrowAction("grow-1", makeUpdateForm());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("re-throws Next framework redirect signals untouched", async () => {
+    const e: Error & { digest?: string } = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT;replace;/grows;307;";
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(e);
+    await expect(updateGrowAction("g", makeUpdateForm())).rejects.toBe(e);
+  });
+});
+
+describe("advanceGrowStageAction", () => {
+  beforeEach(resetAllMocks);
+
+  it("updates the stage and revalidates", async () => {
+    mocks.eq.mockResolvedValue({ error: null });
+    const result = await advanceGrowStageAction("grow-1", "flower");
+    expect(mocks.update).toHaveBeenCalledWith({ stage: "flower" });
+    expect(mocks.eq).toHaveBeenCalledWith("id", "grow-1");
+    expect(result.status).toBe("success");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows/grow-1");
+  });
+
+  it("rejects an unknown stage without touching supabase", async () => {
+    const result = await advanceGrowStageAction(
+      "grow-1",
+      "not-a-stage" as never,
+    );
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/valid grow stage/i);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it("maps 42501 to an owner-only message", async () => {
+    mocks.eq.mockResolvedValue({
+      error: { code: "42501", message: "permission denied" },
+    });
+    const result = await advanceGrowStageAction("grow-1", "flower");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/only the grow owner/i);
+  });
+
+  it("rejects unauthenticated callers", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
+    const result = await advanceGrowStageAction("grow-1", "flower");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteGrowAction", () => {
+  beforeEach(resetAllMocks);
+
+  it("deletes the row when the typed name matches and returns redirectTo", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { id: "grow-1", name: "Tent A", owner_id: "user-1" },
+      error: null,
+    });
+    mocks.eqDelete.mockResolvedValue({ error: null });
+
+    const result = await deleteGrowAction("grow-1", "tent a");
+
+    expect(mocks.select).toHaveBeenCalledWith("id,name,owner_id");
+    expect(mocks.eqSelect).toHaveBeenCalledWith("id", "grow-1");
+    expect(mocks.del).toHaveBeenCalled();
+    expect(mocks.eqDelete).toHaveBeenCalledWith("id", "grow-1");
+    expect(result.status).toBe("success");
+    expect(result.redirectTo).toBe("/grows?deleted=1");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/grows");
+    expect(mocks.revalidatePath).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("rejects when the typed name doesn't match the grow", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { id: "grow-1", name: "Tent A", owner_id: "user-1" },
+      error: null,
+    });
+    const result = await deleteGrowAction("grow-1", "Tent B");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/doesn't match/i);
+    expect(mocks.del).not.toHaveBeenCalled();
+  });
+
+  it("returns success no-op when the grow row is missing (already deleted or RLS-hidden)", async () => {
+    mocks.maybeSingle.mockResolvedValue({ data: null, error: null });
+    const result = await deleteGrowAction("grow-1", "Tent A");
+    expect(result.status).toBe("success");
+    expect(result.redirectTo).toBe("/grows?deleted=1");
+    expect(mocks.del).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-owners even if RLS would allow read (members)", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { id: "grow-1", name: "Tent A", owner_id: "someone-else" },
+      error: null,
+    });
+    const result = await deleteGrowAction("grow-1", "Tent A");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/only the grow owner/i);
+    expect(mocks.del).not.toHaveBeenCalled();
+  });
+
+  it("maps 42501 from delete to an owner-only message", async () => {
+    mocks.maybeSingle.mockResolvedValue({
+      data: { id: "grow-1", name: "Tent A", owner_id: "user-1" },
+      error: null,
+    });
+    mocks.eqDelete.mockResolvedValue({
+      error: { code: "42501", message: "permission denied" },
+    });
+    const result = await deleteGrowAction("grow-1", "Tent A");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/only the grow owner/i);
+  });
+
+  it("rejects empty confirm name without touching supabase", async () => {
+    const result = await deleteGrowAction("grow-1", "   ");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/type the grow name/i);
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthenticated callers without touching supabase", async () => {
+    mocks.getServerUser.mockResolvedValueOnce(null as never);
+    const result = await deleteGrowAction("grow-1", "Tent A");
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/signed in/i);
+    expect(mocks.from).not.toHaveBeenCalled();
+  });
+
+  it("re-throws Next framework redirect signals untouched", async () => {
+    const e: Error & { digest?: string } = new Error("NEXT_REDIRECT");
+    e.digest = "NEXT_REDIRECT;replace;/grows;307;";
+    mocks.createSupabaseServerClient.mockRejectedValueOnce(e);
+    await expect(deleteGrowAction("g", "x")).rejects.toBe(e);
   });
 });

--- a/apps/web/src/app/(app)/grows/[id]/actions.ts
+++ b/apps/web/src/app/(app)/grows/[id]/actions.ts
@@ -1,9 +1,56 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
+import type { GrowMedium, GrowStage, LightType } from "@phenosage/shared";
 import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { logServerEvent } from "@/lib/server/request-id";
+
+// Stage / medium / light vocabularies are duplicated from
+// new/actions.ts on purpose: keeping the two action files independent
+// means a vocabulary tweak in one path can't silently break the other.
+// If the vocabulary set ever stabilises, hoist into @phenosage/shared.
+const validStages: readonly GrowStage[] = [
+  "germination",
+  "seedling",
+  "vegetative",
+  "pre_flower",
+  "flower",
+  "late_flower",
+  "harvest",
+  "dry_cure",
+];
+const validStagesSet = new Set<GrowStage>(validStages);
+const validMedia = new Set<GrowMedium>([
+  "soil",
+  "coco",
+  "hydro",
+  "aero",
+  "living_soil",
+  "other",
+]);
+const validLightTypes = new Set<LightType>([
+  "hps",
+  "cmh",
+  "led",
+  "t5",
+  "sun",
+  "mixed",
+  "other",
+]);
+
+const MAX_DESCRIPTION_LENGTH = 2_000;
+// Past start dates are fine (data-entry catch-up), future capped at
+// one day to lock out year-9999 fat-fingers — same rule as create.
+const MAX_FUTURE_START_MS = 24 * 60 * 60 * 1000;
+
+function asTrimmedString(value: FormDataEntryValue | null) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function isIsoDate(value: string) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(value));
+}
 
 export type ToggleArchiveActionResult = {
   message?: string;
@@ -101,6 +148,406 @@ export async function toggleGrowArchiveAction(
   return {
     message: nextValue ? "Grow archived." : "Grow restored.",
     redirectTo: `/grows/${growId}`,
+    status: "success",
+  };
+}
+
+// ─── update grow ───────────────────────────────────────────────────────
+// Full edit of the mutable grow fields. Ownership is enforced by RLS
+// (`grows: owner write`) so non-owners get a 42501 we surface as a
+// clean message. Validation mirrors createGrowAction so a user can't
+// reach an invalid state via either path.
+
+export type UpdateGrowActionResult = {
+  fieldErrors?: {
+    description?: string;
+    lightType?: string;
+    medium?: string;
+    name?: string;
+    stage?: string;
+    startDate?: string;
+    targetHarvestDate?: string;
+  };
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const updateGrowActionInitialState: UpdateGrowActionResult = {
+  status: "idle",
+};
+
+export async function updateGrowAction(
+  growId: string,
+  formData: FormData,
+): Promise<UpdateGrowActionResult> {
+  const user = await getServerUser();
+  if (!user) {
+    return {
+      message: "You must be signed in to edit a grow.",
+      status: "error",
+    };
+  }
+
+  if (!growId || typeof growId !== "string") {
+    return { message: "Invalid grow id.", status: "error" };
+  }
+
+  const name = asTrimmedString(formData.get("name"));
+  const description = asTrimmedString(formData.get("description"));
+  const stage = asTrimmedString(formData.get("stage"));
+  const medium = asTrimmedString(formData.get("medium"));
+  const lightType = asTrimmedString(formData.get("lightType"));
+  const startDate = asTrimmedString(formData.get("startDate"));
+  const targetHarvestDate = asTrimmedString(formData.get("targetHarvestDate"));
+
+  const fieldErrors: UpdateGrowActionResult["fieldErrors"] = {};
+
+  if (!name) {
+    fieldErrors.name = "Name is required.";
+  } else if (name.length > 120) {
+    fieldErrors.name = "Keep the grow name under 120 characters.";
+  }
+
+  if (description.length > MAX_DESCRIPTION_LENGTH) {
+    fieldErrors.description = `Keep the description under ${MAX_DESCRIPTION_LENGTH} characters.`;
+  }
+
+  if (!validStagesSet.has(stage as GrowStage)) {
+    fieldErrors.stage = "Choose a valid grow stage.";
+  }
+
+  if (!validMedia.has(medium as GrowMedium)) {
+    fieldErrors.medium = "Choose a valid medium.";
+  }
+
+  if (!validLightTypes.has(lightType as LightType)) {
+    fieldErrors.lightType = "Choose a valid light type.";
+  }
+
+  if (!startDate) {
+    fieldErrors.startDate = "Start date is required.";
+  } else if (!isIsoDate(startDate)) {
+    fieldErrors.startDate = "Use a valid start date.";
+  } else if (Date.parse(startDate) > Date.now() + MAX_FUTURE_START_MS) {
+    fieldErrors.startDate =
+      "Start date can't be more than a day in the future.";
+  }
+
+  if (targetHarvestDate) {
+    if (!isIsoDate(targetHarvestDate)) {
+      fieldErrors.targetHarvestDate = "Use a valid target harvest date.";
+    } else if (
+      startDate &&
+      isIsoDate(startDate) &&
+      targetHarvestDate < startDate
+    ) {
+      fieldErrors.targetHarvestDate =
+        "Target harvest date must be on or after the start date.";
+    }
+  }
+
+  if (Object.keys(fieldErrors).length > 0) {
+    return {
+      fieldErrors,
+      message: "Fix the highlighted fields and try again.",
+      status: "error",
+    };
+  }
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { error } = await supabase
+      .from("grows")
+      .update({
+        description: description || null,
+        light_type: lightType as LightType,
+        medium: medium as GrowMedium,
+        name,
+        stage: stage as GrowStage,
+        start_date: startDate,
+        target_harvest_date: targetHarvestDate || null,
+      })
+      .eq("id", growId);
+
+    if (error) {
+      logServerEvent("error", "update grow failed", {
+        error: error.message,
+        code: error.code,
+        growId,
+        userId: user.id,
+      });
+      if (error.code === "23505") {
+        // Partial UNIQUE on (owner_id, lower(name)) WHERE is_archived=false
+        return {
+          fieldErrors: {
+            name: "Another active grow already uses this name.",
+          },
+          message: "Pick a different name and try again.",
+          status: "error",
+        };
+      }
+      if (error.code === "42501" || /row-level security/i.test(error.message)) {
+        return {
+          message: "Only the grow owner can edit this grow.",
+          status: "error",
+        };
+      }
+      return {
+        message: "We couldn't save your changes right now. Please try again.",
+        status: "error",
+      };
+    }
+  } catch (err) {
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "update grow action threw", {
+      error: err instanceof Error ? err.message : String(err),
+      growId,
+      userId: user.id,
+    });
+    return {
+      message: "We couldn't save your changes right now. Please try again.",
+      status: "error",
+    };
+  }
+
+  revalidatePath("/grows");
+  revalidatePath(`/grows/${growId}`);
+  revalidatePath("/dashboard");
+
+  return {
+    message: "Grow updated.",
+    redirectTo: `/grows/${growId}`,
+    status: "success",
+  };
+}
+
+// ─── advance grow stage ────────────────────────────────────────────────
+// One-click stage transition used by the detail page's stepper. Allows
+// any vocabulary stage as the next value (forward and backward) — the
+// stepper UI presents the linear "next" option, but a future panel that
+// lets owners jump backward shouldn't have to introduce a second
+// action. Owner-only via RLS.
+
+export type AdvanceGrowStageActionResult = {
+  message?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const advanceGrowStageActionInitialState: AdvanceGrowStageActionResult =
+  {
+    status: "idle",
+  };
+
+export async function advanceGrowStageAction(
+  growId: string,
+  nextStage: GrowStage,
+): Promise<AdvanceGrowStageActionResult> {
+  const user = await getServerUser();
+  if (!user) {
+    return {
+      message: "You must be signed in to update the grow stage.",
+      status: "error",
+    };
+  }
+
+  if (!growId || typeof growId !== "string") {
+    return { message: "Invalid grow id.", status: "error" };
+  }
+
+  if (!validStagesSet.has(nextStage)) {
+    return { message: "Choose a valid grow stage.", status: "error" };
+  }
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { error } = await supabase
+      .from("grows")
+      .update({ stage: nextStage })
+      .eq("id", growId);
+
+    if (error) {
+      logServerEvent("error", "advance grow stage failed", {
+        error: error.message,
+        code: error.code,
+        growId,
+        userId: user.id,
+        nextStage,
+      });
+      if (error.code === "42501" || /row-level security/i.test(error.message)) {
+        return {
+          message: "Only the grow owner can change the stage.",
+          status: "error",
+        };
+      }
+      return {
+        message: "We couldn't update the stage right now. Please try again.",
+        status: "error",
+      };
+    }
+  } catch (err) {
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "advance grow stage threw", {
+      error: err instanceof Error ? err.message : String(err),
+      growId,
+      userId: user.id,
+    });
+    return {
+      message: "We couldn't update the stage right now. Please try again.",
+      status: "error",
+    };
+  }
+
+  revalidatePath("/grows");
+  revalidatePath(`/grows/${growId}`);
+  revalidatePath("/dashboard");
+
+  return { message: `Stage set to ${nextStage}.`, status: "success" };
+}
+
+// ─── hard delete grow ──────────────────────────────────────────────────
+// Destructive. Requires the user to retype the grow name (case- and
+// whitespace-insensitive) — same friction pattern GitHub uses for repo
+// deletion. RLS pins this to owners; FK cascades cleanly drop plants,
+// images, analyses, jobs, members, tasks, observations, events, and
+// findings. `chat_threads.grow_id` is SET NULL on purpose, so any
+// assistant chat scoped here unscope's rather than disappearing.
+
+export type DeleteGrowActionResult = {
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const deleteGrowActionInitialState: DeleteGrowActionResult = {
+  status: "idle",
+};
+
+function normaliseName(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export async function deleteGrowAction(
+  growId: string,
+  confirmName: string,
+): Promise<DeleteGrowActionResult> {
+  const user = await getServerUser();
+  if (!user) {
+    return {
+      message: "You must be signed in to delete a grow.",
+      status: "error",
+    };
+  }
+
+  if (!growId || typeof growId !== "string") {
+    return { message: "Invalid grow id.", status: "error" };
+  }
+
+  const typed = typeof confirmName === "string" ? confirmName : "";
+  if (!typed.trim()) {
+    return {
+      message: "Type the grow name exactly to confirm deletion.",
+      status: "error",
+    };
+  }
+
+  try {
+    const supabase = await createSupabaseServerClient();
+
+    // Read the row first so the confirmation guard can't be defeated by
+    // forging the form's hidden name. Membership is RLS-gated so this
+    // also doubles as the access check before destructive work.
+    const { data: existing, error: readError } = await supabase
+      .from("grows")
+      .select("id,name,owner_id")
+      .eq("id", growId)
+      .maybeSingle();
+
+    if (readError) {
+      logServerEvent("error", "delete grow read failed", {
+        error: readError.message,
+        code: readError.code,
+        growId,
+        userId: user.id,
+      });
+      return {
+        message: "We couldn't load the grow to delete. Please try again.",
+        status: "error",
+      };
+    }
+
+    if (!existing) {
+      // Either deleted already or RLS hid it. Treat as a successful
+      // no-op so the UI can navigate away cleanly.
+      revalidatePath("/grows");
+      revalidatePath("/dashboard");
+      return {
+        message: "Grow deleted.",
+        redirectTo: "/grows?deleted=1",
+        status: "success",
+      };
+    }
+
+    if (existing.owner_id !== user.id) {
+      return {
+        message: "Only the grow owner can delete it.",
+        status: "error",
+      };
+    }
+
+    if (normaliseName(existing.name) !== normaliseName(typed)) {
+      return {
+        message:
+          "The name you typed doesn't match. Type the grow name exactly to confirm.",
+        status: "error",
+      };
+    }
+
+    const { error: deleteError } = await supabase
+      .from("grows")
+      .delete()
+      .eq("id", growId);
+
+    if (deleteError) {
+      logServerEvent("error", "delete grow failed", {
+        error: deleteError.message,
+        code: deleteError.code,
+        growId,
+        userId: user.id,
+      });
+      if (
+        deleteError.code === "42501" ||
+        /row-level security/i.test(deleteError.message)
+      ) {
+        return {
+          message: "Only the grow owner can delete it.",
+          status: "error",
+        };
+      }
+      return {
+        message: "We couldn't delete the grow right now. Please try again.",
+        status: "error",
+      };
+    }
+  } catch (err) {
+    if (isNextFrameworkError(err)) throw err;
+    logServerEvent("error", "delete grow action threw", {
+      error: err instanceof Error ? err.message : String(err),
+      growId,
+      userId: user.id,
+    });
+    return {
+      message: "We couldn't delete the grow right now. Please try again.",
+      status: "error",
+    };
+  }
+
+  revalidatePath("/grows");
+  revalidatePath("/dashboard");
+
+  return {
+    message: "Grow deleted.",
+    redirectTo: "/grows?deleted=1",
     status: "success",
   };
 }

--- a/apps/web/src/app/(app)/grows/[id]/delete-button.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/delete-button.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useActionWithRecovery } from "@/lib/client/action-runner";
+import {
+  deleteGrowAction,
+  deleteGrowActionInitialState,
+  type DeleteGrowActionResult,
+} from "./actions";
+
+// Destructive island. Two-step UI: the "Delete grow" CTA reveals an
+// inline confirmation that requires the user to retype the grow name.
+// Match is case- and whitespace-insensitive so trivial typos still
+// pass — but the user must produce the actual word, not "yes" or "y".
+//
+// On success the action returns a redirectTo (/grows?deleted=1) and
+// the recovery hook fires router.push automatically. If push fails
+// the runner still records `recoveryUrl` and we surface a manual
+// link so the user is never stranded on a dead detail page.
+export function DeleteGrowButton({
+  growId,
+  growName,
+}: {
+  growId: string;
+  growName: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [typed, setTyped] = useState("");
+  const { state, isPending, run } =
+    useActionWithRecovery<DeleteGrowActionResult>(
+      deleteGrowActionInitialState,
+      { fallbackUrl: "/grows" },
+    );
+
+  const trimmed = typed.trim();
+  const matches = trimmed.toLowerCase() === growName.trim().toLowerCase();
+
+  async function onSubmit() {
+    if (!matches) return;
+    try {
+      await run(() => deleteGrowAction(growId, trimmed));
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.error("deleteGrowAction failed after retries", err);
+      }
+    }
+  }
+
+  if (!open) {
+    return (
+      <div className="space-y-2">
+        <Button
+          onClick={() => setOpen(true)}
+          size="sm"
+          type="button"
+          variant="destructive"
+        >
+          Delete grow
+        </Button>
+        <p className="text-xs leading-5 text-muted-foreground">
+          Permanently removes the grow plus all plants, photos, analyses, and
+          tasks. Assistant chats scoped here are kept (unscoped). Cannot be
+          undone — prefer Archive if you might want it back.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form action={onSubmit} className="space-y-3">
+      <div>
+        <label
+          className="block text-sm font-medium text-foreground"
+          htmlFor="confirm-delete-name"
+        >
+          Type{" "}
+          <span className="font-semibold text-danger">
+            &ldquo;{growName}&rdquo;
+          </span>{" "}
+          to confirm
+        </label>
+        <input
+          autoComplete="off"
+          autoFocus
+          className="mt-2 block w-full rounded-[1.15rem] border border-border/80 bg-surface px-4 py-3 text-sm text-foreground shadow-soft transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger/40"
+          id="confirm-delete-name"
+          name="confirmName"
+          onChange={(event) => setTyped(event.target.value)}
+          placeholder={growName}
+          type="text"
+          value={typed}
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          aria-busy={isPending || undefined}
+          disabled={isPending || !matches}
+          size="sm"
+          type="submit"
+          variant="destructive"
+        >
+          {isPending ? "Deleting…" : "Confirm delete"}
+        </Button>
+        <Button
+          disabled={isPending}
+          onClick={() => {
+            setOpen(false);
+            setTyped("");
+          }}
+          size="sm"
+          type="button"
+          variant="surface"
+        >
+          Cancel
+        </Button>
+      </div>
+
+      {state.status === "error" && state.message ? (
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-danger"
+          role="status"
+        >
+          {state.message}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/grows/[id]/edit/edit-form.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/edit/edit-form.tsx
@@ -1,0 +1,416 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Button, buttonStyles } from "@/components/ui/button";
+import { FormErrorSummary } from "@/components/form-error-summary";
+import { useActionWithRecovery } from "@/lib/client/action-runner";
+import {
+  updateGrowAction,
+  updateGrowActionInitialState,
+  type UpdateGrowActionResult,
+} from "../actions";
+
+const FIELD_META = {
+  name: { label: "Grow name", targetId: "grow-name" },
+  description: { label: "Description", targetId: "grow-description" },
+  stage: { label: "Stage", targetId: "grow-stage" },
+  medium: { label: "Medium", targetId: "grow-medium" },
+  lightType: { label: "Light type", targetId: "grow-light-type" },
+  startDate: { label: "Start date", targetId: "start-date" },
+  targetHarvestDate: {
+    label: "Target harvest date",
+    targetId: "target-harvest-date",
+  },
+} as const;
+
+const growStages = [
+  { label: "Germination", value: "germination" },
+  { label: "Seedling", value: "seedling" },
+  { label: "Vegetative", value: "vegetative" },
+  { label: "Pre-flower", value: "pre_flower" },
+  { label: "Flower", value: "flower" },
+  { label: "Late flower", value: "late_flower" },
+  { label: "Harvest", value: "harvest" },
+  { label: "Dry / cure", value: "dry_cure" },
+] as const;
+
+const growMedia = [
+  { label: "Soil", value: "soil" },
+  { label: "Coco", value: "coco" },
+  { label: "Hydro", value: "hydro" },
+  { label: "Aero", value: "aero" },
+  { label: "Living soil", value: "living_soil" },
+  { label: "Other", value: "other" },
+] as const;
+
+const lightTypes = [
+  { label: "LED", value: "led" },
+  { label: "HPS", value: "hps" },
+  { label: "CMH", value: "cmh" },
+  { label: "T5", value: "t5" },
+  { label: "Sun", value: "sun" },
+  { label: "Mixed", value: "mixed" },
+  { label: "Other", value: "other" },
+] as const;
+
+const inputClassName =
+  "mt-2 block w-full rounded-[1.15rem] border border-border/80 bg-surface px-4 py-3 text-sm text-foreground shadow-soft transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35";
+
+function describedBy(id: string, hasError: boolean): string | undefined {
+  return hasError ? `${id}-error` : undefined;
+}
+
+function FieldError({
+  fieldId,
+  message,
+}: {
+  fieldId: string;
+  message: string | undefined;
+}) {
+  if (!message) return null;
+  return (
+    <p id={`${fieldId}-error`} className="mt-2 text-sm text-danger">
+      {message}
+    </p>
+  );
+}
+
+export interface EditGrowFormInitial {
+  description: string;
+  lightType: (typeof lightTypes)[number]["value"];
+  medium: (typeof growMedia)[number]["value"];
+  name: string;
+  stage: (typeof growStages)[number]["value"];
+  startDate: string;
+  targetHarvestDate: string;
+}
+
+export function EditGrowForm({
+  growId,
+  initial,
+}: {
+  growId: string;
+  initial: EditGrowFormInitial;
+}) {
+  // Same recovery story as create-grow: transient throws retry once,
+  // permanent errors keep the user on the form with a clear escape
+  // hatch back to the detail page (their input is preserved).
+  const {
+    state,
+    isPending,
+    run: runUpdate,
+  } = useActionWithRecovery<UpdateGrowActionResult>(
+    updateGrowActionInitialState,
+    { fallbackUrl: `/grows/${growId}` },
+  );
+
+  const [name, setName] = useState(initial.name);
+  const [description, setDescription] = useState(initial.description);
+  const [stage, setStage] = useState<EditGrowFormInitial["stage"]>(
+    initial.stage,
+  );
+  const [medium, setMedium] = useState<EditGrowFormInitial["medium"]>(
+    initial.medium,
+  );
+  const [lightType, setLightType] = useState<EditGrowFormInitial["lightType"]>(
+    initial.lightType,
+  );
+  const [startDate, setStartDate] = useState(initial.startDate);
+  const [targetHarvestDate, setTargetHarvestDate] = useState(
+    initial.targetHarvestDate,
+  );
+
+  async function handleAction(formData: FormData) {
+    try {
+      await runUpdate(() => updateGrowAction(growId, formData));
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.error("updateGrowAction failed after retries", err);
+      }
+    }
+  }
+
+  return (
+    <form action={handleAction} className="space-y-5" noValidate>
+      <FormErrorSummary
+        message={state.message}
+        fieldErrors={state.fieldErrors}
+        fieldMeta={FIELD_META}
+      />
+
+      {state.status === "success" && state.recoveryUrl ? (
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-success/40 bg-success/10 px-4 py-4 text-sm leading-6 text-foreground"
+          role="status"
+        >
+          <p className="font-medium">Grow updated.</p>
+          <p className="mt-1 text-muted-foreground">
+            If your screen didn&apos;t move on its own, tap below to continue.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link
+              className={buttonStyles({ size: "sm" })}
+              href={state.recoveryUrl}
+            >
+              Back to grow
+            </Link>
+          </div>
+        </div>
+      ) : null}
+
+      {state.status === "error" && state.recoveryUrl ? (
+        <div
+          aria-live="polite"
+          className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3 text-sm leading-6 text-muted-foreground"
+        >
+          Need to step away?{" "}
+          <Link className="text-accent underline" href={state.recoveryUrl}>
+            Back to the grow
+          </Link>{" "}
+          — your form input stays here when you come back.
+        </div>
+      ) : null}
+
+      <div>
+        <label
+          className="block text-sm font-medium text-foreground"
+          htmlFor="grow-name"
+        >
+          Grow name
+        </label>
+        <input
+          aria-describedby={describedBy(
+            "grow-name",
+            Boolean(state.fieldErrors?.name),
+          )}
+          aria-invalid={Boolean(state.fieldErrors?.name) || undefined}
+          className={inputClassName}
+          id="grow-name"
+          maxLength={120}
+          name="name"
+          onChange={(event) => setName(event.target.value)}
+          required
+          value={name}
+        />
+        <FieldError fieldId="grow-name" message={state.fieldErrors?.name} />
+      </div>
+
+      <div>
+        <label
+          className="block text-sm font-medium text-foreground"
+          htmlFor="grow-description"
+        >
+          Description
+        </label>
+        <textarea
+          aria-describedby={describedBy(
+            "grow-description",
+            Boolean(state.fieldErrors?.description),
+          )}
+          aria-invalid={Boolean(state.fieldErrors?.description) || undefined}
+          className={`${inputClassName} min-h-[120px] resize-y`}
+          id="grow-description"
+          maxLength={2_000}
+          name="description"
+          onChange={(event) => setDescription(event.target.value)}
+          value={description}
+        />
+        <FieldError
+          fieldId="grow-description"
+          message={state.fieldErrors?.description}
+        />
+        <p className="mt-2 text-sm text-muted-foreground">
+          Optional. Use this for location, room constraints, or handoff notes
+          (up to 2,000 characters).
+        </p>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-3">
+        <div>
+          <label
+            className="block text-sm font-medium text-foreground"
+            htmlFor="grow-stage"
+          >
+            Stage
+          </label>
+          <select
+            aria-describedby={describedBy(
+              "grow-stage",
+              Boolean(state.fieldErrors?.stage),
+            )}
+            aria-invalid={Boolean(state.fieldErrors?.stage) || undefined}
+            className={inputClassName}
+            id="grow-stage"
+            name="stage"
+            onChange={(event) =>
+              setStage(event.target.value as EditGrowFormInitial["stage"])
+            }
+            value={stage}
+          >
+            {growStages.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <FieldError fieldId="grow-stage" message={state.fieldErrors?.stage} />
+        </div>
+
+        <div>
+          <label
+            className="block text-sm font-medium text-foreground"
+            htmlFor="grow-medium"
+          >
+            Medium
+          </label>
+          <select
+            aria-describedby={describedBy(
+              "grow-medium",
+              Boolean(state.fieldErrors?.medium),
+            )}
+            aria-invalid={Boolean(state.fieldErrors?.medium) || undefined}
+            className={inputClassName}
+            id="grow-medium"
+            name="medium"
+            onChange={(event) =>
+              setMedium(event.target.value as EditGrowFormInitial["medium"])
+            }
+            value={medium}
+          >
+            {growMedia.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <FieldError
+            fieldId="grow-medium"
+            message={state.fieldErrors?.medium}
+          />
+        </div>
+
+        <div>
+          <label
+            className="block text-sm font-medium text-foreground"
+            htmlFor="grow-light-type"
+          >
+            Light type
+          </label>
+          <select
+            aria-describedby={describedBy(
+              "grow-light-type",
+              Boolean(state.fieldErrors?.lightType),
+            )}
+            aria-invalid={Boolean(state.fieldErrors?.lightType) || undefined}
+            className={inputClassName}
+            id="grow-light-type"
+            name="lightType"
+            onChange={(event) =>
+              setLightType(
+                event.target.value as EditGrowFormInitial["lightType"],
+              )
+            }
+            value={lightType}
+          >
+            {lightTypes.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+          <FieldError
+            fieldId="grow-light-type"
+            message={state.fieldErrors?.lightType}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <div>
+          <label
+            className="block text-sm font-medium text-foreground"
+            htmlFor="start-date"
+          >
+            Start date
+          </label>
+          <input
+            aria-describedby={describedBy(
+              "start-date",
+              Boolean(state.fieldErrors?.startDate),
+            )}
+            aria-invalid={Boolean(state.fieldErrors?.startDate) || undefined}
+            className={inputClassName}
+            id="start-date"
+            name="startDate"
+            onChange={(event) => setStartDate(event.target.value)}
+            required
+            type="date"
+            value={startDate}
+          />
+          <FieldError
+            fieldId="start-date"
+            message={state.fieldErrors?.startDate}
+          />
+        </div>
+
+        <div>
+          <label
+            className="block text-sm font-medium text-foreground"
+            htmlFor="target-harvest-date"
+          >
+            Target harvest date
+          </label>
+          <input
+            aria-describedby={describedBy(
+              "target-harvest-date",
+              Boolean(state.fieldErrors?.targetHarvestDate),
+            )}
+            aria-invalid={
+              Boolean(state.fieldErrors?.targetHarvestDate) || undefined
+            }
+            className={inputClassName}
+            id="target-harvest-date"
+            min={startDate || undefined}
+            name="targetHarvestDate"
+            onChange={(event) => setTargetHarvestDate(event.target.value)}
+            type="date"
+            value={targetHarvestDate}
+          />
+          <FieldError
+            fieldId="target-harvest-date"
+            message={state.fieldErrors?.targetHarvestDate}
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border/70 pt-5">
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-muted-foreground"
+        >
+          {isPending
+            ? "Saving changes..."
+            : "Changes apply immediately to plants, timelines, and assistant context."}
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link
+            className={buttonStyles({ size: "md", variant: "surface" })}
+            href={`/grows/${growId}`}
+          >
+            Cancel
+          </Link>
+          <Button
+            aria-busy={isPending || undefined}
+            disabled={isPending}
+            size="md"
+            type="submit"
+          >
+            {isPending ? "Saving..." : "Save changes"}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/(app)/grows/[id]/edit/page.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/edit/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { buttonStyles } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/ui/page-header";
+import { getServerUser } from "@/lib/server/auth";
+import { fetchGrowDetail } from "@/lib/server/workspace-records";
+import { EditGrowForm, type EditGrowFormInitial } from "./edit-form";
+
+export const metadata: Metadata = { title: "Edit grow" };
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+// Owner-gated edit screen. Non-owners get a clean 404 instead of a
+// disabled-but-visible form, which would leak the existence of grows
+// they're a viewer/collaborator on without being able to edit. The
+// underlying server action also enforces ownership via RLS, so this
+// is defence-in-depth.
+export default async function EditGrowPage({ params }: Props) {
+  const { id } = await params;
+  const [user, detail] = await Promise.all([
+    getServerUser(),
+    fetchGrowDetail(id),
+  ]);
+
+  if (!user) {
+    redirect(`/auth?next=/grows/${encodeURIComponent(id)}/edit`);
+  }
+  if (!detail) {
+    notFound();
+  }
+  if (detail.grow.ownerId !== user.id) {
+    notFound();
+  }
+
+  const { grow } = detail;
+
+  return (
+    <main className="app-page">
+      <PageHeader
+        actions={
+          <Link
+            className={buttonStyles({ size: "md", variant: "surface" })}
+            href={`/grows/${grow.id}`}
+          >
+            Cancel
+          </Link>
+        }
+        breadcrumbs={[
+          { href: "/dashboard", label: "Dashboard" },
+          { href: "/grows", label: "Grows" },
+          { href: `/grows/${grow.id}`, label: grow.name },
+          { label: "Edit" },
+        ]}
+        description="Update the metadata that anchors plants, photos, and assistant context for this grow."
+        title={`Edit ${grow.name}`}
+      />
+
+      <Card>
+        <CardContent>
+          <EditGrowForm
+            growId={grow.id}
+            initial={{
+              description: grow.description ?? "",
+              lightType:
+                (grow.lightType as EditGrowFormInitial["lightType"] | null) ??
+                "led",
+              medium:
+                (grow.medium as EditGrowFormInitial["medium"] | null) ?? "soil",
+              name: grow.name,
+              stage:
+                (grow.stage as EditGrowFormInitial["stage"] | null) ??
+                "seedling",
+              startDate: grow.startDate ?? "",
+              targetHarvestDate: grow.targetHarvestDate ?? "",
+            }}
+          />
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/apps/web/src/app/(app)/grows/[id]/page.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/page.tsx
@@ -1,3 +1,4 @@
+import type { GrowStage } from "@phenosage/shared";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
@@ -13,8 +14,11 @@ import {
 } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { getServerUser } from "@/lib/server/auth";
 import { fetchGrowDetail } from "@/lib/server/workspace-records";
 import { ArchiveButton } from "./archive-button";
+import { DeleteGrowButton } from "./delete-button";
+import { StageStepper } from "./stage-stepper";
 
 export const metadata: Metadata = { title: "Grow detail" };
 
@@ -58,11 +62,15 @@ function titleCase(value: string | null | undefined): string {
 //   * Footer with the Archive / Restore action.
 export default async function GrowDetailPage({ params, searchParams }: Props) {
   const { id } = await params;
-  const detail = await fetchGrowDetail(id);
+  const [user, detail] = await Promise.all([
+    getServerUser(),
+    fetchGrowDetail(id),
+  ]);
   if (!detail) {
     notFound();
   }
   const { grow, plants } = detail;
+  const isOwner = Boolean(user && user.id === grow.ownerId);
 
   const resolvedSearchParams = searchParams ? await searchParams : undefined;
   const justCreated = firstParam(resolvedSearchParams?.just_created) === "1";
@@ -81,6 +89,14 @@ export default async function GrowDetailPage({ params, searchParams }: Props) {
             >
               Back to registry
             </Link>
+            {isOwner ? (
+              <Link
+                className={buttonStyles({ size: "md", variant: "surface" })}
+                href={`/grows/${grow.id}/edit`}
+              >
+                Edit grow
+              </Link>
+            ) : null}
             <Link
               className={buttonStyles({ size: "md" })}
               href={`/plants/new?growId=${grow.id}`}
@@ -244,9 +260,37 @@ export default async function GrowDetailPage({ params, searchParams }: Props) {
                   : "Archiving keeps history but hides the grow from active workflows. You can restore it anytime."}
               </p>
             </div>
+            {isOwner && !grow.isArchived ? (
+              <div className="mt-5 border-t border-border/60 pt-4">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Stage
+                </p>
+                <StageStepper
+                  currentStage={grow.stage as GrowStage | null}
+                  growId={grow.id}
+                />
+              </div>
+            ) : null}
           </CardContent>
         </Card>
       </section>
+
+      {isOwner ? (
+        <section>
+          <Card className="border-danger/40">
+            <CardHeader>
+              <CardTitle>Danger zone</CardTitle>
+              <CardDescription>
+                Permanent deletion. Prefer archive for anything you might want
+                back.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DeleteGrowButton growId={grow.id} growName={grow.name} />
+            </CardContent>
+          </Card>
+        </section>
+      ) : null}
 
       <section className="grid gap-6 lg:grid-cols-2">
         <Card>

--- a/apps/web/src/app/(app)/grows/[id]/stage-stepper.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/stage-stepper.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import type { GrowStage } from "@phenosage/shared";
+import { Button } from "@/components/ui/button";
+import { useActionWithRecovery } from "@/lib/client/action-runner";
+import {
+  advanceGrowStageAction,
+  advanceGrowStageActionInitialState,
+  type AdvanceGrowStageActionResult,
+} from "./actions";
+
+// Linear vocabulary order matches the create-grow form's option list.
+// `dry_cure` is the terminal stage — beyond it there's no "next" step
+// to offer, so the stepper renders nothing instead of a noop button.
+const STAGE_ORDER: GrowStage[] = [
+  "germination",
+  "seedling",
+  "vegetative",
+  "pre_flower",
+  "flower",
+  "late_flower",
+  "harvest",
+  "dry_cure",
+];
+
+const STAGE_LABEL: Record<GrowStage, string> = {
+  germination: "Germination",
+  seedling: "Seedling",
+  vegetative: "Vegetative",
+  pre_flower: "Pre-flower",
+  flower: "Flower",
+  late_flower: "Late flower",
+  harvest: "Harvest",
+  dry_cure: "Dry / cure",
+};
+
+function nextStageOf(current: GrowStage | null): GrowStage | null {
+  if (!current) return STAGE_ORDER[0]!;
+  const idx = STAGE_ORDER.indexOf(current);
+  if (idx < 0 || idx >= STAGE_ORDER.length - 1) return null;
+  return STAGE_ORDER[idx + 1]!;
+}
+
+// One-click forward stage transition shown on the grow detail page.
+// Owner-only by RLS; non-owners see the button but get a clean error
+// message back. The owner-gating in the page also hides this for
+// non-owners, so this is the destructive-action recovery path more
+// than the primary UX.
+export function StageStepper({
+  growId,
+  currentStage,
+}: {
+  growId: string;
+  currentStage: GrowStage | null;
+}) {
+  const next = nextStageOf(currentStage);
+  const { state, isPending, run } =
+    useActionWithRecovery<AdvanceGrowStageActionResult>(
+      advanceGrowStageActionInitialState,
+      { fallbackUrl: `/grows/${growId}` },
+    );
+
+  if (!next) {
+    return (
+      <p className="text-xs leading-5 text-muted-foreground">
+        Final stage. Use Edit to change the stage manually.
+      </p>
+    );
+  }
+
+  async function onSubmit() {
+    if (!next) return;
+    try {
+      await run(() => advanceGrowStageAction(growId, next));
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.error("advanceGrowStageAction failed after retries", err);
+      }
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <form action={onSubmit}>
+        <Button
+          aria-busy={isPending || undefined}
+          disabled={isPending}
+          size="sm"
+          type="submit"
+          variant="surface"
+        >
+          {isPending ? "Advancing…" : `Advance to ${STAGE_LABEL[next]}`}
+        </Button>
+      </form>
+      {state.status === "error" && state.message ? (
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-danger"
+          role="status"
+        >
+          {state.message}
+        </p>
+      ) : null}
+      {state.status === "success" && state.message ? (
+        <p
+          aria-live="polite"
+          className="text-sm leading-6 text-muted-foreground"
+          role="status"
+        >
+          {state.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds three owner-only lifecycle controls to `/grows/[id]`:

- **Edit page** (`/grows/[id]/edit`) mirroring the create form, same 23505/42501 mapping and validation rules.
- **One-click StageStepper** that advances through the linear stage vocabulary; hidden at the terminal stage (`dry_cure`).
- **Type-the-name DeleteGrowButton** in a Danger Zone card. RLS pins delete to owners; FK cascades clear plants/photos/analyses/jobs/members/tasks/observations/events/findings. `chat_threads.grow_id` is SET NULL by design so assistant chats survive (unscoped).

Server actions live alongside `toggleGrowArchive` in `[id]/actions.ts` and use the `redirectTo` string pattern (NEXT_REDIRECT can't be intercepted from inside `startTransition`). Existing archive flow untouched.

## Tests
19 new cases in `actions.test.ts` covering update / advance / delete happy paths, validation, 23505 collision, 42501 RLS, name-mismatch guard, missing-row no-op, non-owner read, unauth, and NEXT_REDIRECT pass-through.

- `pnpm --filter @phenosage/web test` ΓåÆ **561/561 pass**
- `pnpm type-check` ΓåÆ clean
- `pnpm lint` ΓåÆ clean