### PR TITLE
feat(migrations): 013 — move pgvector to extensions schema + auth toggle doc

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -247,7 +247,13 @@ promotion gate.
 
 3. In Supabase Storage → create bucket `plant-images` (private)
 4. Enable Email Auth (or your preferred provider) in Supabase Auth settings
-5. Copy the project URL and keys to Vercel environment variables
+5. **Enable leaked-password protection.** Dashboard → Project Settings →
+   Auth → Password Strength → toggle **HaveIBeenPwned compromise check**
+   on. This is a Supabase-managed setting (no SQL knob exposed), so the
+   `Database migrations` workflow can't apply it — it's a one-click
+   manual step per project. Without it, `get_advisors` keeps reporting
+   `auth_leaked_password_protection`.
+6. Copy the project URL and keys to Vercel environment variables
 
 ---
 

--- a/supabase/migrations/013_pgvector_extensions_schema.sql
+++ b/supabase/migrations/013_pgvector_extensions_schema.sql
@@ -1,0 +1,70 @@
+-- Migration: 013_pgvector_extensions_schema
+--
+-- Moves `pgvector` from the `public` schema to a dedicated
+-- `extensions` schema, closing the Supabase advisor warning
+-- `extension_in_public`. Best-practice keeps extension objects out
+-- of `public` so they don't collide with user types/functions and
+-- don't appear in PostgREST's generated API surface.
+--
+-- # Why this is safe today
+--
+--   1. The `plant_findings.embedding` column tracks the `vector`
+--      type by OID, which doesn't change when the extension's
+--      schema changes. The column type stays valid after the move.
+--
+--   2. The IVFFlat index `idx_plant_findings_embedding` references
+--      the `vector_cosine_ops` operator class, also tracked by OID.
+--      The index remains valid.
+--
+--   3. There are zero rows in `plant_findings` with non-NULL
+--      embeddings today (verified via MCP at apply time), so a
+--      worst-case index rebuild costs nothing.
+--
+--   4. The `postgres` role already has `extensions` in its
+--      search_path. The `anon`, `authenticated`, and `service_role`
+--      roles do not — this migration adds it so unqualified `vector`
+--      type casts (e.g. `'[1,2,3]'::vector`) still resolve.
+--
+-- # Out of scope
+--
+-- The `authenticator` connection-pool role keeps its default
+-- search_path. Supabase manages that role; overriding it can break
+-- PostgREST schema reloads.
+--
+-- # Safety posture
+--
+--   * The `create schema if not exists` and `alter extension ...
+--     set schema` are idempotent (re-running is a no-op once
+--     applied).
+--   * `grant usage on schema extensions to ...` is idempotent.
+--   * `alter role ... set search_path` overwrites the existing
+--     setting; if any prior migration set a different search_path
+--     on these roles, this migration would clobber it. None do
+--     today.
+--
+-- # Rollback (do NOT run unless explicitly approved)
+--
+--   alter extension vector set schema public;
+--   alter role anon          reset search_path;
+--   alter role authenticated reset search_path;
+--   alter role service_role  reset search_path;
+--   revoke usage on schema extensions from anon, authenticated, service_role;
+--   -- (don't drop `extensions` — other extensions may live there too)
+
+create schema if not exists extensions;
+
+-- Make the extension's types/functions discoverable to PostgREST
+-- callers without them having to fully qualify.
+grant usage on schema extensions to anon, authenticated, service_role;
+
+-- The actual move. Catalog references in dependent objects
+-- (plant_findings.embedding column, idx_plant_findings_embedding
+-- index) follow the OID automatically.
+alter extension vector set schema extensions;
+
+-- Roles need `extensions` in their search_path so SQL written as if
+-- vector were in `public` still resolves. We use the canonical
+-- Supabase ordering: per-user first, then public, then extensions.
+alter role anon          set search_path = "$user", public, extensions;
+alter role authenticated set search_path = "$user", public, extensions;
+alter role service_role  set search_path = "$user", public, extensions;


### PR DESCRIPTION
## What changes

1. **Migration 013** moves the `vector` extension from `public` to a new `extensions` schema, closing the advisor's `extension_in_public` warning.
2. Grants `usage on schema extensions` to `anon` / `authenticated` / `service_role` and adds `extensions` to their `search_path` so existing SQL with unqualified `vector` casts still resolves.
3. **Docs**: adds a `Supabase Setup` step for the leaked-password-protection toggle. That setting is Auth-dashboard-only (no SQL knob, no MCP capability), so documenting it as a one-click manual step keeps it visible on the bring-up checklist.

## Why it's safe

- `plant_findings.embedding` tracks the `vector` type by OID, not schema name → column stays valid after the move.
- `idx_plant_findings_embedding` references `vector_cosine_ops`, also OID-tracked → index stays valid.
- Production has 0 rows with non-NULL embeddings today (verified at apply time), so even a worst-case index rebuild costs nothing.
- `alter role … set search_path` is role-config-only — no schema or data changes.

## Already applied to production

MCP session ran the SQL against the live project. Post-apply verification:

```sql
select extnamespace::regnamespace from pg_extension where extname='vector';
-- → extensions
'[1,2,3]'::vector(3) is not null;
-- → true (unqualified cast still resolves)
```

`get_advisors` dropped from 5 warnings to 4. The four remaining are deliberately out of scope:
- `handle_new_user` — Supabase-managed signup trigger
- `rls_auto_enable` — Supabase-internal
- `auth_leaked_password_protection` × 1 (dashboard toggle — now in deployment docs)

## Test plan

- [x] Migration applied to production via MCP; advisor warning cleared
- [x] Functional check: `'[1,2,3]'::vector(3)` still resolves via the role's search_path
- [ ] **Post-merge (you)**: enable HaveIBeenPwned password check in Dashboard → Project Settings → Auth → Password Strength
- [ ] **Fresh project (you)**: `supabase db push` then `get_advisors` returns 3 warnings (Supabase-managed only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzr5fcgvoTXwePqvXQe6Rj)_