### PR TITLE
feat(migrations): 012_function_hardening — close advisor warnings

### DIFF
--- a/supabase/migrations/012_function_hardening.sql
+++ b/supabase/migrations/012_function_hardening.sql
@@ -1,0 +1,96 @@
+-- Migration: 012_function_hardening
+--
+-- Closes the security advisor warnings introduced by migrations 003,
+-- 005, 008, and the inherited `update_updated_at` from 001:
+--
+--   1. **Function search_path hardening** — five plpgsql functions in
+--      `public` were created without `SET search_path = …`, which the
+--      Supabase linter flags as `function_search_path_mutable`. A
+--      function with a mutable search_path can resolve unqualified
+--      object names against whatever the calling role has in
+--      `search_path` at runtime — a known privilege-escalation vector
+--      for SECURITY DEFINER functions, and best-practice to lock down
+--      for SECURITY INVOKER functions too (forward-compat if the
+--      function is later promoted, and to suppress the lint).
+--
+--   2. **REVOKE EXECUTE on trigger-only SECURITY DEFINER functions** —
+--      `grow_insert_owner_member` (migration 011) and
+--      `plant_findings_auto_task` (migration 008) are only ever invoked
+--      from row-level triggers, but were created without explicit
+--      REVOKEs, so Supabase exposed them at `/rest/v1/rpc/…` callable by
+--      `anon` and `authenticated`. We revoke EXECUTE from all three
+--      principals (`public`, `anon`, `authenticated`) so the only path
+--      that reaches them is the trigger that owns them.
+--
+--      `enqueue_analysis_job` (migration 005) already revoked
+--      `authenticated` + `public`, but the linter still flagged `anon`
+--      executable. We add an explicit `revoke from anon` for parity.
+--
+-- Out of scope (deferred to a separate PR after careful staging):
+--   * Moving `pgvector` from `public` to an `extensions` schema. The
+--     `idx_plant_findings_embedding` index already exists and uses the
+--     `vector_cosine_ops` operator class — moving the extension is
+--     safe in theory but worth its own change-window so any ORM /
+--     migration tooling that hard-codes `public.vector` can be caught.
+--   * `handle_new_user` and `rls_auto_enable` are Supabase-managed and
+--     left untouched.
+--   * `auth_leaked_password_protection` is an Auth-dashboard toggle
+--     (Settings → Auth → Password Strength → HaveIBeenPwned), not a
+--     SQL change.
+--
+-- Safety posture:
+--   * Every `ALTER FUNCTION … SET search_path = public` is idempotent
+--     and changes only the function's metadata — no schema changes,
+--     no data motion.
+--   * REVOKEs against absent grants are no-ops in Postgres, so the
+--     migration is safe to re-run.
+--
+-- Rollback (do NOT run unless explicitly approved):
+--   alter function public.grow_tasks_touch_updated_at()           reset search_path;
+--   alter function public.plant_findings_user_update_guard()      reset search_path;
+--   alter function public.set_analysis_jobs_updated_at()          reset search_path;
+--   alter function public.set_audit_columns()                     reset search_path;
+--   alter function public.update_updated_at()                     reset search_path;
+--   grant execute on function public.grow_insert_owner_member()   to anon, authenticated, public;
+--   grant execute on function public.plant_findings_auto_task()   to anon, authenticated, public;
+--   grant execute on function public.enqueue_analysis_job(uuid, uuid, uuid, uuid, text, integer) to anon;
+
+-- ─── 1. search_path hardening ────────────────────────────────────────
+
+alter function public.grow_tasks_touch_updated_at()
+  set search_path = public;
+
+alter function public.plant_findings_user_update_guard()
+  set search_path = public;
+
+alter function public.set_analysis_jobs_updated_at()
+  set search_path = public;
+
+alter function public.set_audit_columns()
+  set search_path = public;
+
+alter function public.update_updated_at()
+  set search_path = public;
+
+-- ─── 2. REVOKE EXECUTE on trigger-only SECURITY DEFINER functions ────
+
+-- Trigger on grows.AFTER INSERT (migration 011). No RPC use case.
+revoke execute on function public.grow_insert_owner_member()
+  from public, anon, authenticated;
+
+-- Trigger on plant_findings.AFTER INSERT (migration 008). No RPC use case.
+revoke execute on function public.plant_findings_auto_task()
+  from public, anon, authenticated;
+
+-- Server-only (migration 005 grants execute only to service_role). The
+-- explicit `from anon` is belt-and-suspenders so the linter's
+-- `anon_security_definer_function_executable` warning clears even on
+-- environments where the original REVOKE didn't catch `anon`.
+revoke execute on function public.enqueue_analysis_job(
+  p_plant_id uuid,
+  p_image_id uuid,
+  p_grow_id uuid,
+  p_requested_by uuid,
+  p_idempotency_key text,
+  p_max_attempts integer
+) from public, anon, authenticated;


### PR DESCRIPTION
## Why

After this session brought migrations 003–011 fully into sync with the live database, `get_advisors` returned ~17 security warnings. This PR closes the ones whose remediation is a clean SQL change. Already applied to the live project via MCP — committing the canonical SQL so fresh `supabase db push` (and the `Database migrations` workflow from #148) reproduce the same state.

## What changes

1. **`SET search_path = public`** on five plpgsql functions in `public` that were missing it:
   - `grow_tasks_touch_updated_at`
   - `plant_findings_user_update_guard`
   - `set_analysis_jobs_updated_at`
   - `set_audit_columns`
   - `update_updated_at`

   A function with a mutable search_path can resolve unqualified names against whatever the calling role has in `search_path` at runtime — a known privilege-escalation vector for SECURITY DEFINER and best practice to pin for SECURITY INVOKER too.

2. **`REVOKE EXECUTE`** on two trigger-only SECURITY DEFINER functions that Supabase auto-exposed at `/rest/v1/rpc/…`:
   - `grow_insert_owner_member` (the migration 011 owner-member trigger)
   - `plant_findings_auto_task` (the migration 008 auto-task trigger)

   Both are only ever invoked from row-level triggers; the RPC surface was unintended.

3. **Belt-and-suspenders REVOKE on `enqueue_analysis_job`** — 005 already revoked `authenticated` + `public`, the advisor still flagged `anon` executable, so we add it explicitly.

## Out of scope (deliberately)

- **`handle_new_user`** — Supabase-managed signup trigger
- **`rls_auto_enable`** — Supabase-internal helper
- **Moving `pgvector` to `extensions` schema** — safe in theory but worth its own change-window because `idx_plant_findings_embedding` already uses `vector_cosine_ops` and any tooling that hard-codes `public.vector` (ORMs, custom migrations) needs to be caught
- **`auth_leaked_password_protection`** — Auth dashboard toggle, not SQL

## Verification

After applying via MCP, `get_advisors` dropped from ~17 warnings to 5 (the four bullets above + the password-protection toggle). Every cleared warning corresponds to one statement in this migration.

## Safety

- Every `ALTER FUNCTION ... SET` is metadata-only — no schema or data changes.
- REVOKEs against absent grants are no-ops, so the migration is safe to re-run on any environment.
- Rollback block included in the header.

## Validation

- `pnpm run validate` — ✓
- Applied to production live; `get_advisors` confirms the fixes landed
- Migration recorded in `supabase_migrations.schema_migrations` as `012 function_hardening`

## Test plan

- [x] Production: 5/6 search_path findings cleared, 2/2 REVOKE findings cleared
- [ ] **Manual (post-merge, fresh project)**: `supabase db push` then `get_advisors` returns the same 5 deferred warnings only


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_