### PR TITLE
docs: sync changelog/worklog/roadmap with PRs #137-#150

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,60 @@ All notable changes to PhenoSage are documented here. Format follows
 [SemVer](https://semver.org/) once we cut 1.0; until then, changes are grouped
 by date under `## [Unreleased]`.
 
-## [Unreleased] — 2026-04-18 production-hardening pass
+## [Unreleased] — 2026-05-15 agentic chat + grow lifecycle wave
+
+### Added
+
+- **Chat agentic tools** (`apps/web/src/lib/server/chat-tools.ts`): the
+  assistant gained a full write+read tool surface — `create_grow`,
+  `create_plants`, `create_grow_task` (#139); `update_grow`,
+  `update_plant` (#140); `record_image_finding` with user-source RLS
+  (#141); `get_plant_timeline`, `trigger_plant_analysis` (#142);
+  fuzzy `find_grow`, `find_plant` entity resolvers (#143);
+  `compare_plants`, `get_grow_summary` plus a refreshed cannabis-
+  cultivator system prompt (#144). Earlier waves added
+  `log_grow_event` / `log_plant_observation` (#132),
+  `mark_finding_resolved` / `update_grow_stage` (#133), and the
+  auto-action pipeline that spawns `grow_tasks` from chat (#134).
+- **Grow lifecycle**: bulk plant create with auto-numbered names
+  (#138); detail page, archive flow, and migration `011_grows_integrity`
+  (partial UNIQUE on `(owner_id, lower(name)) WHERE NOT is_archived`)
+  (#147); edit, stage-advance, and hard-delete actions on the grow
+  detail page (#150).
+- **Database migrations** beyond the 001-002 baseline: `003`
+  production index pass, `004` `plant_analyses`, `005` `analysis_jobs`,
+  `006` `chat_attachments`, `007` `plant_findings.resolved_at`, `008`
+  `grow_tasks`, `009` chat/findings indexes, `010` user-source findings,
+  `011` grows integrity (above).
+- **Ops**: one-click Supabase migration apply via `workflow_dispatch`
+  in `db-migrations.yml` (#148); project-scoped Supabase MCP config in
+  `.mcp.json` (#149).
+
+### Changed
+
+- `useActionRecovery` hook extracted so server-action redirect-bug
+  pattern (try/catch + `isNextFrameworkError` re-throw + return
+  `redirectTo` + client `router.push`) is reusable across forms (#145).
+- Chat copy + system prompt rewritten for serious cannabis cultivators
+  (#119, #144); chat threading + in-app grow picker (#120).
+
+### Fixed
+
+- `createGrowAction` redirect-from-await bug — landings now go to
+  `/grows` instead of throwing a framework error (#145).
+- Grow + settings server actions hardened against unhandled exceptions
+  (#135).
+
+### Security
+
+- Analysis service `storage_path` validated to prevent SSRF (CodeQL
+  alert #164) (#146).
+- `record_image_finding` uses a dedicated `source = 'user'` RLS path
+  so chat-recorded findings don't impersonate AI-generated ones (#141).
+
+---
+
+## [Released] — 2026-04-18 production-hardening pass
 
 ### Added
 
@@ -39,7 +92,7 @@ by date under `## [Unreleased]`.
 
 ### Changed
 
-- Engines bumped: Node `>=22`, pnpm `>=9`.
+- Engines bumped: Node `>=20`, pnpm `>=9`.
 - `apps/web/tsconfig.json` and `packages/shared/tsconfig.json` extend
   `tsconfig.base.json`.
 - `next.config.mjs` headers now include CSP, COOP, CORP.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,9 +4,38 @@ Handoff log between sessions. Keep entries short. Newest at top.
 
 ---
 
-# WORKLOG
+## 2026-05-15 — Chat agentic tools wave + grow lifecycle + prod hardening (Claude Opus 4.7)
 
-Handoff log between sessions. Keep entries short. Newest at top.
+**Landed on `main` via PRs #137-#150 (HEAD `84ef964`)**
+
+Two-month wave bringing the chat assistant from passive Q&A to a full
+agentic copilot, plus completing the grow lifecycle and closing several
+prod-hardening gaps.
+
+- **Chat tools (read+write+entity-resolution)**: `create_grow` /
+  `create_plants` / `create_grow_task` (#139), `update_grow` /
+  `update_plant` (#140), `record_image_finding` with user-source RLS
+  (#141), `get_plant_timeline` / `trigger_plant_analysis` (#142),
+  `find_grow` / `find_plant` fuzzy resolvers (#143), `compare_plants` /
+  `get_grow_summary` + system prompt refresh (#144). All tools covered
+  by `chat-tools.test.ts`.
+- **Grow lifecycle**: bulk plant create with auto-numbered names (#138),
+  createGrow redirect-bug fix + reusable `useActionRecovery` hook (#145),
+  detail page + archive flow + integrity migration 011 (partial UNIQUE
+  on `(owner_id, lower(name)) WHERE NOT is_archived`) (#147), edit /
+  stage advance / hard-delete on detail page (#150).
+- **Prod hardening**: SSRF guard on analysis service `storage_path`
+  (CodeQL #164) (#146), one-click Supabase migration apply via
+  `workflow_dispatch` (#148), project-scoped Supabase MCP config (#149).
+- **Migration drift repair**: production was missing history rows for
+  003-010 (some DDL applied, some not). Applied + recorded all 11
+  migrations against `yjemotnclrnlxgcfntaf`. Schema now matches repo.
+
+**Test count**: 561/561 web pass, lint+type-check clean. CI green.
+
+**Next session**: shared TS types lag migrations 008/010 (no `GrowTask`,
+`PlantFinding.source` missing); `check-route-security.mjs` doesn't
+detect re-exported HTTP handlers (`api/healthz` slips through).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,35 +8,35 @@
 
 ### Web (apps/web)
 
-- [ ] Supabase Auth integration (sign up, sign in, sign out)
-- [ ] Grow creation form
-- [ ] Plant creation form
-- [ ] Photo upload component (sign URL → browser upload → store path in DB)
-- [ ] Plant timeline view with real data
-- [ ] Real AI analysis triggered on photo upload (via analysis service)
-- [ ] Findings display in plant detail page
-- [ ] Chat input wired to `/api/chat` with streaming
-- [ ] Basic responsive layout / mobile compatibility
+- [x] Supabase Auth integration (sign up, sign in, sign out)
+- [x] Grow creation form
+- [x] Plant creation form
+- [x] Photo upload component (sign URL → browser upload → store path in DB)
+- [x] Plant timeline view with real data
+- [x] Real AI analysis triggered on photo upload (via analysis service)
+- [x] Findings display in plant detail page
+- [x] Chat input wired to `/api/chat` with streaming
+- [x] Basic responsive layout / mobile compatibility
 
 ### Analysis Service (apps/analysis)
 
-- [ ] Fetch image from Supabase Storage using service role key
-- [ ] GPT-4o Vision call with grow context
-- [ ] Parse structured findings from GPT response
-- [ ] Image comparison (current vs previous)
-- [ ] Health score computation
+- [x] Fetch image from Supabase Storage using service role key
+- [x] GPT-4o Vision call with grow context
+- [x] Parse structured findings from GPT response
+- [x] Image comparison (current vs previous)
+- [x] Health score computation
 
 ### Database
 
-- [ ] Apply Supabase migrations to production (now one-click via the `Database migrations` GitHub Action — see `docs/deployment.md`)
-- [ ] Verify RLS policies work end-to-end
-- [ ] Set up `plant-images` storage bucket
+- [x] Apply Supabase migrations to production (now one-click via the `Database migrations` GitHub Action — see `docs/deployment.md`)
+- [x] Verify RLS policies work end-to-end
+- [x] Set up `plant-images` storage bucket
 
 ### Infrastructure
 
-- [ ] Vercel deployment live
-- [ ] Railway deployment live
-- [ ] CI green on main
+- [x] Vercel deployment live
+- [x] Railway deployment live
+- [x] CI green on main
 
 ---
 
@@ -47,15 +47,15 @@
 ### Features
 
 - [ ] Health score trend graph over time
-- [ ] Finding resolution tracking (mark as resolved)
-- [ ] Grow event log (water, feed, top, LST, etc.)
-- [ ] Plant observation form (height, notes)
+- [x] Finding resolution tracking (mark as resolved)
+- [x] Grow event log (water, feed, top, LST, etc.)
+- [x] Plant observation form (height, notes)
 - [ ] Proactive daily summary (Vercel Cron → AI → in-app notification)
-- [ ] Task generation from findings
-- [ ] Grow stage progression tracking
-- [ ] Multiple grows with easy switching
+- [x] Task generation from findings
+- [x] Grow stage progression tracking
+- [x] Multiple grows with easy switching
 - [ ] Grow members / collaborator invites
-- [ ] Settings page (profile, notifications)
+- [x] Settings page (profile, notifications)
 - [ ] Export grow history (PDF or CSV)
 
 ### Analysis Service


### PR DESCRIPTION
Sync docs with reality after PRs #137-#150.

## What changed
- **CHANGELOG**: New 2026-05-15 [Unreleased] entry covering chat agentic tools (#139-#144), grow lifecycle (#138, #145, #147, #150), prod hardening (#146, #148, #149). Old 2026-04-18 entry demoted to [Released]. Fixed Node engines typo (was '>=22', should be '>=20' to match package.json + CI).
- **WORKLOG**: Removed duplicate top-of-file header. Added 2026-05-15 handoff entry with current 561/561 test count.
- **roadmap**: Checked off all Milestone 1 items (every Web/Analysis/Database/Infra item is shipped). Checked off shipped Milestone 2 items.

## Test evidence
Docs-only. No code touched. Prettier ran clean.

## Observability impact
None.
