### PR TITLE
perf(chat): pg_trgm search + per-tool rate limits + file-budget guard

### DIFF
--- a/apps/web/src/app/(app)/grows/[id]/actions.ts
+++ b/apps/web/src/app/(app)/grows/[id]/actions.ts
@@ -5,6 +5,7 @@ import type { GrowMedium, GrowStage, LightType } from "@phenosage/shared";
 import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { logServerEvent } from "@/lib/server/request-id";
+import { MAX_DESCRIPTION_LENGTH, MAX_FUTURE_START_MS } from "../constants";
 
 // Stage / medium / light vocabularies are duplicated from
 // new/actions.ts on purpose: keeping the two action files independent
@@ -38,11 +39,6 @@ const validLightTypes = new Set<LightType>([
   "mixed",
   "other",
 ]);
-
-const MAX_DESCRIPTION_LENGTH = 2_000;
-// Past start dates are fine (data-entry catch-up), future capped at
-// one day to lock out year-9999 fat-fingers — same rule as create.
-const MAX_FUTURE_START_MS = 24 * 60 * 60 * 1000;
 
 function asTrimmedString(value: FormDataEntryValue | null) {
   return typeof value === "string" ? value.trim() : "";

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -7,6 +7,7 @@ import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { rateLimit } from "@/lib/server/rate-limit";
 import { logServerEvent, REQUEST_ID_HEADER } from "@/lib/server/request-id";
+import { MAX_DESCRIPTION_LENGTH, MAX_FUTURE_START_MS } from "./constants";
 
 const validStages = new Set<GrowStage>([
   "germination",
@@ -37,16 +38,6 @@ const validLightTypes = new Set<LightType>([
   "mixed",
   "other",
 ]);
-
-// Mirrors the chat tool's MAX_NOTES_LENGTH so both create paths agree
-// on prose size. The DB column is unbounded `text`; cap here to keep
-// list views renderable and lock out paste-bomb fat-fingers.
-const MAX_DESCRIPTION_LENGTH = 2_000;
-
-// Mirrors the chat tool's isoDateNotFarFuture refinement: past start
-// dates are allowed (data-entry catching up is the common case), but
-// the future side is clamped to avoid year-9999 fat-finger inputs.
-const MAX_FUTURE_START_MS = 24 * 60 * 60 * 1000;
 
 // Per-attempt deadline on the Supabase insert. Vercel's serverless
 // timeout is 60s on the hobby plan / 300s on pro, but a user staring at

--- a/apps/web/src/app/(app)/grows/constants.ts
+++ b/apps/web/src/app/(app)/grows/constants.ts
@@ -1,0 +1,13 @@
+// Constants shared between the grows server actions (new + [id]).
+// Kept out of actions.ts because Next forbids non-async exports from a
+// "use server" module.
+
+// DB column is unbounded `text`; cap here to keep list views renderable
+// and lock out paste-bomb fat-fingers. Mirrors the chat tool's
+// MAX_NOTES_LENGTH so both create paths agree on prose size.
+export const MAX_DESCRIPTION_LENGTH = 2_000;
+
+// Past start dates are allowed (data-entry catch-up is the common
+// case); the future side is clamped to one day to lock out year-9999
+// fat-fingers.
+export const MAX_FUTURE_START_MS = 24 * 60 * 60 * 1000;

--- a/apps/web/src/app/(app)/plants/new/plant-form.tsx
+++ b/apps/web/src/app/(app)/plants/new/plant-form.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Button, buttonStyles } from "@/components/ui/button";
 import { FormErrorSummary } from "@/components/form-error-summary";
+import { useActionWithRecovery } from "@/lib/client/action-runner";
 type GrowRecord = { id: string; name: string; stage: string | null };
 import {
   createPlantAction,
@@ -51,11 +51,21 @@ export function PlantForm({
   defaultGrowId: string;
   grows: GrowRecord[];
 }) {
-  const router = useRouter();
-  const [state, setState] = useState<CreatePlantActionResult>(
+  // useActionWithRecovery handles transient throws (network blip,
+  // ChunkLoadError) with one automatic retry, surfaces validation
+  // errors unchanged, and exposes `state.recoveryUrl` so a router.push
+  // failure can't strand the user on a stale form. /grows is the
+  // fallback because every successful plant create either lands on
+  // the new plant page (single create) or back on the grows list
+  // (bulk create) — /grows is always a safe escape hatch.
+  const {
+    state,
+    isPending,
+    run: runCreatePlant,
+  } = useActionWithRecovery<CreatePlantActionResult>(
     createPlantActionInitialState,
+    { fallbackUrl: "/grows" },
   );
-  const [isPending, startTransition] = useTransition();
   const [growId, setGrowId] = useState(defaultGrowId);
   const [name, setName] = useState("");
   const [strain, setStrain] = useState("");
@@ -81,24 +91,16 @@ export function PlantForm({
     : "";
 
   async function handleAction(formData: FormData) {
-    startTransition(async () => {
-      try {
-        const result = await createPlantAction(formData);
-        setState(result);
-        if (result.status === "success" && result.redirectTo) {
-          router.push(result.redirectTo);
-        }
-      } catch (err) {
-        // Safety net so an unexpected throw can never crash into the
-        // (app)/error.tsx boundary.
-        console.error("createPlantAction failed unexpectedly", err);
-        setState({
-          message:
-            "Something went wrong saving the plant. Please try again in a moment.",
-          status: "error",
-        });
+    try {
+      await runCreatePlant(() => createPlantAction(formData));
+    } catch (err) {
+      // The runner has already updated component state with an
+      // error-shaped result + recoveryUrl. Re-throws here are expected
+      // when retries are exhausted — log for diagnostics, don't crash.
+      if (typeof console !== "undefined") {
+        console.error("createPlantAction failed after retries", err);
       }
-    });
+    }
   }
 
   return (

--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -4,6 +4,7 @@ const createSupabaseServerClient = vi.fn();
 const logServerEvent = vi.fn();
 const getPlantTimeline = vi.fn();
 const runAndPersistPlantAnalysis = vi.fn();
+const rateLimit = vi.fn();
 
 vi.mock("../auth", () => ({
   createSupabaseServerClient: (...args: unknown[]) =>
@@ -17,6 +18,44 @@ vi.mock("../plants", () => ({
   runAndPersistPlantAnalysis: (...args: unknown[]) =>
     runAndPersistPlantAnalysis(...args),
 }));
+vi.mock("../chat-tool-policies", () => ({
+  // Default: allow every call. Suite-specific tests override via
+  // `rateLimit.mockResolvedValueOnce(...)` to exercise the limit branch.
+  // We use the existing `rateLimit` symbol to map onto the policy check
+  // so the per-tool rate-limit test continues to look natural.
+  checkPerToolRateLimit: async (
+    name: string,
+    ctx: { userId: string | null; requestId: string },
+  ) => {
+    // Only consult the mock if a per-tool policy exists for this tool;
+    // otherwise allow unconditionally (matches the real helper).
+    const policied = new Set([
+      "trigger_plant_analysis",
+      "create_plants",
+      "create_grow",
+      "record_image_finding",
+    ]);
+    if (!policied.has(name)) return { ok: true };
+    const r = await rateLimit({
+      key: `chat-tool:${name}:${ctx.userId ?? "anonymous"}`,
+      limit: 1,
+      windowMs: 1,
+    });
+    if (r.ok) return { ok: true };
+    return {
+      ok: false,
+      error: `rate limit: too many ${name} calls in a row; retry in ~1s`,
+    };
+  },
+}));
+
+// Default behavior for the mocked rateLimit: always permit. Tests that
+// need to assert the limited branch override per-test with mockResolvedValueOnce.
+rateLimit.mockResolvedValue({
+  ok: true,
+  remaining: 99,
+  resetAt: Date.now() + 60_000,
+});
 
 import { CHAT_TOOL_DEFINITIONS, executeChatTool } from "../chat-tools";
 
@@ -2160,11 +2199,64 @@ describe("chat-tools — find_grow", () => {
     expect(def?.function.parameters).toMatchObject({ required: ["query"] });
   });
 
-  it("ILIKE-searches name + description and excludes archived by default", async () => {
+  it("calls search_grows RPC with trigram ranking and default args", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: [{ id: "g-1", name: "North Tent A", match_score: 0.62 }],
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    const result = await executeChatTool(
+      "find_grow",
+      { query: "north" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("search_grows", {
+      q: "north",
+      include_archived: false,
+      max_results: 5,
+    });
+  });
+
+  it("forwards includeArchived=true to the RPC", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    await executeChatTool(
+      "find_grow",
+      { query: "spring", includeArchived: true },
+      CTX_AUTHED,
+    );
+
+    expect(rpc).toHaveBeenCalledWith("search_grows", {
+      q: "spring",
+      include_archived: true,
+      max_results: 5,
+    });
+  });
+
+  it("caps max_results at 15 even when a higher value is requested", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    await executeChatTool("find_grow", { query: "x", limit: 9999 }, CTX_AUTHED);
+
+    expect(rpc.mock.calls[0]?.[1]).toMatchObject({ max_results: 15 });
+  });
+
+  it("falls back to ILIKE when the RPC fails (e.g. migration not applied)", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "function search_grows does not exist" },
+    });
     const { client, calls, from } = makeSelectChainMock({
       data: [{ id: "g-1", name: "North Tent A" }],
       error: null,
     });
+    // Splice the rpc mock onto the chain client.
+    (client as unknown as { rpc: typeof rpc }).rpc = rpc;
     createSupabaseServerClient.mockResolvedValue(client);
 
     const result = await executeChatTool(
@@ -2174,65 +2266,22 @@ describe("chat-tools — find_grow", () => {
     );
 
     expect(result.ok).toBe(true);
+    expect(rpc).toHaveBeenCalled();
     expect(from).toHaveBeenCalledWith("grows");
     expect(calls.or[0]?.[0]).toBe(
       "name.ilike.%north%,description.ilike.%north%",
     );
-    expect(calls.eq).toContainEqual(["is_archived", false]);
-    expect(calls.limit[0]?.[0]).toBe(5);
-  });
-
-  it("includes archived when includeArchived=true", async () => {
-    const { client, calls } = makeSelectChainMock({ data: [], error: null });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    await executeChatTool(
-      "find_grow",
-      { query: "spring", includeArchived: true },
-      CTX_AUTHED,
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "warn",
+      expect.stringContaining("search_grows rpc failed"),
+      expect.any(Object),
     );
-
-    expect(calls.eq).toEqual([]);
-  });
-
-  it("caps limit at 15 even when a higher value is requested", async () => {
-    const { client, calls } = makeSelectChainMock({ data: [], error: null });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    await executeChatTool("find_grow", { query: "x", limit: 9999 }, CTX_AUTHED);
-
-    expect(calls.limit[0]?.[0]).toBe(15);
-  });
-
-  it("escapes %, _ and \\ in the user query so wildcards stay literal", async () => {
-    const { client, calls } = makeSelectChainMock({ data: [], error: null });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    await executeChatTool("find_grow", { query: "50% _ \\room" }, CTX_AUTHED);
-
-    expect(calls.or[0]?.[0]).toBe(
-      "name.ilike.%50\\% \\_ \\\\room%,description.ilike.%50\\% \\_ \\\\room%",
-    );
-  });
-
-  it("returns the supabase error message when the query fails", async () => {
-    const { client } = makeSelectChainMock({
-      data: null,
-      error: { message: "syntax error" },
-    });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    const result = await executeChatTool(
-      "find_grow",
-      { query: "x" },
-      CTX_AUTHED,
-    );
-
-    expect(result).toEqual({ ok: false, error: "syntax error" });
   });
 
   it("rejects an empty query without touching the database", async () => {
+    const rpc = vi.fn();
     const { client, from } = makeSelectChainMock({ data: [], error: null });
+    (client as unknown as { rpc: typeof rpc }).rpc = rpc;
     createSupabaseServerClient.mockResolvedValue(client);
 
     const result = await executeChatTool(
@@ -2242,6 +2291,7 @@ describe("chat-tools — find_grow", () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
     expect(from).not.toHaveBeenCalled();
   });
 });
@@ -2263,11 +2313,78 @@ describe("chat-tools — find_plant", () => {
     expect(def?.function.parameters).toMatchObject({ required: ["query"] });
   });
 
-  it("ILIKE-searches name + strain + batch_label and excludes archived by default", async () => {
+  it("calls search_plants RPC with trigram ranking and null grow scope by default", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: [{ id: "p-1", name: "Mother", match_score: 0.81 }],
+      error: null,
+    });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    const result = await executeChatTool(
+      "find_plant",
+      { query: "mother" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(rpc).toHaveBeenCalledWith("search_plants", {
+      q: "mother",
+      scope_grow_id: null,
+      include_archived: false,
+      max_results: 5,
+    });
+  });
+
+  it("scopes to a grow when growId is supplied", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    await executeChatTool(
+      "find_plant",
+      { query: "NL", growId: "g-1" },
+      CTX_AUTHED,
+    );
+
+    expect(rpc).toHaveBeenCalledWith("search_plants", {
+      q: "NL",
+      scope_grow_id: "g-1",
+      include_archived: false,
+      max_results: 5,
+    });
+  });
+
+  it("caps max_results at 15 even when a higher value is requested", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    await executeChatTool("find_plant", { query: "x", limit: 100 }, CTX_AUTHED);
+
+    expect(rpc.mock.calls[0]?.[1]).toMatchObject({ max_results: 15 });
+  });
+
+  it("includes archived when includeArchived=true", async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue({ rpc, from: vi.fn() });
+
+    await executeChatTool(
+      "find_plant",
+      { query: "old", includeArchived: true },
+      CTX_AUTHED,
+    );
+
+    expect(rpc.mock.calls[0]?.[1]).toMatchObject({ include_archived: true });
+  });
+
+  it("falls back to ILIKE when the RPC fails", async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "function search_plants does not exist" },
+    });
     const { client, calls, from } = makeSelectChainMock({
       data: [{ id: "p-1", name: "Mother" }],
       error: null,
     });
+    (client as unknown as { rpc: typeof rpc }).rpc = rpc;
     createSupabaseServerClient.mockResolvedValue(client);
 
     const result = await executeChatTool(
@@ -2277,51 +2394,17 @@ describe("chat-tools — find_plant", () => {
     );
 
     expect(result.ok).toBe(true);
+    expect(rpc).toHaveBeenCalled();
     expect(from).toHaveBeenCalledWith("plants");
     expect(calls.or[0]?.[0]).toBe(
       "name.ilike.%mother%,strain.ilike.%mother%,batch_label.ilike.%mother%",
     );
-    expect(calls.eq).toContainEqual(["is_archived", false]);
-  });
-
-  it("scopes to a grow when growId is supplied", async () => {
-    const { client, calls } = makeSelectChainMock({ data: [], error: null });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    await executeChatTool(
-      "find_plant",
-      { query: "NL", growId: "g-1" },
-      CTX_AUTHED,
-    );
-
-    expect(calls.eq).toContainEqual(["grow_id", "g-1"]);
-    expect(calls.eq).toContainEqual(["is_archived", false]);
-  });
-
-  it("caps limit at 15 even when a higher value is requested", async () => {
-    const { client, calls } = makeSelectChainMock({ data: [], error: null });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    await executeChatTool("find_plant", { query: "x", limit: 100 }, CTX_AUTHED);
-
-    expect(calls.limit[0]?.[0]).toBe(15);
-  });
-
-  it("includes archived when includeArchived=true", async () => {
-    const { client, calls } = makeSelectChainMock({ data: [], error: null });
-    createSupabaseServerClient.mockResolvedValue(client);
-
-    await executeChatTool(
-      "find_plant",
-      { query: "old", includeArchived: true },
-      CTX_AUTHED,
-    );
-
-    expect(calls.eq).toEqual([]);
   });
 
   it("rejects an empty query without touching the database", async () => {
+    const rpc = vi.fn();
     const { client, from } = makeSelectChainMock({ data: [], error: null });
+    (client as unknown as { rpc: typeof rpc }).rpc = rpc;
     createSupabaseServerClient.mockResolvedValue(client);
 
     const result = await executeChatTool(
@@ -2331,6 +2414,7 @@ describe("chat-tools — find_plant", () => {
     );
 
     expect(result.ok).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
     expect(from).not.toHaveBeenCalled();
   });
 });
@@ -2607,5 +2691,55 @@ describe("chat-tools — get_grow_summary", () => {
       const data = result.data as { daysSinceStart: number | null };
       expect(data.daysSinceStart).toBeNull();
     }
+  });
+});
+
+describe("chat-tools — per-tool rate limit", () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    runAndPersistPlantAnalysis.mockReset();
+    rateLimit.mockReset();
+    logServerEvent.mockReset();
+    rateLimit.mockResolvedValue({
+      ok: true,
+      remaining: 99,
+      resetAt: Date.now() + 60_000,
+    });
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns a rate-limit error for trigger_plant_analysis when the budget is exceeded and never touches Gemini", async () => {
+    const resetAt = Date.now() + 30_000;
+    rateLimit.mockResolvedValueOnce({ ok: false, remaining: 0, resetAt });
+
+    const result = await executeChatTool(
+      "trigger_plant_analysis",
+      { plantId: "p-1" },
+      CTX_AUTHED,
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/rate limit/i);
+    }
+    expect(rateLimit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: expect.stringContaining("chat-tool:trigger_plant_analysis:"),
+      }),
+    );
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+    expect(runAndPersistPlantAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("does not impose a per-tool budget on read tools like list_grows", async () => {
+    const { client } = makeSelectChainMock({ data: [], error: null });
+    createSupabaseServerClient.mockResolvedValue(client);
+
+    await executeChatTool("list_grows", {}, CTX_AUTHED);
+
+    // No per-tool policy → rateLimit not consulted for list_grows.
+    expect(rateLimit).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/server/chat-tool-definitions.ts
+++ b/apps/web/src/lib/server/chat-tool-definitions.ts
@@ -1,0 +1,816 @@
+import "server-only";
+
+// Tool definitions exposed to OpenAI. Extracted from chat-tools.ts
+// to keep the executor module under a manageable size — pure data,
+// no behavior. The matching argument schemas + handlers live in
+// chat-tools.ts; the matching system-prompt copy lives in chat-prompt.ts.
+
+export const CHAT_TOOL_DEFINITIONS = [
+  {
+    type: "function" as const,
+    function: {
+      name: "list_grows",
+      description:
+        "List the user's grows (most recently updated first). Use when the user references a grow but you don't yet know which one, or to find candidate grows by stage.",
+      parameters: {
+        type: "object",
+        properties: {
+          limit: {
+            type: "number",
+            description: "Max grows to return. Default 10, max 25.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "list_plants",
+      description:
+        "List plants in a given grow. Returns id, name, strain, batch label, notes.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: { type: "string", description: "Grow ID to scope to." },
+          limit: { type: "number", description: "Max plants. Default 25." },
+        },
+        required: ["growId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_recent_findings",
+      description:
+        "Return the most recent plant findings (diagnoses from image analysis) for a grow or plant. Use to ground advice in observed evidence.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: { type: "string" },
+          plantId: { type: "string" },
+          limit: { type: "number", description: "Max findings. Default 10." },
+          sinceDays: {
+            type: "number",
+            description: "Only findings within the last N days. Default 30.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_recent_observations",
+      description:
+        "Return the most recent grower-recorded plant observations (height, notes) for a grow or plant.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: { type: "string" },
+          plantId: { type: "string" },
+          limit: {
+            type: "number",
+            description: "Max observations. Default 10.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_grow_events",
+      description:
+        "Return recent grow events (water, feed, top, lst, defoliate, transplant, ipm, harvest, observation, note, etc.) for a grow or plant. Critical for diagnosing watering / feeding / training issues.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: { type: "string" },
+          plantId: { type: "string" },
+          limit: { type: "number", description: "Max events. Default 15." },
+          sinceDays: { type: "number", description: "Default 14." },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_latest_analysis",
+      description:
+        "Return the most recent image analysis (overall health score, summary, comparison summary) for a plant.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: { type: "string" },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_analysis_history",
+      description:
+        "Return the recent image-analysis history for a plant (newest first) so you can describe trends over time. Each row includes overall_health_score, summary, comparison_summary, model_version, and created_at — use these to discuss progression, regression, or stability.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: { type: "string" },
+          limit: {
+            type: "number",
+            description: "Max history rows. Default 8, max 20.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "log_grow_event",
+      description:
+        "Record a cultivation action the grower just performed: water, feed, top, fim, lst, defoliate, transplant, ipm (pest treatment), harvest, observation, note, other. Use this when the user describes something they DID — 'I just watered tent 2', 'fed plant 3 with FloraNova at 800 EC', 'topped #4 above the 5th node'. Always confirm the grow (and plant, if specific) and the event_type before calling. The event is attributed to the current user and timestamped to now unless occurredAt is supplied. Returns the new event id.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description:
+              "Grow ID the event belongs to. Required. If unknown, call list_grows first.",
+          },
+          plantId: {
+            type: "string",
+            description:
+              "Optional plant ID when the action targeted a single plant. Omit for whole-grow events (e.g. environmental adjustments).",
+          },
+          eventType: {
+            type: "string",
+            enum: [
+              "water",
+              "feed",
+              "top",
+              "fim",
+              "lst",
+              "defoliate",
+              "transplant",
+              "ipm",
+              "harvest",
+              "observation",
+              "note",
+              "other",
+            ],
+            description:
+              "Event category. Pick the most specific match. Use 'other' only when no category fits.",
+          },
+          notes: {
+            type: "string",
+            description:
+              "Free-text detail (product, dose, EC/pH, observed runoff, branch trained, etc.). Up to 2000 chars.",
+          },
+          occurredAt: {
+            type: "string",
+            description:
+              "ISO 8601 timestamp the action actually happened. Omit to use now. Cannot be in the future.",
+          },
+        },
+        required: ["growId", "eventType"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "log_plant_observation",
+      description:
+        "Record a manual observation about a single plant — typically height in cm and/or a free-text note ('node 5 inter-nodal spacing tightening, pistils fattening'). Use when the user reports a measurement or qualitative observation. Returns the new observation id.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID being observed. Required.",
+          },
+          growId: {
+            type: "string",
+            description:
+              "Grow ID the plant belongs to. Required so the row can be RLS-checked.",
+          },
+          heightCm: {
+            type: "number",
+            description:
+              "Height in centimetres (numeric, two decimals). Omit if not measured.",
+          },
+          notes: {
+            type: "string",
+            description:
+              "Free-text observation (up to 2000 chars). At least one of heightCm or notes must be supplied.",
+          },
+          observedAt: {
+            type: "string",
+            description:
+              "ISO 8601 timestamp the observation was made. Omit to use now. Cannot be in the future.",
+          },
+        },
+        required: ["plantId", "growId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "mark_finding_resolved",
+      description:
+        "Mark an AI-generated plant finding as resolved (or re-open it). Use when the user confirms they've addressed an issue ('I flushed the deficiency yesterday and it looks better' → mark the matching nutrient_deficiency finding resolved) or wants to re-open one they thought was fixed. Resolution sets `resolved_at` to now (or a supplied timestamp); re-opening clears it. You can only modify this field — severity, category, and description are immutable.",
+      parameters: {
+        type: "object",
+        properties: {
+          findingId: {
+            type: "string",
+            description:
+              "Finding ID to update. Required. If you don't know it, call get_recent_findings first.",
+          },
+          resolved: {
+            type: "boolean",
+            description:
+              "true to mark resolved (sets resolved_at), false to re-open (clears resolved_at). Required.",
+          },
+          resolvedAt: {
+            type: "string",
+            description:
+              "ISO 8601 timestamp the issue was actually resolved. Omit to use now. Ignored when resolved=false. Cannot be in the future.",
+          },
+        },
+        required: ["findingId", "resolved"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_grow_stage",
+      description:
+        "Transition the entire grow to a new growth stage. Use when the user says they switched the room/tent — 'I flipped the tent to flower yesterday', 'moved everyone to veg'. Stage is a property of the GROW, not individual plants (schema constraint today), so this affects every plant in that grow. Only grow OWNERS can change stage today (collaborators get a permission error). Returns the updated stage.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description: "Grow ID to update. Required.",
+          },
+          stage: {
+            type: "string",
+            enum: [
+              "germination",
+              "seedling",
+              "vegetative",
+              "pre_flower",
+              "flower",
+              "late_flower",
+              "harvest",
+              "dry_cure",
+            ],
+            description:
+              "New stage. Use 'pre_flower' for the stretch / first-pistils transition, 'late_flower' for the final 2-3 weeks before harvest, 'dry_cure' for post-harvest dry+cure.",
+          },
+        },
+        required: ["growId", "stage"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "list_open_tasks",
+      description:
+        "List actionable tasks for a grow or plant. Tasks are auto-created from high/critical AI findings, and may also be created manually. Use to surface what the grower should do next, or to ground a reply in their actual worklist. Returns open + in_progress tasks by default, newest urgent first.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description:
+              "Grow ID to scope to. Either growId or plantId is required.",
+          },
+          plantId: {
+            type: "string",
+            description:
+              "Plant ID to scope to (filters tasks where plant_id matches). Either growId or plantId is required.",
+          },
+          includeCompleted: {
+            type: "boolean",
+            description:
+              "Set true to include done + dismissed tasks too. Default false (only open + in_progress).",
+          },
+          limit: {
+            type: "number",
+            description: "Max tasks. Default 10, max 25.",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_task_status",
+      description:
+        "Transition a grow_task to a new status — typically 'done' when the grower says they completed the action, or 'dismissed' when the task no longer applies (e.g. a false-positive finding). Setting status to 'done' or 'dismissed' stamps completed_at; setting it back to 'open' or 'in_progress' clears completed_at. Returns the updated task. Owner + collaborator only.",
+      parameters: {
+        type: "object",
+        properties: {
+          taskId: {
+            type: "string",
+            description: "Task ID to update. Required.",
+          },
+          status: {
+            type: "string",
+            enum: ["open", "in_progress", "done", "dismissed"],
+            description: "New status. Required.",
+          },
+        },
+        required: ["taskId", "status"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "create_grow",
+      description:
+        "Create a new grow record on the user's behalf. Use when the user wants to set up a brand-new tent / room / cultivation program — 'start a new grow called North Tent in soil under LED', 'I'm beginning week 1 of a hydro flower run, set it up'. Always confirm at least name + stage + medium + light before calling. The grow is owned by the current user. Returns the new grow id and name so follow-up tools (create_plants, etc.) can reference it.",
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description:
+              "Operator-facing grow name (1-120 chars). Required. Examples: 'North Tent A', 'Greenhouse Spring 2026', 'Veg Room B'.",
+          },
+          stage: {
+            type: "string",
+            enum: [
+              "germination",
+              "seedling",
+              "vegetative",
+              "pre_flower",
+              "flower",
+              "late_flower",
+              "harvest",
+              "dry_cure",
+            ],
+            description:
+              "Current stage. Pick the most specific match for what the grower is doing today (default to 'seedling' for a fresh start when unclear).",
+          },
+          medium: {
+            type: "string",
+            enum: ["soil", "coco", "hydro", "aero", "living_soil", "other"],
+            description: "Cultivation medium.",
+          },
+          lightType: {
+            type: "string",
+            enum: ["hps", "cmh", "led", "t5", "sun", "mixed", "other"],
+            description: "Primary light source.",
+          },
+          startDate: {
+            type: "string",
+            description:
+              "ISO 8601 date (YYYY-MM-DD) the grow began. Omit to default to today. Cannot be more than 1 day in the future.",
+          },
+          targetHarvestDate: {
+            type: "string",
+            description:
+              "Optional ISO 8601 date (YYYY-MM-DD) the grower is aiming to harvest. Must be on or after startDate.",
+          },
+          description: {
+            type: "string",
+            description:
+              "Optional free-text notes about the room / cultivar / facility (up to 2000 chars).",
+          },
+        },
+        required: ["name", "stage", "medium", "lightType"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "create_plants",
+      description:
+        "Create one or more plant records inside an existing grow. Use immediately after create_grow when the user describes how many plants they're running, or any time they say 'add N plants to <grow>'. When count > 1, names are auto-suffixed with zero-padded numbers (e.g. 'Plant 01', 'Plant 02'; 'NL 10' two-digit padding when count >= 10). Returns the list of created plant ids and names so the model can reference specific plants in follow-up.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description:
+              "Target grow ID. Required. If unknown, call list_grows first.",
+          },
+          name: {
+            type: "string",
+            description:
+              "Plant name (count=1) or name prefix (count>1). 1-115 chars; the bulk path appends ' NN' so keep room for the suffix.",
+          },
+          count: {
+            type: "number",
+            description:
+              "How many plants to create. Default 1. Maximum 25 per call.",
+          },
+          strain: {
+            type: "string",
+            description:
+              "Optional cultivar / strain name applied to every plant created in this call.",
+          },
+          batchLabel: {
+            type: "string",
+            description:
+              "Optional tray or batch reference applied to every plant.",
+          },
+          notes: {
+            type: "string",
+            description:
+              "Optional free-text notes applied to every plant (up to 2000 chars).",
+          },
+        },
+        required: ["growId", "name"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "create_grow_task",
+      description:
+        "Create a manual task in a grow's worklist. Use when the user asks for a reminder, follow-up action, or to capture something they need to do later — 'remind me to flush in 3 days', 'add a task to check trichomes Friday'. Tasks auto-created from AI findings already exist; this tool is for grower-initiated reminders only. Returns the new task id.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description:
+              "Grow ID the task belongs to. Required. If unknown, call list_grows first.",
+          },
+          plantId: {
+            type: "string",
+            description:
+              "Optional plant ID when the task targets a single plant.",
+          },
+          title: {
+            type: "string",
+            description:
+              "Short, action-oriented title (1-200 chars). Examples: 'Flush plants 3 and 4', 'Check trichomes Friday'.",
+          },
+          description: {
+            type: "string",
+            description: "Optional longer detail (up to 2000 chars).",
+          },
+          priority: {
+            type: "string",
+            enum: ["low", "medium", "high", "urgent"],
+            description:
+              "Task priority. Default 'medium'. Use 'urgent' only when the grower flags an immediate issue.",
+          },
+          dueAt: {
+            type: "string",
+            description:
+              "Optional ISO 8601 datetime when the task is due. Must be in the future.",
+          },
+        },
+        required: ["growId", "title"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_grow",
+      description:
+        "Update a grow's mutable metadata — rename it, edit the description, fix the medium / light_type, set or clear the target harvest date, or archive / un-archive it. Use when the user wants to correct a mistake ('rename the Test grow to North Tent'), evolve the program ('we switched to coco'), or wrap up the cycle ('archive the spring 2026 run'). Stage transitions go through update_grow_stage, not this tool. Pass only the fields the user actually wants to change — omitted fields are left untouched. At least one mutable field is required. Owner only.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description: "Grow ID to update. Required.",
+          },
+          name: {
+            type: "string",
+            description:
+              "New grow name (1-120 chars). Omit to leave unchanged.",
+          },
+          description: {
+            type: "string",
+            description:
+              "Replacement free-text description (up to 2000 chars). Pass an empty string to clear an existing description; omit to leave unchanged.",
+          },
+          medium: {
+            type: "string",
+            enum: ["soil", "coco", "hydro", "aero", "living_soil", "other"],
+            description: "New cultivation medium. Omit to leave unchanged.",
+          },
+          lightType: {
+            type: "string",
+            enum: ["hps", "cmh", "led", "t5", "sun", "mixed", "other"],
+            description: "New primary light source. Omit to leave unchanged.",
+          },
+          targetHarvestDate: {
+            type: "string",
+            description:
+              "ISO 8601 date (YYYY-MM-DD) the grower is now aiming to harvest. Pass an empty string to clear an existing target; omit to leave unchanged.",
+          },
+          archived: {
+            type: "boolean",
+            description:
+              "true to archive the grow (soft-delete; plants + history stay readable), false to un-archive it. Omit to leave unchanged.",
+          },
+        },
+        required: ["growId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "update_plant",
+      description:
+        "Update a plant's mutable metadata — rename it, set/replace the strain, batch label, or notes, or archive / un-archive it. Use when the user wants to correct a name from a bulk create ('rename Plant 03 to Mother'), tag a phenotype ('strain is Northern Lights #5'), or retire a plant ('archive Plant 02, it died'). Pass only the fields the user actually wants to change — omitted fields are left untouched. At least one mutable field is required. Owner only.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID to update. Required.",
+          },
+          name: {
+            type: "string",
+            description:
+              "New plant name (1-120 chars). Omit to leave unchanged.",
+          },
+          strain: {
+            type: "string",
+            description:
+              "Replacement cultivar / strain name. Pass an empty string to clear; omit to leave unchanged.",
+          },
+          batchLabel: {
+            type: "string",
+            description:
+              "Replacement batch / tray reference. Pass an empty string to clear; omit to leave unchanged.",
+          },
+          notes: {
+            type: "string",
+            description:
+              "Replacement free-text notes (up to 2000 chars). Pass an empty string to clear; omit to leave unchanged.",
+          },
+          archived: {
+            type: "boolean",
+            description:
+              "true to archive the plant (soft-delete; image history + findings stay readable), false to un-archive it. Omit to leave unchanged.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "record_image_finding",
+      description:
+        "File a structured plant_findings row when the user describes a plant-health issue they've observed — typically tied to a photo they just uploaded. Use this for definite diagnoses ('there's brown spots on Plant 4's middle fans, looks like septoria'), not for casual notes (use log_plant_observation for that). The row is tagged source='user_reported' to distinguish it from AI-generated findings, and the existing auto-task trigger will create an open grow_task automatically if severity is high or critical. Owner + collaborator only. Returns the new finding id.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID the finding is about. Required.",
+          },
+          growId: {
+            type: "string",
+            description:
+              "Grow ID the plant belongs to. Required so the row can be RLS-checked.",
+          },
+          category: {
+            type: "string",
+            enum: [
+              "nutrient_deficiency",
+              "nutrient_toxicity",
+              "pest",
+              "disease",
+              "environmental",
+              "training",
+              "general",
+              "positive",
+            ],
+            description:
+              "Finding category. Pick the most specific match. 'general' is the catch-all when nothing fits; 'positive' is for confirming things are going right.",
+          },
+          severity: {
+            type: "string",
+            enum: ["info", "low", "medium", "high", "critical"],
+            description:
+              "How urgent this is. high + critical auto-create an open grow_task via the existing trigger — reserve those for issues that need action soon.",
+          },
+          title: {
+            type: "string",
+            description:
+              "Short, headline-style title (1-200 chars). Examples: 'Early N deficiency on lower fans', 'Suspected spider mites under leaves'.",
+          },
+          description: {
+            type: "string",
+            description:
+              "Longer detail (up to 2000 chars). What was observed, where on the plant, in what context.",
+          },
+          recommendation: {
+            type: "string",
+            description:
+              "Optional suggested action (up to 2000 chars). Becomes the body of the auto-created task when severity is high/critical.",
+          },
+          imageId: {
+            type: "string",
+            description:
+              "Optional plant_image ID this finding refers to. Omit if not tied to a specific image.",
+          },
+        },
+        required: ["plantId", "growId", "category", "severity", "title"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_plant_timeline",
+      description:
+        "Return the unified time-ordered timeline of a plant — images, observations, AI findings, and analysis summaries merged in one feed. Use when the user asks a question that needs cross-source history ('how has Plant 3 progressed this week?', 'when did we last water this one?', 'show me everything that's happened to plant 4'). Newest items first. Returns up to `limit` items.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID to read. Required.",
+          },
+          limit: {
+            type: "number",
+            description:
+              "Max items to return. Default 20, max 50. The model should request the smallest useful window to stay within token budget.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "trigger_plant_analysis",
+      description:
+        "Run the AI vision analysis pipeline on a plant photo and persist the result. Use when the user just uploaded a photo and wants immediate diagnostic feedback, or asks 'analyze this again with the new context'. By default analyzes the most recent image; pass imageId to analyze a specific historical image. The call is synchronous and may take 5-30 seconds — narrate that to the user before invoking. Returns the new analysis row (overall_health_score, summary, comparison_summary, findings count). RLS-scoped: the user must own or collaborate on the plant's grow.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantId: {
+            type: "string",
+            description: "Plant ID to analyze. Required.",
+          },
+          imageId: {
+            type: "string",
+            description:
+              "Specific image to analyze. Omit to use the most recent image. Useful for re-analyzing a historical capture in light of new context.",
+          },
+        },
+        required: ["plantId"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "find_grow",
+      description:
+        "Resolve a free-text reference to a grow ('north tent', 'the spring run', 'soil hydro') into one or more candidate grow ids. Use as the FIRST step when the user mentions a grow conversationally so you can avoid an awkward 'which grow?' round-trip. Case-insensitive substring match on grow name + description, ordered by most recently updated. Returns up to `limit` candidates; if exactly one matches, the model can confidently proceed.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Free-text reference from the user (1-120 chars). Examples: 'north tent', 'spring 2026', 'flower room'.",
+          },
+          includeArchived: {
+            type: "boolean",
+            description:
+              "Set true to include archived grows. Default false — most resolution queries should ignore archived rows.",
+          },
+          limit: {
+            type: "number",
+            description:
+              "Max candidates to return. Default 5, max 15. Smaller is better — narrow the search if you get too many.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "find_plant",
+      description:
+        "Resolve a free-text reference to a plant ('the mother', 'plant 3', 'NL 01', 'phenotype A') into one or more candidate plant ids. Use as the FIRST step when the user mentions a plant conversationally. Case-insensitive substring match across plants.name, strain, and batch_label; optionally scoped to a grow. Ordered by most recently updated. Returns up to `limit` candidates with their grow id so follow-up tools can be called immediately.",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description:
+              "Free-text reference from the user (1-120 chars). Examples: 'the mother', 'NL 01', 'phenotype A', 'plant 3'.",
+          },
+          growId: {
+            type: "string",
+            description:
+              "Optional grow ID to constrain the search. Use this when you already know which grow the user is talking about.",
+          },
+          includeArchived: {
+            type: "boolean",
+            description: "Set true to include archived plants. Default false.",
+          },
+          limit: {
+            type: "number",
+            description: "Max candidates. Default 5, max 15.",
+          },
+        },
+        required: ["query"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "compare_plants",
+      description:
+        "Side-by-side comparison of 2-4 plants over a recent window. Returns each plant's latest analysis summary (health score, summary, comparison_summary) plus event / observation / open-task / unresolved-finding counts since `sinceDays`. Use for cross-plant longitudinal questions: 'how does plant 3 compare to plant 4 this week', 'which of the seedlings is lagging', 'is the LED tent doing better than the HPS tent overall'. Cheaper than calling get_plant_timeline for each plant — one call returns the comparable summary fields.",
+      parameters: {
+        type: "object",
+        properties: {
+          plantIds: {
+            type: "array",
+            items: { type: "string" },
+            description: "2-4 plant ids to compare. Required.",
+          },
+          sinceDays: {
+            type: "number",
+            description:
+              "Activity window for the counts (events, observations, findings). Default 14, max 90.",
+          },
+        },
+        required: ["plantIds"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function" as const,
+    function: {
+      name: "get_grow_summary",
+      description:
+        "Whole-grow snapshot in one call — grow metadata (stage, medium, light, days since start), plant count, open-task count broken down by priority, unresolved-finding count broken down by severity, and the most recent event / observation timestamps. Use to answer 'how's the north tent doing overall?' or as a fast first read before deeper investigation. Replaces several separate read tool chains.",
+      parameters: {
+        type: "object",
+        properties: {
+          growId: {
+            type: "string",
+            description: "Grow ID to summarise. Required.",
+          },
+        },
+        required: ["growId"],
+        additionalProperties: false,
+      },
+    },
+  },
+];

--- a/apps/web/src/lib/server/chat-tool-policies.ts
+++ b/apps/web/src/lib/server/chat-tool-policies.ts
@@ -1,0 +1,66 @@
+import "server-only";
+import { rateLimit } from "./rate-limit";
+import { logServerEvent } from "./request-id";
+
+// Per-tool rate limits keyed on `(userId|anonymous, toolName)`. The
+// chat route already enforces a generic ceiling on the whole turn
+// (~30/min/user, see /api/chat/route.ts); this is a defence-in-depth
+// budget that throttles the expensive tools specifically, so a single
+// runaway prompt can't fan out N analysis calls inside one turn.
+//
+// Tools not listed inherit no per-tool cap. Limits expressed as
+// `{ limit, windowMs }` for the sliding-window backend.
+export const PER_TOOL_RATE_LIMITS: Record<
+  string,
+  { limit: number; windowMs: number }
+> = {
+  // Hits Gemini + Supabase writes; expensive and slow.
+  trigger_plant_analysis: { limit: 6, windowMs: 60_000 },
+  // Bulk insert with auto-numbered names; bounded but worth capping.
+  create_plants: { limit: 10, windowMs: 60_000 },
+  // Wallet-spending writes worth capping per minute.
+  create_grow: { limit: 10, windowMs: 60_000 },
+  record_image_finding: { limit: 20, windowMs: 60_000 },
+};
+
+export type RateLimitToolResult = { ok: true } | { ok: false; error: string };
+
+export type RateLimitToolContext = {
+  userId: string | null;
+  requestId: string;
+};
+
+// Returns { ok: true } when the call is permitted (either no policy
+// configured for the tool, or the budget hasn't been exhausted).
+// Returns { ok: false, error } with a user-readable retry hint when
+// the budget IS exhausted.
+export async function checkPerToolRateLimit(
+  toolName: string,
+  ctx: RateLimitToolContext,
+): Promise<RateLimitToolResult> {
+  const policy = PER_TOOL_RATE_LIMITS[toolName];
+  if (!policy) return { ok: true };
+  const subject = ctx.userId ?? "anonymous";
+  const result = await rateLimit({
+    key: `chat-tool:${toolName}:${subject}`,
+    limit: policy.limit,
+    windowMs: policy.windowMs,
+  });
+  if (!result.ok) {
+    logServerEvent("warn", "chat tool rate-limited", {
+      requestId: ctx.requestId,
+      userId: ctx.userId,
+      tool: toolName,
+      resetAt: result.resetAt,
+    });
+    const retryInSec = Math.max(
+      1,
+      Math.ceil((result.resetAt - Date.now()) / 1000),
+    );
+    return {
+      ok: false,
+      error: `rate limit: too many ${toolName} calls in a row; retry in ~${retryInSec}s`,
+    };
+  }
+  return { ok: true };
+}

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -1,824 +1,22 @@
 import "server-only";
 import { z } from "zod";
 import { createSupabaseServerClient } from "./auth";
+import { checkPerToolRateLimit } from "./chat-tool-policies";
 import { getPlantTimeline, runAndPersistPlantAnalysis } from "./plants";
 import { logServerEvent } from "./request-id";
 
-// Tool definitions exposed to OpenAI. The handlers are intentionally
-// thin — they call the user-scoped Supabase client which is RLS-gated,
-// so a user can never read another user's data through a chat tool call.
-
-export const CHAT_TOOL_DEFINITIONS = [
-  {
-    type: "function" as const,
-    function: {
-      name: "list_grows",
-      description:
-        "List the user's grows (most recently updated first). Use when the user references a grow but you don't yet know which one, or to find candidate grows by stage.",
-      parameters: {
-        type: "object",
-        properties: {
-          limit: {
-            type: "number",
-            description: "Max grows to return. Default 10, max 25.",
-          },
-        },
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "list_plants",
-      description:
-        "List plants in a given grow. Returns id, name, strain, batch label, notes.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: { type: "string", description: "Grow ID to scope to." },
-          limit: { type: "number", description: "Max plants. Default 25." },
-        },
-        required: ["growId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_recent_findings",
-      description:
-        "Return the most recent plant findings (diagnoses from image analysis) for a grow or plant. Use to ground advice in observed evidence.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: { type: "string" },
-          plantId: { type: "string" },
-          limit: { type: "number", description: "Max findings. Default 10." },
-          sinceDays: {
-            type: "number",
-            description: "Only findings within the last N days. Default 30.",
-          },
-        },
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_recent_observations",
-      description:
-        "Return the most recent grower-recorded plant observations (height, notes) for a grow or plant.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: { type: "string" },
-          plantId: { type: "string" },
-          limit: {
-            type: "number",
-            description: "Max observations. Default 10.",
-          },
-        },
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_grow_events",
-      description:
-        "Return recent grow events (water, feed, top, lst, defoliate, transplant, ipm, harvest, observation, note, etc.) for a grow or plant. Critical for diagnosing watering / feeding / training issues.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: { type: "string" },
-          plantId: { type: "string" },
-          limit: { type: "number", description: "Max events. Default 15." },
-          sinceDays: { type: "number", description: "Default 14." },
-        },
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_latest_analysis",
-      description:
-        "Return the most recent image analysis (overall health score, summary, comparison summary) for a plant.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: { type: "string" },
-        },
-        required: ["plantId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_analysis_history",
-      description:
-        "Return the recent image-analysis history for a plant (newest first) so you can describe trends over time. Each row includes overall_health_score, summary, comparison_summary, model_version, and created_at — use these to discuss progression, regression, or stability.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: { type: "string" },
-          limit: {
-            type: "number",
-            description: "Max history rows. Default 8, max 20.",
-          },
-        },
-        required: ["plantId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "log_grow_event",
-      description:
-        "Record a cultivation action the grower just performed: water, feed, top, fim, lst, defoliate, transplant, ipm (pest treatment), harvest, observation, note, other. Use this when the user describes something they DID — 'I just watered tent 2', 'fed plant 3 with FloraNova at 800 EC', 'topped #4 above the 5th node'. Always confirm the grow (and plant, if specific) and the event_type before calling. The event is attributed to the current user and timestamped to now unless occurredAt is supplied. Returns the new event id.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description:
-              "Grow ID the event belongs to. Required. If unknown, call list_grows first.",
-          },
-          plantId: {
-            type: "string",
-            description:
-              "Optional plant ID when the action targeted a single plant. Omit for whole-grow events (e.g. environmental adjustments).",
-          },
-          eventType: {
-            type: "string",
-            enum: [
-              "water",
-              "feed",
-              "top",
-              "fim",
-              "lst",
-              "defoliate",
-              "transplant",
-              "ipm",
-              "harvest",
-              "observation",
-              "note",
-              "other",
-            ],
-            description:
-              "Event category. Pick the most specific match. Use 'other' only when no category fits.",
-          },
-          notes: {
-            type: "string",
-            description:
-              "Free-text detail (product, dose, EC/pH, observed runoff, branch trained, etc.). Up to 2000 chars.",
-          },
-          occurredAt: {
-            type: "string",
-            description:
-              "ISO 8601 timestamp the action actually happened. Omit to use now. Cannot be in the future.",
-          },
-        },
-        required: ["growId", "eventType"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "log_plant_observation",
-      description:
-        "Record a manual observation about a single plant — typically height in cm and/or a free-text note ('node 5 inter-nodal spacing tightening, pistils fattening'). Use when the user reports a measurement or qualitative observation. Returns the new observation id.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: {
-            type: "string",
-            description: "Plant ID being observed. Required.",
-          },
-          growId: {
-            type: "string",
-            description:
-              "Grow ID the plant belongs to. Required so the row can be RLS-checked.",
-          },
-          heightCm: {
-            type: "number",
-            description:
-              "Height in centimetres (numeric, two decimals). Omit if not measured.",
-          },
-          notes: {
-            type: "string",
-            description:
-              "Free-text observation (up to 2000 chars). At least one of heightCm or notes must be supplied.",
-          },
-          observedAt: {
-            type: "string",
-            description:
-              "ISO 8601 timestamp the observation was made. Omit to use now. Cannot be in the future.",
-          },
-        },
-        required: ["plantId", "growId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "mark_finding_resolved",
-      description:
-        "Mark an AI-generated plant finding as resolved (or re-open it). Use when the user confirms they've addressed an issue ('I flushed the deficiency yesterday and it looks better' → mark the matching nutrient_deficiency finding resolved) or wants to re-open one they thought was fixed. Resolution sets `resolved_at` to now (or a supplied timestamp); re-opening clears it. You can only modify this field — severity, category, and description are immutable.",
-      parameters: {
-        type: "object",
-        properties: {
-          findingId: {
-            type: "string",
-            description:
-              "Finding ID to update. Required. If you don't know it, call get_recent_findings first.",
-          },
-          resolved: {
-            type: "boolean",
-            description:
-              "true to mark resolved (sets resolved_at), false to re-open (clears resolved_at). Required.",
-          },
-          resolvedAt: {
-            type: "string",
-            description:
-              "ISO 8601 timestamp the issue was actually resolved. Omit to use now. Ignored when resolved=false. Cannot be in the future.",
-          },
-        },
-        required: ["findingId", "resolved"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "update_grow_stage",
-      description:
-        "Transition the entire grow to a new growth stage. Use when the user says they switched the room/tent — 'I flipped the tent to flower yesterday', 'moved everyone to veg'. Stage is a property of the GROW, not individual plants (schema constraint today), so this affects every plant in that grow. Only grow OWNERS can change stage today (collaborators get a permission error). Returns the updated stage.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description: "Grow ID to update. Required.",
-          },
-          stage: {
-            type: "string",
-            enum: [
-              "germination",
-              "seedling",
-              "vegetative",
-              "pre_flower",
-              "flower",
-              "late_flower",
-              "harvest",
-              "dry_cure",
-            ],
-            description:
-              "New stage. Use 'pre_flower' for the stretch / first-pistils transition, 'late_flower' for the final 2-3 weeks before harvest, 'dry_cure' for post-harvest dry+cure.",
-          },
-        },
-        required: ["growId", "stage"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "list_open_tasks",
-      description:
-        "List actionable tasks for a grow or plant. Tasks are auto-created from high/critical AI findings, and may also be created manually. Use to surface what the grower should do next, or to ground a reply in their actual worklist. Returns open + in_progress tasks by default, newest urgent first.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description:
-              "Grow ID to scope to. Either growId or plantId is required.",
-          },
-          plantId: {
-            type: "string",
-            description:
-              "Plant ID to scope to (filters tasks where plant_id matches). Either growId or plantId is required.",
-          },
-          includeCompleted: {
-            type: "boolean",
-            description:
-              "Set true to include done + dismissed tasks too. Default false (only open + in_progress).",
-          },
-          limit: {
-            type: "number",
-            description: "Max tasks. Default 10, max 25.",
-          },
-        },
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "update_task_status",
-      description:
-        "Transition a grow_task to a new status — typically 'done' when the grower says they completed the action, or 'dismissed' when the task no longer applies (e.g. a false-positive finding). Setting status to 'done' or 'dismissed' stamps completed_at; setting it back to 'open' or 'in_progress' clears completed_at. Returns the updated task. Owner + collaborator only.",
-      parameters: {
-        type: "object",
-        properties: {
-          taskId: {
-            type: "string",
-            description: "Task ID to update. Required.",
-          },
-          status: {
-            type: "string",
-            enum: ["open", "in_progress", "done", "dismissed"],
-            description: "New status. Required.",
-          },
-        },
-        required: ["taskId", "status"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "create_grow",
-      description:
-        "Create a new grow record on the user's behalf. Use when the user wants to set up a brand-new tent / room / cultivation program — 'start a new grow called North Tent in soil under LED', 'I'm beginning week 1 of a hydro flower run, set it up'. Always confirm at least name + stage + medium + light before calling. The grow is owned by the current user. Returns the new grow id and name so follow-up tools (create_plants, etc.) can reference it.",
-      parameters: {
-        type: "object",
-        properties: {
-          name: {
-            type: "string",
-            description:
-              "Operator-facing grow name (1-120 chars). Required. Examples: 'North Tent A', 'Greenhouse Spring 2026', 'Veg Room B'.",
-          },
-          stage: {
-            type: "string",
-            enum: [
-              "germination",
-              "seedling",
-              "vegetative",
-              "pre_flower",
-              "flower",
-              "late_flower",
-              "harvest",
-              "dry_cure",
-            ],
-            description:
-              "Current stage. Pick the most specific match for what the grower is doing today (default to 'seedling' for a fresh start when unclear).",
-          },
-          medium: {
-            type: "string",
-            enum: ["soil", "coco", "hydro", "aero", "living_soil", "other"],
-            description: "Cultivation medium.",
-          },
-          lightType: {
-            type: "string",
-            enum: ["hps", "cmh", "led", "t5", "sun", "mixed", "other"],
-            description: "Primary light source.",
-          },
-          startDate: {
-            type: "string",
-            description:
-              "ISO 8601 date (YYYY-MM-DD) the grow began. Omit to default to today. Cannot be more than 1 day in the future.",
-          },
-          targetHarvestDate: {
-            type: "string",
-            description:
-              "Optional ISO 8601 date (YYYY-MM-DD) the grower is aiming to harvest. Must be on or after startDate.",
-          },
-          description: {
-            type: "string",
-            description:
-              "Optional free-text notes about the room / cultivar / facility (up to 2000 chars).",
-          },
-        },
-        required: ["name", "stage", "medium", "lightType"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "create_plants",
-      description:
-        "Create one or more plant records inside an existing grow. Use immediately after create_grow when the user describes how many plants they're running, or any time they say 'add N plants to <grow>'. When count > 1, names are auto-suffixed with zero-padded numbers (e.g. 'Plant 01', 'Plant 02'; 'NL 10' two-digit padding when count >= 10). Returns the list of created plant ids and names so the model can reference specific plants in follow-up.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description:
-              "Target grow ID. Required. If unknown, call list_grows first.",
-          },
-          name: {
-            type: "string",
-            description:
-              "Plant name (count=1) or name prefix (count>1). 1-115 chars; the bulk path appends ' NN' so keep room for the suffix.",
-          },
-          count: {
-            type: "number",
-            description:
-              "How many plants to create. Default 1. Maximum 25 per call.",
-          },
-          strain: {
-            type: "string",
-            description:
-              "Optional cultivar / strain name applied to every plant created in this call.",
-          },
-          batchLabel: {
-            type: "string",
-            description:
-              "Optional tray or batch reference applied to every plant.",
-          },
-          notes: {
-            type: "string",
-            description:
-              "Optional free-text notes applied to every plant (up to 2000 chars).",
-          },
-        },
-        required: ["growId", "name"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "create_grow_task",
-      description:
-        "Create a manual task in a grow's worklist. Use when the user asks for a reminder, follow-up action, or to capture something they need to do later — 'remind me to flush in 3 days', 'add a task to check trichomes Friday'. Tasks auto-created from AI findings already exist; this tool is for grower-initiated reminders only. Returns the new task id.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description:
-              "Grow ID the task belongs to. Required. If unknown, call list_grows first.",
-          },
-          plantId: {
-            type: "string",
-            description:
-              "Optional plant ID when the task targets a single plant.",
-          },
-          title: {
-            type: "string",
-            description:
-              "Short, action-oriented title (1-200 chars). Examples: 'Flush plants 3 and 4', 'Check trichomes Friday'.",
-          },
-          description: {
-            type: "string",
-            description: "Optional longer detail (up to 2000 chars).",
-          },
-          priority: {
-            type: "string",
-            enum: ["low", "medium", "high", "urgent"],
-            description:
-              "Task priority. Default 'medium'. Use 'urgent' only when the grower flags an immediate issue.",
-          },
-          dueAt: {
-            type: "string",
-            description:
-              "Optional ISO 8601 datetime when the task is due. Must be in the future.",
-          },
-        },
-        required: ["growId", "title"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "update_grow",
-      description:
-        "Update a grow's mutable metadata — rename it, edit the description, fix the medium / light_type, set or clear the target harvest date, or archive / un-archive it. Use when the user wants to correct a mistake ('rename the Test grow to North Tent'), evolve the program ('we switched to coco'), or wrap up the cycle ('archive the spring 2026 run'). Stage transitions go through update_grow_stage, not this tool. Pass only the fields the user actually wants to change — omitted fields are left untouched. At least one mutable field is required. Owner only.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description: "Grow ID to update. Required.",
-          },
-          name: {
-            type: "string",
-            description:
-              "New grow name (1-120 chars). Omit to leave unchanged.",
-          },
-          description: {
-            type: "string",
-            description:
-              "Replacement free-text description (up to 2000 chars). Pass an empty string to clear an existing description; omit to leave unchanged.",
-          },
-          medium: {
-            type: "string",
-            enum: ["soil", "coco", "hydro", "aero", "living_soil", "other"],
-            description: "New cultivation medium. Omit to leave unchanged.",
-          },
-          lightType: {
-            type: "string",
-            enum: ["hps", "cmh", "led", "t5", "sun", "mixed", "other"],
-            description: "New primary light source. Omit to leave unchanged.",
-          },
-          targetHarvestDate: {
-            type: "string",
-            description:
-              "ISO 8601 date (YYYY-MM-DD) the grower is now aiming to harvest. Pass an empty string to clear an existing target; omit to leave unchanged.",
-          },
-          archived: {
-            type: "boolean",
-            description:
-              "true to archive the grow (soft-delete; plants + history stay readable), false to un-archive it. Omit to leave unchanged.",
-          },
-        },
-        required: ["growId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "update_plant",
-      description:
-        "Update a plant's mutable metadata — rename it, set/replace the strain, batch label, or notes, or archive / un-archive it. Use when the user wants to correct a name from a bulk create ('rename Plant 03 to Mother'), tag a phenotype ('strain is Northern Lights #5'), or retire a plant ('archive Plant 02, it died'). Pass only the fields the user actually wants to change — omitted fields are left untouched. At least one mutable field is required. Owner only.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: {
-            type: "string",
-            description: "Plant ID to update. Required.",
-          },
-          name: {
-            type: "string",
-            description:
-              "New plant name (1-120 chars). Omit to leave unchanged.",
-          },
-          strain: {
-            type: "string",
-            description:
-              "Replacement cultivar / strain name. Pass an empty string to clear; omit to leave unchanged.",
-          },
-          batchLabel: {
-            type: "string",
-            description:
-              "Replacement batch / tray reference. Pass an empty string to clear; omit to leave unchanged.",
-          },
-          notes: {
-            type: "string",
-            description:
-              "Replacement free-text notes (up to 2000 chars). Pass an empty string to clear; omit to leave unchanged.",
-          },
-          archived: {
-            type: "boolean",
-            description:
-              "true to archive the plant (soft-delete; image history + findings stay readable), false to un-archive it. Omit to leave unchanged.",
-          },
-        },
-        required: ["plantId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "record_image_finding",
-      description:
-        "File a structured plant_findings row when the user describes a plant-health issue they've observed — typically tied to a photo they just uploaded. Use this for definite diagnoses ('there's brown spots on Plant 4's middle fans, looks like septoria'), not for casual notes (use log_plant_observation for that). The row is tagged source='user_reported' to distinguish it from AI-generated findings, and the existing auto-task trigger will create an open grow_task automatically if severity is high or critical. Owner + collaborator only. Returns the new finding id.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: {
-            type: "string",
-            description: "Plant ID the finding is about. Required.",
-          },
-          growId: {
-            type: "string",
-            description:
-              "Grow ID the plant belongs to. Required so the row can be RLS-checked.",
-          },
-          category: {
-            type: "string",
-            enum: [
-              "nutrient_deficiency",
-              "nutrient_toxicity",
-              "pest",
-              "disease",
-              "environmental",
-              "training",
-              "general",
-              "positive",
-            ],
-            description:
-              "Finding category. Pick the most specific match. 'general' is the catch-all when nothing fits; 'positive' is for confirming things are going right.",
-          },
-          severity: {
-            type: "string",
-            enum: ["info", "low", "medium", "high", "critical"],
-            description:
-              "How urgent this is. high + critical auto-create an open grow_task via the existing trigger — reserve those for issues that need action soon.",
-          },
-          title: {
-            type: "string",
-            description:
-              "Short, headline-style title (1-200 chars). Examples: 'Early N deficiency on lower fans', 'Suspected spider mites under leaves'.",
-          },
-          description: {
-            type: "string",
-            description:
-              "Longer detail (up to 2000 chars). What was observed, where on the plant, in what context.",
-          },
-          recommendation: {
-            type: "string",
-            description:
-              "Optional suggested action (up to 2000 chars). Becomes the body of the auto-created task when severity is high/critical.",
-          },
-          imageId: {
-            type: "string",
-            description:
-              "Optional plant_image ID this finding refers to. Omit if not tied to a specific image.",
-          },
-        },
-        required: ["plantId", "growId", "category", "severity", "title"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_plant_timeline",
-      description:
-        "Return the unified time-ordered timeline of a plant — images, observations, AI findings, and analysis summaries merged in one feed. Use when the user asks a question that needs cross-source history ('how has Plant 3 progressed this week?', 'when did we last water this one?', 'show me everything that's happened to plant 4'). Newest items first. Returns up to `limit` items.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: {
-            type: "string",
-            description: "Plant ID to read. Required.",
-          },
-          limit: {
-            type: "number",
-            description:
-              "Max items to return. Default 20, max 50. The model should request the smallest useful window to stay within token budget.",
-          },
-        },
-        required: ["plantId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "trigger_plant_analysis",
-      description:
-        "Run the AI vision analysis pipeline on a plant photo and persist the result. Use when the user just uploaded a photo and wants immediate diagnostic feedback, or asks 'analyze this again with the new context'. By default analyzes the most recent image; pass imageId to analyze a specific historical image. The call is synchronous and may take 5-30 seconds — narrate that to the user before invoking. Returns the new analysis row (overall_health_score, summary, comparison_summary, findings count). RLS-scoped: the user must own or collaborate on the plant's grow.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantId: {
-            type: "string",
-            description: "Plant ID to analyze. Required.",
-          },
-          imageId: {
-            type: "string",
-            description:
-              "Specific image to analyze. Omit to use the most recent image. Useful for re-analyzing a historical capture in light of new context.",
-          },
-        },
-        required: ["plantId"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "find_grow",
-      description:
-        "Resolve a free-text reference to a grow ('north tent', 'the spring run', 'soil hydro') into one or more candidate grow ids. Use as the FIRST step when the user mentions a grow conversationally so you can avoid an awkward 'which grow?' round-trip. Case-insensitive substring match on grow name + description, ordered by most recently updated. Returns up to `limit` candidates; if exactly one matches, the model can confidently proceed.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description:
-              "Free-text reference from the user (1-120 chars). Examples: 'north tent', 'spring 2026', 'flower room'.",
-          },
-          includeArchived: {
-            type: "boolean",
-            description:
-              "Set true to include archived grows. Default false — most resolution queries should ignore archived rows.",
-          },
-          limit: {
-            type: "number",
-            description:
-              "Max candidates to return. Default 5, max 15. Smaller is better — narrow the search if you get too many.",
-          },
-        },
-        required: ["query"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "find_plant",
-      description:
-        "Resolve a free-text reference to a plant ('the mother', 'plant 3', 'NL 01', 'phenotype A') into one or more candidate plant ids. Use as the FIRST step when the user mentions a plant conversationally. Case-insensitive substring match across plants.name, strain, and batch_label; optionally scoped to a grow. Ordered by most recently updated. Returns up to `limit` candidates with their grow id so follow-up tools can be called immediately.",
-      parameters: {
-        type: "object",
-        properties: {
-          query: {
-            type: "string",
-            description:
-              "Free-text reference from the user (1-120 chars). Examples: 'the mother', 'NL 01', 'phenotype A', 'plant 3'.",
-          },
-          growId: {
-            type: "string",
-            description:
-              "Optional grow ID to constrain the search. Use this when you already know which grow the user is talking about.",
-          },
-          includeArchived: {
-            type: "boolean",
-            description: "Set true to include archived plants. Default false.",
-          },
-          limit: {
-            type: "number",
-            description: "Max candidates. Default 5, max 15.",
-          },
-        },
-        required: ["query"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "compare_plants",
-      description:
-        "Side-by-side comparison of 2-4 plants over a recent window. Returns each plant's latest analysis summary (health score, summary, comparison_summary) plus event / observation / open-task / unresolved-finding counts since `sinceDays`. Use for cross-plant longitudinal questions: 'how does plant 3 compare to plant 4 this week', 'which of the seedlings is lagging', 'is the LED tent doing better than the HPS tent overall'. Cheaper than calling get_plant_timeline for each plant — one call returns the comparable summary fields.",
-      parameters: {
-        type: "object",
-        properties: {
-          plantIds: {
-            type: "array",
-            items: { type: "string" },
-            description: "2-4 plant ids to compare. Required.",
-          },
-          sinceDays: {
-            type: "number",
-            description:
-              "Activity window for the counts (events, observations, findings). Default 14, max 90.",
-          },
-        },
-        required: ["plantIds"],
-        additionalProperties: false,
-      },
-    },
-  },
-  {
-    type: "function" as const,
-    function: {
-      name: "get_grow_summary",
-      description:
-        "Whole-grow snapshot in one call — grow metadata (stage, medium, light, days since start), plant count, open-task count broken down by priority, unresolved-finding count broken down by severity, and the most recent event / observation timestamps. Use to answer 'how's the north tent doing overall?' or as a fast first read before deeper investigation. Replaces several separate read tool chains.",
-      parameters: {
-        type: "object",
-        properties: {
-          growId: {
-            type: "string",
-            description: "Grow ID to summarise. Required.",
-          },
-        },
-        required: ["growId"],
-        additionalProperties: false,
-      },
-    },
-  },
-];
+// Tool definitions live in chat-tool-definitions.ts (pure data) so this
+// module — executor + schemas + handlers — stays focused on behavior.
+export { CHAT_TOOL_DEFINITIONS } from "./chat-tool-definitions";
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
+
+// Hard ceiling on the synchronous Gemini analysis call inside
+// `trigger_plant_analysis`. Vercel hobby is 60s and pro is 300s on
+// route handlers; 45s leaves headroom for the model's own response
+// after the tool completes. When async via analysis_jobs lands
+// (migration 005 — worker not yet wired up), this constant goes away.
+const ANALYSIS_TOOL_TIMEOUT_MS = 45_000;
 
 const numClamp = (n: unknown, def: number, max: number): number => {
   const parsed = typeof n === "number" && Number.isFinite(n) ? n : def;
@@ -1185,6 +383,12 @@ export async function executeChatTool(
   ctx: ChatToolContext,
 ): Promise<ToolResult> {
   const started = Date.now();
+
+  // Per-tool rate limit BEFORE client init so a hammered tool doesn't
+  // even pay the auth-cookie-parse cost.
+  const rl = await checkPerToolRateLimit(name, ctx);
+  if (!rl.ok) return { ok: false, error: rl.error };
+
   let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
   if (ctx.supabase) {
     supabase = ctx.supabase;
@@ -1839,7 +1043,22 @@ export async function executeChatTool(
               requestId: ctx.requestId,
             };
             if (args.imageId) analyzeParams.imageId = args.imageId;
-            const result = await runAndPersistPlantAnalysis(analyzeParams);
+            // Synchronous Gemini call inside the tool loop. Hard
+            // ceiling so a stalled upstream doesn't hold the chat
+            // stream open indefinitely — the model can re-issue the
+            // tool call on the next turn if the user wants to retry.
+            // (async-job follow-up: see analysis_jobs table from
+            // migration 005 — a worker that drains the queue is not
+            // wired up yet, so the sync path stays default.)
+            const result = await Promise.race([
+              runAndPersistPlantAnalysis(analyzeParams),
+              new Promise<never>((_, reject) =>
+                setTimeout(
+                  () => reject(new Error("analysis timed out after 45s")),
+                  ANALYSIS_TOOL_TIMEOUT_MS,
+                ),
+              ),
+            ]);
             if (!result) {
               return {
                 ok: false,
@@ -1891,39 +1110,82 @@ export async function executeChatTool(
         case "find_grow": {
           const args = FindGrowArgs.parse(rawArgs);
           const limit = numClamp(args.limit, 5, 15);
-          const pattern = `%${escapeIlikePattern(args.query)}%`;
-          let q = supabase
-            .from("grows")
-            .select(
-              "id,name,description,stage,medium,light_type,start_date,is_archived,updated_at",
-            )
-            .or(`name.ilike.${pattern},description.ilike.${pattern}`)
-            .order("updated_at", { ascending: false })
-            .limit(limit);
-          if (!args.includeArchived) q = q.eq("is_archived", false);
-          const { data, error } = await q;
-          if (error) return { ok: false, error: error.message };
+          // Trigram-ranked RPC (migration 019). RLS still applies
+          // because the RPC is SECURITY INVOKER. Falls back to
+          // substring ILIKE inside the SQL function for very short
+          // queries that don't meet the trigram similarity threshold.
+          const { data, error } = await supabase.rpc("search_grows", {
+            q: args.query,
+            include_archived: args.includeArchived ?? false,
+            max_results: limit,
+          });
+          if (error) {
+            // Defence in depth: if the RPC is missing (migration not
+            // applied) or its signature drifts, fall back to the old
+            // ILIKE path so the agent stays functional rather than
+            // returning "(error)" for every grow lookup.
+            logServerEvent(
+              "warn",
+              "search_grows rpc failed, falling back to ilike",
+              {
+                requestId: ctx.requestId,
+                userId: ctx.userId,
+                error: error.message,
+              },
+            );
+            const pattern = `%${escapeIlikePattern(args.query)}%`;
+            let q = supabase
+              .from("grows")
+              .select(
+                "id,name,description,stage,medium,light_type,start_date,is_archived,updated_at",
+              )
+              .or(`name.ilike.${pattern},description.ilike.${pattern}`)
+              .order("updated_at", { ascending: false })
+              .limit(limit);
+            if (!args.includeArchived) q = q.eq("is_archived", false);
+            const fb = await q;
+            if (fb.error) return { ok: false, error: fb.error.message };
+            return { ok: true, data: fb.data ?? [] };
+          }
           return { ok: true, data: data ?? [] };
         }
 
         case "find_plant": {
           const args = FindPlantArgs.parse(rawArgs);
           const limit = numClamp(args.limit, 5, 15);
-          const pattern = `%${escapeIlikePattern(args.query)}%`;
-          let q = supabase
-            .from("plants")
-            .select(
-              "id,grow_id,name,strain,batch_label,notes,is_archived,updated_at",
-            )
-            .or(
-              `name.ilike.${pattern},strain.ilike.${pattern},batch_label.ilike.${pattern}`,
-            )
-            .order("updated_at", { ascending: false })
-            .limit(limit);
-          if (args.growId) q = q.eq("grow_id", args.growId);
-          if (!args.includeArchived) q = q.eq("is_archived", false);
-          const { data, error } = await q;
-          if (error) return { ok: false, error: error.message };
+          const { data, error } = await supabase.rpc("search_plants", {
+            q: args.query,
+            scope_grow_id: args.growId ?? null,
+            include_archived: args.includeArchived ?? false,
+            max_results: limit,
+          });
+          if (error) {
+            logServerEvent(
+              "warn",
+              "search_plants rpc failed, falling back to ilike",
+              {
+                requestId: ctx.requestId,
+                userId: ctx.userId,
+                error: error.message,
+              },
+            );
+            const pattern = `%${escapeIlikePattern(args.query)}%`;
+            let q = supabase
+              .from("plants")
+              .select(
+                "id,grow_id,name,strain,batch_label,notes,is_archived,updated_at",
+              )
+              .or(
+                `name.ilike.${pattern},strain.ilike.${pattern},batch_label.ilike.${pattern}`,
+              )
+              .order("updated_at", { ascending: false })
+              .limit(limit);
+            if (args.growId) q = q.eq("grow_id", args.growId);
+            if (!args.includeArchived) q = q.eq("is_archived", false);
+            const fb = await q;
+            if (fb.error) return { ok: false, error: fb.error.message };
+            return { ok: true, data: fb.data ?? [] };
+          }
           return { ok: true, data: data ?? [] };
         }
 

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -1050,15 +1050,23 @@ export async function executeChatTool(
             // (async-job follow-up: see analysis_jobs table from
             // migration 005 — a worker that drains the queue is not
             // wired up yet, so the sync path stays default.)
+            //
+            // The timer is captured in a let-binding and cleared in
+            // `finally` so a fast-path success doesn't leave the
+            // event loop holding a 45s timeout — important when
+            // multiple tool calls fan out in one chat turn.
+            let timeoutId: ReturnType<typeof setTimeout> | undefined;
             const result = await Promise.race([
               runAndPersistPlantAnalysis(analyzeParams),
-              new Promise<never>((_, reject) =>
-                setTimeout(
+              new Promise<never>((_, reject) => {
+                timeoutId = setTimeout(
                   () => reject(new Error("analysis timed out after 45s")),
                   ANALYSIS_TOOL_TIMEOUT_MS,
-                ),
-              ),
-            ]);
+                );
+              }),
+            ]).finally(() => {
+              if (timeoutId !== undefined) clearTimeout(timeoutId);
+            });
             if (!result) {
               return {
                 ok: false,

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "check:routes": "node scripts/check-route-boundaries.mjs",
     "check:imports": "node scripts/check-imports.mjs",
     "check:code-scanning": "node scripts/check-code-scanning-patterns.mjs",
+    "check:budgets": "node scripts/check-file-budgets.mjs",
     "check:scope": "node scripts/check-changed-scope.mjs",
     "security:routes": "node scripts/check-route-security.mjs",
     "security:audit": "node scripts/security-audit.mjs",
     "pr:guardian": "node scripts/pr-guardian.mjs",
     "smoke:preview": "node scripts/smoke-preview.mjs",
-    "validate": "pnpm run check:env && pnpm run check:routes && pnpm run check:imports && pnpm run check:code-scanning",
+    "validate": "pnpm run check:env && pnpm run check:routes && pnpm run check:imports && pnpm run check:code-scanning && pnpm run check:budgets",
     "prepare": "husky"
   },
   "engines": {

--- a/scripts/check-file-budgets.mjs
+++ b/scripts/check-file-budgets.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// scripts/check-file-budgets.mjs
+//
+// Per-file line-count budgets. Forces a focused refactor before a hot file
+// grows past the point where it becomes hard to reason about, hard to
+// merge concurrently, and slow for the IDE/tooling to parse.
+//
+// Budgets are deliberately generous — they exist to prevent runaway
+// growth, not to police every PR. When a budget is hit, the right move
+// is to split the file (see chat-tools.ts → chat-tool-definitions.ts
+// for the pattern); raising the limit should be a last resort and
+// explained in the PR body.
+
+import { readFileSync, existsSync } from "node:fs";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(
+  /^\/([A-Za-z]:)/,
+  "$1",
+);
+
+// path → max non-empty lines. Test files are exempt by convention
+// (they grow with coverage); add them explicitly if a cap is desired.
+const BUDGETS = [
+  ["apps/web/src/lib/server/chat-tools.ts", 1500],
+  ["apps/web/src/lib/server/chat-tool-definitions.ts", 1200],
+];
+
+const errors = [];
+
+for (const [rel, max] of BUDGETS) {
+  const full = ROOT + rel;
+  if (!existsSync(full)) {
+    errors.push(`Missing file in budget list: ${rel}`);
+    continue;
+  }
+  const lines = readFileSync(full, "utf8").split("\n").length;
+  if (lines > max) {
+    errors.push(
+      `${rel}: ${lines} lines exceeds budget of ${max}. Split the file (extract pure data, schemas, or per-domain handlers) before adding more.`,
+    );
+  }
+}
+
+if (errors.length) {
+  console.error("✗ check-file-budgets: violations\n");
+  for (const e of errors) console.error("  - " + e);
+  process.exit(1);
+}
+console.log("✓ check-file-budgets: OK");

--- a/supabase/migrations/019_pg_trgm_search.sql
+++ b/supabase/migrations/019_pg_trgm_search.sql
@@ -1,0 +1,210 @@
+-- Migration: 019_pg_trgm_search
+--
+-- Installs pg_trgm and adds GIN trigram indexes on the columns the chat
+-- agent's find_grow / find_plant tools currently scan with ILIKE
+-- (see PR #143). Drop-in speedup: PostgREST `.ilike()` queries
+-- transparently pick up GIN trigram indexes, so even without code
+-- changes ILIKE goes from full-scan to index-lookup at scale (~60-80ms
+-- for fuzzy substring on multi-million-row tables per pg_trgm docs).
+--
+-- This migration also exposes two SECURITY INVOKER RPCs —
+-- `search_grows` and `search_plants` — that rank results by trigram
+-- similarity instead of substring match alone. The RPCs run as the
+-- calling role, so RLS policies on `grows` and `plants` apply
+-- unmodified (a viewer can't surface another user's rows via the RPC).
+--
+-- # Why pg_trgm vs full-text-search
+--
+--   * Plant + grow names are typically short labels ("North Tent",
+--     "Plant 03", "OG Kush #2") — not prose. Full-text search shines
+--     on tokenised prose; trigrams shine on short fuzzy substrings,
+--     misspellings, and partial matches.
+--   * pg_trgm `%` operator and `similarity()` provide a single
+--     similarity score we can rank by; FTS needs `ts_rank_cd` plus
+--     a tsvector column.
+--   * pg_trgm needs no extra column (operates directly on the text
+--     column), so no rewrite of insert paths.
+--
+-- # Safety posture
+--
+--   * Extension lives in `extensions` schema, consistent with
+--     migration 013 for pgvector. Roles already have `extensions` in
+--     search_path so unqualified `similarity()` resolves.
+--   * Indexes are `IF NOT EXISTS` — re-running the migration is a
+--     no-op. CONCURRENTLY is intentionally NOT used because Supabase
+--     migrations run inside a transaction; expected row counts are
+--     small (per-user dozens of grows, hundreds of plants).
+--   * RPCs are SECURITY INVOKER with locked search_path. RLS
+--     policies on the underlying tables enforce ownership. The RPCs
+--     return only public columns already exposed by the existing
+--     read tools.
+--   * `pg_trgm.similarity_threshold` is left at the default (0.3).
+--     The `%` operator uses it for the candidate filter; the RPC
+--     also accepts a substring fallback so single-character or
+--     diacritic-stripped queries still resolve.
+--
+-- # Rollback (do NOT run unless explicitly approved)
+--
+--   drop function if exists public.search_grows(text, boolean, int);
+--   drop function if exists public.search_plants(text, uuid, boolean, int);
+--   drop index if exists idx_grows_name_trgm;
+--   drop index if exists idx_grows_description_trgm;
+--   drop index if exists idx_plants_name_trgm;
+--   drop index if exists idx_plants_strain_trgm;
+--   drop index if exists idx_plants_batch_label_trgm;
+--   -- Leave the extension installed; other tooling may rely on it.
+
+-- ─── 1. Install pg_trgm in extensions schema ─────────────────────────
+
+create extension if not exists pg_trgm with schema extensions;
+
+-- ─── 2. GIN trigram indexes on hot search columns ────────────────────
+-- `gin_trgm_ops` is the GIN operator class shipped by pg_trgm; it
+-- accelerates ILIKE, LIKE, ~*, ~ on the indexed column. Partial
+-- indexes skip archived rows because the chat tools default to
+-- `is_archived = false`; archived rows still match via sequential
+-- scan if `includeArchived = true` is passed.
+
+create index if not exists idx_grows_name_trgm
+  on public.grows using gin (name extensions.gin_trgm_ops)
+  where is_archived = false;
+
+create index if not exists idx_grows_description_trgm
+  on public.grows using gin (description extensions.gin_trgm_ops)
+  where is_archived = false and description is not null;
+
+create index if not exists idx_plants_name_trgm
+  on public.plants using gin (name extensions.gin_trgm_ops)
+  where is_archived = false;
+
+create index if not exists idx_plants_strain_trgm
+  on public.plants using gin (strain extensions.gin_trgm_ops)
+  where is_archived = false and strain is not null;
+
+create index if not exists idx_plants_batch_label_trgm
+  on public.plants using gin (batch_label extensions.gin_trgm_ops)
+  where is_archived = false and batch_label is not null;
+
+-- ─── 3. search_grows RPC — trigram-ranked find ───────────────────────
+-- Returns up to `max_results` grows ordered by similarity score.
+-- The candidate set is the union of:
+--   * substring match (ilike '%q%') — preserves the old behavior so
+--     single-character / very short queries still resolve
+--   * trigram match (% operator, threshold 0.3 by default) — catches
+--     misspellings + reorderings ("nort tnt" → "North Tent")
+-- Ranking favors name matches over description matches (0.7x weight).
+
+create or replace function public.search_grows(
+  q text,
+  include_archived boolean default false,
+  max_results int default 5
+)
+returns table (
+  id uuid,
+  name text,
+  description text,
+  stage text,
+  medium text,
+  light_type text,
+  start_date date,
+  is_archived boolean,
+  updated_at timestamptz,
+  match_score real
+)
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  with q_input as (
+    select trim(coalesce(q, '')) as qt
+  ), candidates as (
+    select g.id, g.name, g.description, g.stage::text, g.medium::text,
+           g.light_type::text, g.start_date, g.is_archived, g.updated_at,
+           greatest(
+             extensions.similarity(g.name, (select qt from q_input)),
+             coalesce(
+               extensions.similarity(g.description, (select qt from q_input)) * 0.7,
+               0
+             )
+           )::real as match_score
+    from public.grows g, q_input
+    where (include_archived or g.is_archived = false)
+      and length(q_input.qt) > 0
+      and (
+        g.name ilike '%' || q_input.qt || '%'
+        or g.description ilike '%' || q_input.qt || '%'
+        or g.name operator(extensions.%) q_input.qt
+        or coalesce(g.description, '') operator(extensions.%) q_input.qt
+      )
+  )
+  select * from candidates
+  order by match_score desc, updated_at desc
+  limit greatest(1, least(coalesce(max_results, 5), 25));
+$$;
+
+-- ─── 4. search_plants RPC — trigram-ranked find ──────────────────────
+-- Optional grow_id scope so the agent can narrow to a single grow.
+
+create or replace function public.search_plants(
+  q text,
+  scope_grow_id uuid default null,
+  include_archived boolean default false,
+  max_results int default 5
+)
+returns table (
+  id uuid,
+  grow_id uuid,
+  name text,
+  strain text,
+  batch_label text,
+  notes text,
+  is_archived boolean,
+  updated_at timestamptz,
+  match_score real
+)
+language sql
+stable
+security invoker
+set search_path = ''
+as $$
+  with q_input as (
+    select trim(coalesce(q, '')) as qt
+  ), candidates as (
+    select p.id, p.grow_id, p.name, p.strain, p.batch_label, p.notes,
+           p.is_archived, p.updated_at,
+           greatest(
+             extensions.similarity(p.name, (select qt from q_input)),
+             coalesce(
+               extensions.similarity(p.strain, (select qt from q_input)) * 0.8,
+               0
+             ),
+             coalesce(
+               extensions.similarity(p.batch_label, (select qt from q_input)) * 0.7,
+               0
+             )
+           )::real as match_score
+    from public.plants p, q_input
+    where (scope_grow_id is null or p.grow_id = scope_grow_id)
+      and (include_archived or p.is_archived = false)
+      and length(q_input.qt) > 0
+      and (
+        p.name ilike '%' || q_input.qt || '%'
+        or p.strain ilike '%' || q_input.qt || '%'
+        or p.batch_label ilike '%' || q_input.qt || '%'
+        or p.name operator(extensions.%) q_input.qt
+        or coalesce(p.strain, '') operator(extensions.%) q_input.qt
+        or coalesce(p.batch_label, '') operator(extensions.%) q_input.qt
+      )
+  )
+  select * from candidates
+  order by match_score desc, updated_at desc
+  limit greatest(1, least(coalesce(max_results, 5), 25));
+$$;
+
+-- Grants — PostgREST honors these for `.rpc()` callability. Without
+-- the grant, anon/authenticated get "function … does not exist".
+grant execute on function public.search_grows(text, boolean, int)
+  to authenticated, service_role;
+grant execute on function public.search_plants(text, uuid, boolean, int)
+  to authenticated, service_role;


### PR DESCRIPTION
## Summary

Closes the post-#146 review punch list across six items. Adds the **pg_trgm migration** the agentic chat tools have wanted since PR #143, tightens reliability around the synchronous Gemini path, and pays down a few hygiene items (constant duplication, file-size drift) before they got worse.

### What changed

- **Migration 019 — `pg_trgm_search`**
  - Installs `pg_trgm` in the `extensions` schema (consistent with PR #013's pgvector posture).
  - Adds partial GIN trigram indexes on `grows.{name,description}` and `plants.{name,strain,batch_label}` — automatic ILIKE acceleration from full-scan to index lookup.
  - Exposes two SECURITY INVOKER RPCs (`search_grows`, `search_plants`) that rank candidates by trigram similarity, with a substring fallback inside the SQL for very short queries. RLS still applies because they run as the calling user.
- **`chat-tools.ts` rewires `find_grow` / `find_plant`** to use the new RPCs, with a defence-in-depth ILIKE fallback so the agent stays functional if the migration hasn't been applied yet.
- **`trigger_plant_analysis` timeout** — 45s `Promise.race` ceiling so a stalled Gemini call can't hold the chat stream open. Comment notes that this constant goes away once `analysis_jobs` (migration 005) gets a worker.
- **Per-tool rate limits** — defence-in-depth budgets for the expensive tools (analysis 6/min, create_grow / create_plants 10/min, record_image_finding 20/min). Extracted into `chat-tool-policies.ts` so the executor stays focused on behavior. Tests added for both the limited and unbudgeted-tool branches.
- **`useActionWithRecovery` on `plant-form`** — PR #145 hook is now consumed by the plants create flow too. Transient errors retry once with backoff; router.push failures can't strand the user.
- **`grows/constants.ts`** — dedupes `MAX_DESCRIPTION_LENGTH` + `MAX_FUTURE_START_MS` that PR #145 left split across `grows/actions.ts` and `grows/[id]/actions.ts`.
- **`scripts/check-file-budgets.mjs`** — new guard wired into `pnpm run validate`. Today caps `chat-tools.ts` at 1500 lines and `chat-tool-definitions.ts` at 1200. Forces an explicit refactor before merge when a budget is hit (which is exactly what surfaced the policy-module extraction in this PR).
- **`CHAT_TOOL_DEFINITIONS` extracted** to its own data module so the executor file's size budget bites on behavior code only.

### Verification

Run locally on the branch:

- `pnpm run validate` — env / routes / imports / code-scanning / **budgets** ✓
- `pnpm turbo run type-check` (2/2 pkgs) ✓
- `pnpm turbo run test` — **676/676 tests pass** ✓
- `pnpm turbo run lint` ✓
- `pytest` (apps/analysis) — **86/86 pass** ✓
- `pnpm run security:routes` ✓

### Action required after merge

Apply migration 019 to prod via `supabase db push` (or the standard migration workflow). Until then the RPC path returns `function search_grows does not exist` and the code path falls back to ILIKE — functional, just slower at scale.

### Deferred (not in this PR — separate issue worthy)

- Full async `trigger_plant_analysis` via the `analysis_jobs` table from migration 005. The table is provisioned but no worker drains it; flipping the chat tool to enqueue-and-return without a worker would silently regress the user-facing behavior. The 45s timeout in this PR is the safe interim hardening.
- `plant_aliases` table for chat to learn user-coined names (PR #143 follow-up).
- Action receipt UI cards for write-tool audit trail (PR #144 follow-up).
- HNSW vs IVFFlat reconsider for embeddings — premature at current row counts.

## Test plan

- [ ] CI green: `validate`, `type-check`, `test`, `lint`, `security:routes`, `pytest`
- [ ] Apply migration 019 to a Supabase branch / preview project and smoke-test that the `search_grows` / `search_plants` RPCs return rows (the chat-tools tests cover the fallback path; the RPC path itself needs a real Postgres)
- [ ] Manual smoke: open `/plants/new`, simulate a transient submit failure (devtools throttle to offline → restore), confirm the form retries once and the manual recovery link appears if push fails

https://claude.ai/code/session_019hXZpCWsYndVMGhJdAedey

---
_Generated by [Claude Code](https://claude.ai/code/session_019hXZpCWsYndVMGhJdAedey)_