### PR TITLE
chore(types,security): close type/scanner drift after migrations 008-010

### DIFF
--- a/apps/web/src/app/api/healthz/__tests__/route.test.ts
+++ b/apps/web/src/app/api/healthz/__tests__/route.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { GET as healthzGET, runtime as healthzRuntime } from "../route";
+import { GET as healthGET } from "../../health/route";
+
+// /api/healthz is intentionally a thin re-export of /api/health so that
+// uptime probers and load balancers using the conventional `/healthz`
+// path get the same body and status as `/api/health`. These tests pin
+// that contract so an accidental divergence (e.g. someone replacing the
+// re-export with a different handler) would fail CI.
+describe("GET /api/healthz", () => {
+  it("re-exports the same GET handler as /api/health", () => {
+    expect(healthzGET).toBe(healthGET);
+  });
+
+  it("returns 200 with the same shape as /api/health", async () => {
+    const res = healthzGET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+    expect(body.service).toBe("phenosage-web");
+    expect(typeof body.timestamp).toBe("string");
+    expect(Number.isNaN(Date.parse(body.timestamp))).toBe(false);
+  });
+
+  it("declares edge runtime (route-segment config can't be re-exported)", () => {
+    expect(healthzRuntime).toBe("edge");
+  });
+});

--- a/packages/shared/src/__tests__/types.test.ts
+++ b/packages/shared/src/__tests__/types.test.ts
@@ -5,8 +5,11 @@ import type {
   FindingSeverity,
   Grow,
   GrowStage,
+  GrowTask,
   Plant,
   PlantFinding,
+  TaskPriority,
+  TaskStatus,
 } from "../types";
 
 describe("shared contract types", () => {
@@ -78,9 +81,44 @@ describe("shared contract types", () => {
       severity: severities[4]!,
       title: "N deficiency",
       description: "Yellowing lower leaves",
+      source: "ai",
       createdAt: "2026-04-01T00:00:00Z",
     };
     expect(finding.severity).toBe("critical");
+  });
+
+  it("accepts a user-reported PlantFinding (migration 010)", () => {
+    const finding: PlantFinding = {
+      id: "f2",
+      plantId: "p1",
+      growId: "g1",
+      category: "pest",
+      severity: "high",
+      title: "Spider mites on lower fan leaves",
+      description: "Stippling + webbing observed at lights-on",
+      source: "user_reported",
+      createdAt: "2026-04-02T00:00:00Z",
+    };
+    expect(finding.source).toBe("user_reported");
+  });
+
+  it("accepts a GrowTask covering all priorities and statuses (migration 008)", () => {
+    const priorities: TaskPriority[] = ["low", "medium", "high", "urgent"];
+    const statuses: TaskStatus[] = ["open", "in_progress", "done", "dismissed"];
+    const task: GrowTask = {
+      id: "t1",
+      growId: "g1",
+      plantId: "p1",
+      findingId: "f1",
+      title: "Address: N deficiency",
+      description: "Bump base nutrient EC by 0.2",
+      priority: priorities[3]!,
+      status: statuses[0]!,
+      createdAt: "2026-04-01T00:00:00Z",
+      updatedAt: "2026-04-01T00:00:00Z",
+    };
+    expect(task.priority).toBe("urgent");
+    expect(task.status).toBe("open");
   });
 
   it("accepts an AnalysisResponse with findings array", () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -104,6 +104,11 @@ export type FindingCategory =
   | "general"
   | "positive";
 
+// Mirrors the `source` text+check column added in migration 010_user_findings.
+// 'ai' = analysis service write (service role); 'user_reported' = user-side
+// insert via the chat `record_image_finding` tool or future manual flows.
+export type FindingSource = "ai" | "user_reported";
+
 export interface PlantFinding {
   id: string;
   plantId: string;
@@ -114,6 +119,7 @@ export interface PlantFinding {
   title: string;
   description: string;
   recommendation?: string;
+  source: FindingSource;
   resolvedAt?: string;
   createdAt: string;
 }
@@ -195,4 +201,28 @@ export interface GrowEvent {
   notes?: string;
   occurredAt: string; // ISO timestamp
   createdAt: string;
+}
+
+// GrowTask — mirrors migration 008_grow_tasks.
+// Tasks may be auto-spawned by the AFTER INSERT trigger on plant_findings
+// (high/critical severity → urgent/high priority task), or created manually
+// by the chat `create_grow_task` tool / future user-facing forms.
+export type TaskPriority = "low" | "medium" | "high" | "urgent";
+export type TaskStatus = "open" | "in_progress" | "done" | "dismissed";
+
+export interface GrowTask {
+  id: string;
+  growId: string;
+  plantId?: string;
+  // 1:1 link to the plant_findings row that spawned this task. NULL when
+  // the task was created manually.
+  findingId?: string;
+  title: string;
+  description?: string;
+  priority: TaskPriority;
+  status: TaskStatus;
+  dueAt?: string; // ISO timestamp
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
 }

--- a/scripts/check-route-security.mjs
+++ b/scripts/check-route-security.mjs
@@ -26,6 +26,7 @@ const API_ROOT = join(ROOT, "apps", "web", "src", "app", "api");
 const PUBLIC_ROUTES = new Set([
   // path relative to apps/web/src/app/api, with leading slash
   "/health",
+  "/healthz",
   "/ready",
   // Chat diagnostic — returns only build SHA + Gemini-key-alias presence
   // booleans + env-name inventory (no values). Intentionally unauthenticated
@@ -53,6 +54,12 @@ function* walk(dir) {
 
 const HTTP_METHOD_RE =
   /\bexport\s+(?:async\s+)?function\s+(GET|POST|PUT|PATCH|DELETE)\b/g;
+// Also catch re-exports like `export { GET } from "../health/route"` — these
+// expose an HTTP handler at the alias path but the previous regex missed
+// them, letting public routes (e.g. /api/healthz) slip past the auth audit.
+const HTTP_REEXPORT_RE =
+  /\bexport\s*\{\s*([^}]+)\s*\}\s*from\s+["'][^"']+["']/g;
+const HTTP_METHOD_NAMES = new Set(["GET", "POST", "PUT", "PATCH", "DELETE"]);
 const AUTH_IMPORT_RE = /from\s+["']@\/lib\/server\/auth["']/;
 const COMPONENTS_IMPORT_RE = /from\s+["']@\/components\//;
 const CRON_SECRET_RE =
@@ -71,6 +78,19 @@ for (const file of walk(API_ROOT)) {
   }
 
   const methods = [...text.matchAll(HTTP_METHOD_RE)].map((m) => m[1]);
+  for (const reexport of text.matchAll(HTTP_REEXPORT_RE)) {
+    const names = reexport[1]
+      .split(",")
+      .map((s) =>
+        s
+          .trim()
+          .split(/\s+as\s+/i)
+          .pop()
+          .trim(),
+      )
+      .filter((n) => HTTP_METHOD_NAMES.has(n));
+    methods.push(...names);
+  }
   if (methods.length === 0) continue;
 
   const isPublic = PUBLIC_ROUTES.has(apiPath);


### PR DESCRIPTION
Closes type and route-scanner drift surfaced by the lead-engineer audit (alongside the docs sync in #151).

## What changed

### Shared types (migrations 008 + 010 alignment)
- `PlantFinding` gains `source: 'ai' | 'user_reported'` — mirrors migration `010_user_findings`. The chat `record_image_finding` tool already writes `user_reported` rows; the type now reflects that.
- New `GrowTask`, `TaskPriority`, `TaskStatus` — mirror migration `008_grow_tasks`. Both the chat `create_grow_task` tool and the `AFTER INSERT` trigger on `plant_findings` produce these rows; nothing in `packages/shared` modeled them.
- `packages/shared` tests pin the new fields with two new test cases.

### Route-security scanner
- `check-route-security.mjs` now detects re-exported HTTP handlers (`export { GET } from '../foo/route'`) in addition to direct function exports. The previous regex let `api/healthz` slip past the audit entirely.
- `/healthz` added to `PUBLIC_ROUTES` so the now-detected re-export passes for the right reason (intentionally public for uptime probers).

### Healthz colocated test
- New `apps/web/src/app/api/healthz/__tests__/route.test.ts` pins the re-export identity (`healthz.GET === health.GET`) so accidental divergence fails CI.

## Test evidence
- `pnpm test` → 564/564 web pass (was 561, +3 healthz)
- `pnpm run type-check` → clean
- `pnpm run lint` → clean
- `pnpm run security:routes` → OK (14 route files scanned, was 13 — healthz now covered)

## Observability impact
None. No runtime code changed.
