### PR TITLE
refactor(chat-tools): extract schemas; clear file-budget headroom; fix Prettier drift

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -26,7 +26,7 @@
     --ps-surface-2: 230 225 206; /* #E6E1CE */
     --ps-panel: 247 242 226;
     --ps-line: 34 42 32;
-    --ps-line-strength: 0.10;
+    --ps-line-strength: 0.1;
     --ps-line-strong-strength: 0.18;
     --ps-ink: 26 36 24; /* #1A2418 deep cola */
     --ps-ink-2: 58 69 52; /* #3A4534 */
@@ -61,8 +61,8 @@
       var(--font-general-sans, "General Sans"), "Söhne", -apple-system,
       BlinkMacSystemFont, system-ui, sans-serif;
     --ps-font-mono:
-      var(--font-jetbrains-mono, "JetBrains Mono"), "IBM Plex Mono", ui-monospace,
-      SFMono-Regular, Menlo, monospace;
+      var(--font-jetbrains-mono, "JetBrains Mono"), "IBM Plex Mono",
+      ui-monospace, SFMono-Regular, Menlo, monospace;
 
     /* ── Legacy shadcn-style HSL tokens (Tailwind) ─────── */
     --background: 47 32% 90%; /* hemp-paper */
@@ -188,7 +188,10 @@
     background-color: rgb(var(--ps-canvas));
     color: rgb(var(--ps-ink));
     font-family: var(--ps-font-body);
-    font-feature-settings: "rlig" 1, "calt" 1, "ss01" 1;
+    font-feature-settings:
+      "rlig" 1,
+      "calt" 1,
+      "ss01" 1;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -325,12 +328,24 @@
   .ps-rise {
     animation: ps-rise 0.45s cubic-bezier(0.2, 0.7, 0.3, 1) backwards;
   }
-  .ps-rise:nth-child(1) { animation-delay: 0.02s; }
-  .ps-rise:nth-child(2) { animation-delay: 0.06s; }
-  .ps-rise:nth-child(3) { animation-delay: 0.10s; }
-  .ps-rise:nth-child(4) { animation-delay: 0.14s; }
-  .ps-rise:nth-child(5) { animation-delay: 0.18s; }
-  .ps-rise:nth-child(6) { animation-delay: 0.22s; }
+  .ps-rise:nth-child(1) {
+    animation-delay: 0.02s;
+  }
+  .ps-rise:nth-child(2) {
+    animation-delay: 0.06s;
+  }
+  .ps-rise:nth-child(3) {
+    animation-delay: 0.1s;
+  }
+  .ps-rise:nth-child(4) {
+    animation-delay: 0.14s;
+  }
+  .ps-rise:nth-child(5) {
+    animation-delay: 0.18s;
+  }
+  .ps-rise:nth-child(6) {
+    animation-delay: 0.22s;
+  }
 }
 
 /* -----------------------------------------------------------
@@ -350,25 +365,55 @@
   }
 
   /* Surfaces */
-  .bg-surface { background-color: rgb(var(--ps-surface)); }
-  .bg-surface-2 { background-color: rgb(var(--ps-surface-2)); }
-  .bg-panel { background-color: rgb(var(--ps-panel)); }
-  .bg-background-subtle { background-color: rgb(var(--ps-surface-2) / 0.55); }
-  .bg-background-subtle\/50 { background-color: rgb(var(--ps-surface-2) / 0.5); }
-  .bg-background-subtle\/60 { background-color: rgb(var(--ps-surface-2) / 0.6); }
-  .bg-background-subtle\/65 { background-color: rgb(var(--ps-surface-2) / 0.65); }
-  .bg-background-subtle\/70 { background-color: rgb(var(--ps-surface-2) / 0.7); }
+  .bg-surface {
+    background-color: rgb(var(--ps-surface));
+  }
+  .bg-surface-2 {
+    background-color: rgb(var(--ps-surface-2));
+  }
+  .bg-panel {
+    background-color: rgb(var(--ps-panel));
+  }
+  .bg-background-subtle {
+    background-color: rgb(var(--ps-surface-2) / 0.55);
+  }
+  .bg-background-subtle\/50 {
+    background-color: rgb(var(--ps-surface-2) / 0.5);
+  }
+  .bg-background-subtle\/60 {
+    background-color: rgb(var(--ps-surface-2) / 0.6);
+  }
+  .bg-background-subtle\/65 {
+    background-color: rgb(var(--ps-surface-2) / 0.65);
+  }
+  .bg-background-subtle\/70 {
+    background-color: rgb(var(--ps-surface-2) / 0.7);
+  }
 
   /* Borders */
-  .border-strong { border-color: rgb(var(--ps-line) / var(--ps-line-strong-strength)); }
-  .border-border-strong { border-color: rgb(var(--ps-line) / var(--ps-line-strong-strength)); }
-  .border-border-strong\/70 { border-color: rgb(var(--ps-line) / 0.14); }
-  .border-border\/70 { border-color: rgb(var(--ps-line) / 0.07); }
-  .border-border\/80 { border-color: rgb(var(--ps-line) / 0.085); }
+  .border-strong {
+    border-color: rgb(var(--ps-line) / var(--ps-line-strong-strength));
+  }
+  .border-border-strong {
+    border-color: rgb(var(--ps-line) / var(--ps-line-strong-strength));
+  }
+  .border-border-strong\/70 {
+    border-color: rgb(var(--ps-line) / 0.14);
+  }
+  .border-border\/70 {
+    border-color: rgb(var(--ps-line) / 0.07);
+  }
+  .border-border\/80 {
+    border-color: rgb(var(--ps-line) / 0.085);
+  }
 
   /* Accent helpers */
-  .text-accent-strong { color: rgb(var(--ps-accent-strong)); }
-  .bg-accent\/10 { background-color: rgb(var(--ps-accent) / 0.10); }
+  .text-accent-strong {
+    color: rgb(var(--ps-accent-strong));
+  }
+  .bg-accent\/10 {
+    background-color: rgb(var(--ps-accent) / 0.1);
+  }
 
   /* Soft shadow — used for cards and floating chrome. */
   .shadow-soft {
@@ -380,8 +425,16 @@
   /* Soft hero gradient (used by /auth and signed-out home). */
   .bg-hero-gradient {
     background-image:
-      radial-gradient(circle at 18% 12%, rgb(var(--ps-accent) / 0.16), transparent 48%),
-      radial-gradient(circle at 88% -8%, rgb(var(--ps-warn) / 0.12), transparent 50%);
+      radial-gradient(
+        circle at 18% 12%,
+        rgb(var(--ps-accent) / 0.16),
+        transparent 48%
+      ),
+      radial-gradient(
+        circle at 88% -8%,
+        rgb(var(--ps-warn) / 0.12),
+        transparent 50%
+      );
   }
 
   /* Skip-link visible only on focus */
@@ -410,11 +463,31 @@
   /* Trichome-stipple watermark — used inside hero cards. */
   .ps-trichome-bg {
     background-image:
-      radial-gradient(circle at 8% 22%, rgb(var(--ps-accent) / 0.12) 0 1.4px, transparent 2px),
-      radial-gradient(circle at 24% 70%, rgb(var(--ps-accent) / 0.10) 0 1.2px, transparent 2px),
-      radial-gradient(circle at 60% 18%, rgb(var(--ps-accent) / 0.10) 0 1.6px, transparent 2px),
-      radial-gradient(circle at 78% 64%, rgb(var(--ps-accent) / 0.10) 0 1.2px, transparent 2px),
-      radial-gradient(circle at 92% 30%, rgb(var(--ps-accent) / 0.08) 0 1.2px, transparent 2px);
+      radial-gradient(
+        circle at 8% 22%,
+        rgb(var(--ps-accent) / 0.12) 0 1.4px,
+        transparent 2px
+      ),
+      radial-gradient(
+        circle at 24% 70%,
+        rgb(var(--ps-accent) / 0.1) 0 1.2px,
+        transparent 2px
+      ),
+      radial-gradient(
+        circle at 60% 18%,
+        rgb(var(--ps-accent) / 0.1) 0 1.6px,
+        transparent 2px
+      ),
+      radial-gradient(
+        circle at 78% 64%,
+        rgb(var(--ps-accent) / 0.1) 0 1.2px,
+        transparent 2px
+      ),
+      radial-gradient(
+        circle at 92% 30%,
+        rgb(var(--ps-accent) / 0.08) 0 1.2px,
+        transparent 2px
+      );
   }
 }
 
@@ -422,8 +495,14 @@
  * Animations
  * --------------------------------------------------------- */
 @keyframes ps-rise {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/server/__tests__/chat-tool-schemas.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tool-schemas.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  escapeIlikePattern,
+  LogPlantObservationArgs,
+  quotedIlikeOrValue,
+} from "../chat-tool-schemas";
+
+describe("escapeIlikePattern", () => {
+  it("escapes ILIKE wildcards and backslashes", () => {
+    expect(escapeIlikePattern("50%")).toBe("50\\%");
+    expect(escapeIlikePattern("a_b")).toBe("a\\_b");
+    expect(escapeIlikePattern("a\\b")).toBe("a\\\\b");
+  });
+
+  it("caps very long inputs at 120 characters", () => {
+    const long = "a".repeat(500);
+    expect(escapeIlikePattern(long)).toHaveLength(120);
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(escapeIlikePattern("rosemary")).toBe("rosemary");
+  });
+});
+
+describe("quotedIlikeOrValue", () => {
+  it("wraps the pattern in double quotes with ILIKE wildcards", () => {
+    expect(quotedIlikeOrValue("rosemary")).toBe('"%rosemary%"');
+  });
+
+  it("escapes ILIKE wildcards inside the quoted value", () => {
+    expect(quotedIlikeOrValue("50%")).toBe('"%50\\%%"');
+  });
+
+  it("does not let comma/period delimiters break out of the value", () => {
+    // A bare interpolation of `,is_archived.eq.true` would graft an
+    // extra predicate onto the OR. Wrapped in quotes, PostgREST treats
+    // the whole thing as a literal value. The interior `,` and `.`
+    // delimiters must be preserved (escaped underscores are fine —
+    // they're for the inner ILIKE, not the .or() parser).
+    const out = quotedIlikeOrValue(",is_archived.eq.true");
+    expect(out.startsWith('"')).toBe(true);
+    expect(out.endsWith('"')).toBe(true);
+    expect(out).toContain(",is");
+    expect(out).toContain(".eq.true");
+  });
+
+  it("escapes embedded double quotes to defend the quoted-value form", () => {
+    expect(quotedIlikeOrValue('a"b')).toBe('"%a\\"b%"');
+  });
+});
+
+describe("LogPlantObservationArgs", () => {
+  const base = { plantId: "plant-1", growId: "grow-1" };
+
+  it("accepts heightCm alone", () => {
+    expect(
+      LogPlantObservationArgs.safeParse({ ...base, heightCm: 42 }).success,
+    ).toBe(true);
+  });
+
+  it("accepts non-empty notes alone", () => {
+    expect(
+      LogPlantObservationArgs.safeParse({
+        ...base,
+        notes: "Pistils fattening",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects when both heightCm and notes are missing", () => {
+    expect(LogPlantObservationArgs.safeParse(base).success).toBe(false);
+  });
+
+  it("rejects whitespace-only notes when heightCm is missing", () => {
+    expect(
+      LogPlantObservationArgs.safeParse({ ...base, notes: "   " }).success,
+    ).toBe(false);
+    expect(
+      LogPlantObservationArgs.safeParse({ ...base, notes: "\t\n " }).success,
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/lib/server/__tests__/chat-tool-schemas.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tool-schemas.test.ts
@@ -28,7 +28,17 @@ describe("quotedIlikeOrValue", () => {
   });
 
   it("escapes ILIKE wildcards inside the quoted value", () => {
-    expect(quotedIlikeOrValue("50%")).toBe('"%50\\%%"');
+    // ILIKE-level: `%` → `\%` so it matches literally.
+    // PostgREST-level: the resulting `\` must itself be escaped to `\\`
+    // so the parser doesn't consume it as the start of an escape
+    // sequence inside the double-quoted value.
+    expect(quotedIlikeOrValue("50%")).toBe('"%50\\\\%%"');
+  });
+
+  it("escapes backslashes so PostgREST doesn't consume them", () => {
+    // Input `\` would otherwise become a lone `\` inside the quoted
+    // string and PostgREST would treat it as the start of an escape.
+    expect(quotedIlikeOrValue("\\")).toBe('"%\\\\\\\\%"');
   });
 
   it("does not let comma/period delimiters break out of the value", () => {

--- a/apps/web/src/lib/server/__tests__/chat-tools.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-tools.test.ts
@@ -2445,7 +2445,7 @@ describe("chat-tools — find_grow", () => {
     expect(rpc).toHaveBeenCalled();
     expect(from).toHaveBeenCalledWith("grows");
     expect(calls.or[0]?.[0]).toBe(
-      "name.ilike.%north%,description.ilike.%north%",
+      'name.ilike."%north%",description.ilike."%north%"',
     );
     expect(logServerEvent).toHaveBeenCalledWith(
       "warn",
@@ -2573,7 +2573,7 @@ describe("chat-tools — find_plant", () => {
     expect(rpc).toHaveBeenCalled();
     expect(from).toHaveBeenCalledWith("plants");
     expect(calls.or[0]?.[0]).toBe(
-      "name.ilike.%mother%,strain.ilike.%mother%,batch_label.ilike.%mother%",
+      'name.ilike."%mother%",strain.ilike."%mother%",batch_label.ilike."%mother%"',
     );
   });
 

--- a/apps/web/src/lib/server/analysis-config.ts
+++ b/apps/web/src/lib/server/analysis-config.ts
@@ -9,9 +9,7 @@ export function getAnalysisServiceConfig() {
   const apiKey = process.env["ANALYSIS_SERVICE_API_KEY"];
 
   if (!url || !apiKey) {
-    throw new Error(
-      "Missing ANALYSIS_SERVICE_URL or ANALYSIS_SERVICE_API_KEY",
-    );
+    throw new Error("Missing ANALYSIS_SERVICE_URL or ANALYSIS_SERVICE_API_KEY");
   }
 
   return { url, apiKey };

--- a/apps/web/src/lib/server/chat-tool-schemas.ts
+++ b/apps/web/src/lib/server/chat-tool-schemas.ts
@@ -1,0 +1,367 @@
+import "server-only";
+import { z } from "zod";
+
+// Pure data + Zod schemas extracted from chat-tools.ts so the executor
+// module stays focused on behavior. Anything tool-shaped that does not
+// touch I/O lives here: enum lists, length caps, shared refinements,
+// per-tool argument schemas, and the write-tool allowlist used for
+// audit logging.
+
+export const MAX_NOTES_LENGTH = 2_000;
+
+export const EVENT_TYPES = [
+  "water",
+  "feed",
+  "top",
+  "fim",
+  "lst",
+  "defoliate",
+  "transplant",
+  "ipm",
+  "harvest",
+  "observation",
+  "note",
+  "other",
+] as const;
+
+export const GROW_STAGES = [
+  "germination",
+  "seedling",
+  "vegetative",
+  "pre_flower",
+  "flower",
+  "late_flower",
+  "harvest",
+  "dry_cure",
+] as const;
+
+export const TASK_STATUSES = [
+  "open",
+  "in_progress",
+  "done",
+  "dismissed",
+] as const;
+
+export const TASK_PRIORITIES = ["low", "medium", "high", "urgent"] as const;
+
+export const GROW_MEDIA = [
+  "soil",
+  "coco",
+  "hydro",
+  "aero",
+  "living_soil",
+  "other",
+] as const;
+
+export const LIGHT_TYPES = [
+  "hps",
+  "cmh",
+  "led",
+  "t5",
+  "sun",
+  "mixed",
+  "other",
+] as const;
+
+export const FINDING_CATEGORIES = [
+  "nutrient_deficiency",
+  "nutrient_toxicity",
+  "pest",
+  "disease",
+  "environmental",
+  "training",
+  "general",
+  "positive",
+] as const;
+
+export const FINDING_SEVERITIES = [
+  "info",
+  "low",
+  "medium",
+  "high",
+  "critical",
+] as const;
+
+export const isoDatetimeNotFuture = z
+  .string()
+  .min(1)
+  .refine((s) => !Number.isNaN(Date.parse(s)), {
+    message: "must be a valid ISO 8601 datetime",
+  })
+  .refine((s) => Date.parse(s) <= Date.now() + 60_000, {
+    message: "must not be more than 1 minute in the future",
+  });
+
+export const isoDateNotFarFuture = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date")
+  .refine((s) => !Number.isNaN(Date.parse(s)), {
+    message: "must be a valid date",
+  })
+  .refine((s) => Date.parse(s) <= Date.now() + 24 * 60 * 60 * 1000, {
+    message: "must not be more than 1 day in the future",
+  });
+
+// Target-harvest-date accepts either a YYYY-MM-DD string (set) or an empty
+// string (clear). undefined means "leave the existing value untouched".
+export const isoDateOrEmpty = z
+  .string()
+  .refine((s) => s === "" || /^\d{4}-\d{2}-\d{2}$/.test(s), {
+    message: "must be YYYY-MM-DD or empty to clear",
+  })
+  .refine((s) => s === "" || !Number.isNaN(Date.parse(s)), {
+    message: "must be a valid date",
+  });
+
+export const ListGrowsArgs = z.object({ limit: z.number().optional() });
+
+export const ListPlantsArgs = z.object({
+  growId: z.string().min(1),
+  limit: z.number().optional(),
+});
+
+export const FindingsArgs = z.object({
+  growId: z.string().min(1).optional(),
+  plantId: z.string().min(1).optional(),
+  limit: z.number().optional(),
+  sinceDays: z.number().optional(),
+});
+
+export const ObservationsArgs = z.object({
+  growId: z.string().min(1).optional(),
+  plantId: z.string().min(1).optional(),
+  limit: z.number().optional(),
+});
+
+export const EventsArgs = z.object({
+  growId: z.string().min(1).optional(),
+  plantId: z.string().min(1).optional(),
+  limit: z.number().optional(),
+  sinceDays: z.number().optional(),
+});
+
+export const LatestAnalysisArgs = z.object({ plantId: z.string().min(1) });
+
+export const AnalysisHistoryArgs = z.object({
+  plantId: z.string().min(1),
+  limit: z.number().optional(),
+});
+
+export const LogGrowEventArgs = z.object({
+  growId: z.string().min(1),
+  plantId: z.string().min(1).optional(),
+  eventType: z.enum(EVENT_TYPES),
+  notes: z.string().max(MAX_NOTES_LENGTH).optional(),
+  occurredAt: isoDatetimeNotFuture.optional(),
+});
+
+export const LogPlantObservationArgs = z
+  .object({
+    plantId: z.string().min(1),
+    growId: z.string().min(1),
+    heightCm: z.number().positive().max(1_000).optional(),
+    notes: z.string().max(MAX_NOTES_LENGTH).optional(),
+    observedAt: isoDatetimeNotFuture.optional(),
+  })
+  .refine((v) => v.heightCm !== undefined || (v.notes && v.notes.length > 0), {
+    message: "supply at least one of heightCm or notes",
+  });
+
+export const MarkFindingResolvedArgs = z.object({
+  findingId: z.string().min(1),
+  resolved: z.boolean(),
+  resolvedAt: isoDatetimeNotFuture.optional(),
+});
+
+export const UpdateGrowStageArgs = z.object({
+  growId: z.string().min(1),
+  stage: z.enum(GROW_STAGES),
+});
+
+export const ListOpenTasksArgs = z
+  .object({
+    growId: z.string().min(1).optional(),
+    plantId: z.string().min(1).optional(),
+    includeCompleted: z.boolean().optional(),
+    limit: z.number().optional(),
+  })
+  .refine((v) => v.growId !== undefined || v.plantId !== undefined, {
+    message: "supply growId or plantId",
+  });
+
+export const UpdateTaskStatusArgs = z.object({
+  taskId: z.string().min(1),
+  status: z.enum(TASK_STATUSES),
+});
+
+export const CreateGrowArgs = z
+  .object({
+    name: z.string().min(1).max(120),
+    stage: z.enum(GROW_STAGES),
+    medium: z.enum(GROW_MEDIA),
+    lightType: z.enum(LIGHT_TYPES),
+    startDate: isoDateNotFarFuture.optional(),
+    targetHarvestDate: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date")
+      .refine((s) => !Number.isNaN(Date.parse(s)), {
+        message: "must be a valid date",
+      })
+      .optional(),
+    description: z.string().max(MAX_NOTES_LENGTH).optional(),
+  })
+  .refine(
+    (v) =>
+      !v.targetHarvestDate ||
+      !v.startDate ||
+      v.targetHarvestDate >= v.startDate,
+    {
+      message: "targetHarvestDate must be on or after startDate",
+      path: ["targetHarvestDate"],
+    },
+  );
+
+export const CreatePlantsArgs = z.object({
+  growId: z.string().min(1),
+  name: z.string().min(1).max(115),
+  count: z.number().int().min(1).max(25).optional(),
+  strain: z.string().max(120).optional(),
+  batchLabel: z.string().max(120).optional(),
+  notes: z.string().max(MAX_NOTES_LENGTH).optional(),
+});
+
+export const CreateGrowTaskArgs = z.object({
+  growId: z.string().min(1),
+  plantId: z.string().min(1).optional(),
+  title: z.string().min(1).max(200),
+  description: z.string().max(MAX_NOTES_LENGTH).optional(),
+  priority: z.enum(TASK_PRIORITIES).optional(),
+  dueAt: z
+    .string()
+    .min(1)
+    .refine((s) => !Number.isNaN(Date.parse(s)), {
+      message: "must be a valid ISO 8601 datetime",
+    })
+    .refine((s) => Date.parse(s) > Date.now() - 60_000, {
+      message: "dueAt must be in the future",
+    })
+    .optional(),
+});
+
+export const UpdateGrowArgs = z
+  .object({
+    growId: z.string().min(1),
+    name: z.string().min(1).max(120).optional(),
+    description: z.string().max(MAX_NOTES_LENGTH).optional(),
+    medium: z.enum(GROW_MEDIA).optional(),
+    lightType: z.enum(LIGHT_TYPES).optional(),
+    targetHarvestDate: isoDateOrEmpty.optional(),
+    archived: z.boolean().optional(),
+  })
+  .refine(
+    (v) =>
+      v.name !== undefined ||
+      v.description !== undefined ||
+      v.medium !== undefined ||
+      v.lightType !== undefined ||
+      v.targetHarvestDate !== undefined ||
+      v.archived !== undefined,
+    { message: "supply at least one field to update" },
+  );
+
+export const ComparePlantsArgs = z.object({
+  plantIds: z.array(z.string().min(1)).min(2).max(4),
+  sinceDays: z.number().optional(),
+});
+
+export const GetGrowSummaryArgs = z.object({
+  growId: z.string().min(1),
+});
+
+export const FindGrowArgs = z.object({
+  query: z.string().min(1).max(120),
+  includeArchived: z.boolean().optional(),
+  limit: z.number().optional(),
+});
+
+export const FindPlantArgs = z.object({
+  query: z.string().min(1).max(120),
+  growId: z.string().min(1).optional(),
+  includeArchived: z.boolean().optional(),
+  limit: z.number().optional(),
+});
+
+export const GetPlantTimelineArgs = z.object({
+  plantId: z.string().min(1),
+  limit: z.number().optional(),
+});
+
+export const TriggerPlantAnalysisArgs = z.object({
+  plantId: z.string().min(1),
+  imageId: z.string().min(1).optional(),
+});
+
+export const RecordImageFindingArgs = z.object({
+  plantId: z.string().min(1),
+  growId: z.string().min(1),
+  category: z.enum(FINDING_CATEGORIES),
+  severity: z.enum(FINDING_SEVERITIES),
+  title: z.string().min(1).max(200),
+  description: z.string().max(MAX_NOTES_LENGTH).optional(),
+  recommendation: z.string().max(MAX_NOTES_LENGTH).optional(),
+  imageId: z.string().min(1).optional(),
+});
+
+export const UpdatePlantArgs = z
+  .object({
+    plantId: z.string().min(1),
+    name: z.string().min(1).max(120).optional(),
+    strain: z.string().max(120).optional(),
+    batchLabel: z.string().max(120).optional(),
+    notes: z.string().max(MAX_NOTES_LENGTH).optional(),
+    archived: z.boolean().optional(),
+  })
+  .refine(
+    (v) =>
+      v.name !== undefined ||
+      v.strain !== undefined ||
+      v.batchLabel !== undefined ||
+      v.notes !== undefined ||
+      v.archived !== undefined,
+    { message: "supply at least one field to update" },
+  );
+
+export function buildBulkPlantNames(prefix: string, count: number): string[] {
+  if (count <= 1) return [prefix];
+  const pad = count >= 10 ? 2 : 1;
+  return Array.from(
+    { length: count },
+    (_, i) => `${prefix} ${String(i + 1).padStart(pad, "0")}`,
+  );
+}
+
+// PostgREST `ilike` requires us to escape the % and _ wildcards so a user
+// query like "50%" matches the literal characters rather than acting as a
+// wildcard. Belt-and-braces — also caps the query length to keep the LIKE
+// pattern bounded.
+export function escapeIlikePattern(input: string): string {
+  return input.slice(0, 120).replace(/[%_\\]/g, (m) => `\\${m}`);
+}
+
+// Tools whose names start the model down a write path. The executor logs
+// arg keys (never values) for these so we have an audit trail without
+// retaining free-text user content in the request log.
+export const WRITE_TOOLS = new Set<string>([
+  "log_grow_event",
+  "log_plant_observation",
+  "mark_finding_resolved",
+  "update_grow_stage",
+  "update_task_status",
+  "create_grow",
+  "create_plants",
+  "create_grow_task",
+  "update_grow",
+  "update_plant",
+  "record_image_finding",
+  "trigger_plant_analysis",
+]);

--- a/apps/web/src/lib/server/chat-tool-schemas.ts
+++ b/apps/web/src/lib/server/chat-tool-schemas.ts
@@ -163,9 +163,10 @@ export const LogPlantObservationArgs = z
     notes: z.string().max(MAX_NOTES_LENGTH).optional(),
     observedAt: isoDatetimeNotFuture.optional(),
   })
-  .refine((v) => v.heightCm !== undefined || (v.notes && v.notes.length > 0), {
-    message: "supply at least one of heightCm or notes",
-  });
+  .refine(
+    (v) => v.heightCm !== undefined || (v.notes?.trim().length ?? 0) > 0,
+    { message: "supply at least one of heightCm or notes" },
+  );
 
 export const MarkFindingResolvedArgs = z.object({
   findingId: z.string().min(1),
@@ -346,6 +347,18 @@ export function buildBulkPlantNames(prefix: string, count: number): string[] {
 // pattern bounded.
 export function escapeIlikePattern(input: string): string {
   return input.slice(0, 120).replace(/[%_\\]/g, (m) => `\\${m}`);
+}
+
+// Build a value safe to interpolate into a PostgREST `.or()` filter
+// string. PostgREST's `.or()` parser treats `,` `.` `(` `)` `"` as
+// reserved tokens that delimit predicates; if a raw ILIKE value contains
+// any of them, the parser will split mid-value and an attacker (or a
+// well-meaning user typing "50%, droopy") can graft an extra predicate
+// onto the OR. Wrapping the value in double quotes opts the parser into
+// a literal-string mode where the only escape needed is `\"`.
+export function quotedIlikeOrValue(input: string): string {
+  const escaped = escapeIlikePattern(input).replace(/"/g, '\\"');
+  return `"%${escaped}%"`;
 }
 
 // Tools whose names start the model down a write path. The executor logs

--- a/apps/web/src/lib/server/chat-tool-schemas.ts
+++ b/apps/web/src/lib/server/chat-tool-schemas.ts
@@ -355,9 +355,13 @@ export function escapeIlikePattern(input: string): string {
 // any of them, the parser will split mid-value and an attacker (or a
 // well-meaning user typing "50%, droopy") can graft an extra predicate
 // onto the OR. Wrapping the value in double quotes opts the parser into
-// a literal-string mode where the only escape needed is `\"`.
+// literal-string mode, where the two characters that still need
+// escaping are `"` (which would close the string) and `\` (the escape
+// character itself). Escape both before wrapping; otherwise a bare `\`
+// in the input would be consumed by the parser as the start of an
+// escape sequence and the resulting ILIKE value would be wrong.
 export function quotedIlikeOrValue(input: string): string {
-  const escaped = escapeIlikePattern(input).replace(/"/g, '\\"');
+  const escaped = escapeIlikePattern(input).replace(/[\\"]/g, "\\$&");
   return `"%${escaped}%"`;
 }
 

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -2,13 +2,44 @@ import "server-only";
 import { z } from "zod";
 import { createSupabaseServerClient } from "./auth";
 import { checkPerToolRateLimit } from "./chat-tool-policies";
+import {
+  AnalysisHistoryArgs,
+  buildBulkPlantNames,
+  ComparePlantsArgs,
+  CreateGrowArgs,
+  CreateGrowTaskArgs,
+  CreatePlantsArgs,
+  escapeIlikePattern,
+  EventsArgs,
+  FindGrowArgs,
+  FindingsArgs,
+  FindPlantArgs,
+  GetGrowSummaryArgs,
+  GetPlantTimelineArgs,
+  LatestAnalysisArgs,
+  ListGrowsArgs,
+  ListOpenTasksArgs,
+  ListPlantsArgs,
+  LogGrowEventArgs,
+  LogPlantObservationArgs,
+  MarkFindingResolvedArgs,
+  ObservationsArgs,
+  RecordImageFindingArgs,
+  TriggerPlantAnalysisArgs,
+  UpdateGrowArgs,
+  UpdateGrowStageArgs,
+  UpdatePlantArgs,
+  UpdateTaskStatusArgs,
+  WRITE_TOOLS,
+} from "./chat-tool-schemas";
 import { persistSingleFindingEmbeddingBestEffort } from "./embeddings";
 import { getPlantTimeline, runAndPersistPlantAnalysis } from "./plants";
 import { logServerEvent } from "./request-id";
 import { executeSearchSimilarFindingsTool } from "./semantic-findings";
 
 // Tool definitions live in chat-tool-definitions.ts (pure data) so this
-// module — executor + schemas + handlers — stays focused on behavior.
+// module — executor + handlers — stays focused on behavior. Schemas,
+// enum lists, and the write-tool allowlist live in chat-tool-schemas.ts.
 export { CHAT_TOOL_DEFINITIONS } from "./chat-tool-definitions";
 
 type ToolResult = { ok: true; data: unknown } | { ok: false; error: string };
@@ -24,352 +55,6 @@ const numClamp = (n: unknown, def: number, max: number): number => {
   const parsed = typeof n === "number" && Number.isFinite(n) ? n : def;
   return Math.max(1, Math.min(max, Math.floor(parsed)));
 };
-
-const ListGrowsArgs = z.object({ limit: z.number().optional() });
-const ListPlantsArgs = z.object({
-  growId: z.string().min(1),
-  limit: z.number().optional(),
-});
-const FindingsArgs = z.object({
-  growId: z.string().min(1).optional(),
-  plantId: z.string().min(1).optional(),
-  limit: z.number().optional(),
-  sinceDays: z.number().optional(),
-});
-const ObservationsArgs = z.object({
-  growId: z.string().min(1).optional(),
-  plantId: z.string().min(1).optional(),
-  limit: z.number().optional(),
-});
-const EventsArgs = z.object({
-  growId: z.string().min(1).optional(),
-  plantId: z.string().min(1).optional(),
-  limit: z.number().optional(),
-  sinceDays: z.number().optional(),
-});
-const LatestAnalysisArgs = z.object({ plantId: z.string().min(1) });
-const AnalysisHistoryArgs = z.object({
-  plantId: z.string().min(1),
-  limit: z.number().optional(),
-});
-
-const EVENT_TYPES = [
-  "water",
-  "feed",
-  "top",
-  "fim",
-  "lst",
-  "defoliate",
-  "transplant",
-  "ipm",
-  "harvest",
-  "observation",
-  "note",
-  "other",
-] as const;
-
-const MAX_NOTES_LENGTH = 2_000;
-
-const isoDatetimeNotFuture = z
-  .string()
-  .min(1)
-  .refine((s) => !Number.isNaN(Date.parse(s)), {
-    message: "must be a valid ISO 8601 datetime",
-  })
-  .refine((s) => Date.parse(s) <= Date.now() + 60_000, {
-    message: "must not be more than 1 minute in the future",
-  });
-
-const LogGrowEventArgs = z.object({
-  growId: z.string().min(1),
-  plantId: z.string().min(1).optional(),
-  eventType: z.enum(EVENT_TYPES),
-  notes: z.string().max(MAX_NOTES_LENGTH).optional(),
-  occurredAt: isoDatetimeNotFuture.optional(),
-});
-
-const LogPlantObservationArgs = z
-  .object({
-    plantId: z.string().min(1),
-    growId: z.string().min(1),
-    heightCm: z.number().positive().max(1_000).optional(),
-    notes: z.string().max(MAX_NOTES_LENGTH).optional(),
-    observedAt: isoDatetimeNotFuture.optional(),
-  })
-  .refine((v) => v.heightCm !== undefined || (v.notes && v.notes.length > 0), {
-    message: "supply at least one of heightCm or notes",
-  });
-
-const GROW_STAGES = [
-  "germination",
-  "seedling",
-  "vegetative",
-  "pre_flower",
-  "flower",
-  "late_flower",
-  "harvest",
-  "dry_cure",
-] as const;
-
-const MarkFindingResolvedArgs = z.object({
-  findingId: z.string().min(1),
-  resolved: z.boolean(),
-  resolvedAt: isoDatetimeNotFuture.optional(),
-});
-
-const UpdateGrowStageArgs = z.object({
-  growId: z.string().min(1),
-  stage: z.enum(GROW_STAGES),
-});
-
-const TASK_STATUSES = ["open", "in_progress", "done", "dismissed"] as const;
-
-const ListOpenTasksArgs = z
-  .object({
-    growId: z.string().min(1).optional(),
-    plantId: z.string().min(1).optional(),
-    includeCompleted: z.boolean().optional(),
-    limit: z.number().optional(),
-  })
-  .refine((v) => v.growId !== undefined || v.plantId !== undefined, {
-    message: "supply growId or plantId",
-  });
-
-const UpdateTaskStatusArgs = z.object({
-  taskId: z.string().min(1),
-  status: z.enum(TASK_STATUSES),
-});
-
-const GROW_MEDIA = [
-  "soil",
-  "coco",
-  "hydro",
-  "aero",
-  "living_soil",
-  "other",
-] as const;
-const LIGHT_TYPES = [
-  "hps",
-  "cmh",
-  "led",
-  "t5",
-  "sun",
-  "mixed",
-  "other",
-] as const;
-
-const isoDateNotFarFuture = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date")
-  .refine((s) => !Number.isNaN(Date.parse(s)), {
-    message: "must be a valid date",
-  })
-  .refine((s) => Date.parse(s) <= Date.now() + 24 * 60 * 60 * 1000, {
-    message: "must not be more than 1 day in the future",
-  });
-
-const CreateGrowArgs = z
-  .object({
-    name: z.string().min(1).max(120),
-    stage: z.enum(GROW_STAGES),
-    medium: z.enum(GROW_MEDIA),
-    lightType: z.enum(LIGHT_TYPES),
-    startDate: isoDateNotFarFuture.optional(),
-    targetHarvestDate: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date")
-      .refine((s) => !Number.isNaN(Date.parse(s)), {
-        message: "must be a valid date",
-      })
-      .optional(),
-    description: z.string().max(MAX_NOTES_LENGTH).optional(),
-  })
-  .refine(
-    (v) =>
-      !v.targetHarvestDate ||
-      !v.startDate ||
-      v.targetHarvestDate >= v.startDate,
-    {
-      message: "targetHarvestDate must be on or after startDate",
-      path: ["targetHarvestDate"],
-    },
-  );
-
-const CreatePlantsArgs = z.object({
-  growId: z.string().min(1),
-  name: z.string().min(1).max(115),
-  count: z.number().int().min(1).max(25).optional(),
-  strain: z.string().max(120).optional(),
-  batchLabel: z.string().max(120).optional(),
-  notes: z.string().max(MAX_NOTES_LENGTH).optional(),
-});
-
-const TASK_PRIORITIES = ["low", "medium", "high", "urgent"] as const;
-
-const CreateGrowTaskArgs = z.object({
-  growId: z.string().min(1),
-  plantId: z.string().min(1).optional(),
-  title: z.string().min(1).max(200),
-  description: z.string().max(MAX_NOTES_LENGTH).optional(),
-  priority: z.enum(TASK_PRIORITIES).optional(),
-  dueAt: z
-    .string()
-    .min(1)
-    .refine((s) => !Number.isNaN(Date.parse(s)), {
-      message: "must be a valid ISO 8601 datetime",
-    })
-    .refine((s) => Date.parse(s) > Date.now() - 60_000, {
-      message: "dueAt must be in the future",
-    })
-    .optional(),
-});
-
-function buildBulkPlantNames(prefix: string, count: number): string[] {
-  if (count <= 1) return [prefix];
-  const pad = count >= 10 ? 2 : 1;
-  return Array.from(
-    { length: count },
-    (_, i) => `${prefix} ${String(i + 1).padStart(pad, "0")}`,
-  );
-}
-
-// Target-harvest-date accepts either a YYYY-MM-DD string (set) or an empty
-// string (clear). undefined means "leave the existing value untouched".
-const isoDateOrEmpty = z
-  .string()
-  .refine((s) => s === "" || /^\d{4}-\d{2}-\d{2}$/.test(s), {
-    message: "must be YYYY-MM-DD or empty to clear",
-  })
-  .refine((s) => s === "" || !Number.isNaN(Date.parse(s)), {
-    message: "must be a valid date",
-  });
-
-const UpdateGrowArgs = z
-  .object({
-    growId: z.string().min(1),
-    name: z.string().min(1).max(120).optional(),
-    description: z.string().max(MAX_NOTES_LENGTH).optional(),
-    medium: z.enum(GROW_MEDIA).optional(),
-    lightType: z.enum(LIGHT_TYPES).optional(),
-    targetHarvestDate: isoDateOrEmpty.optional(),
-    archived: z.boolean().optional(),
-  })
-  .refine(
-    (v) =>
-      v.name !== undefined ||
-      v.description !== undefined ||
-      v.medium !== undefined ||
-      v.lightType !== undefined ||
-      v.targetHarvestDate !== undefined ||
-      v.archived !== undefined,
-    { message: "supply at least one field to update" },
-  );
-
-const FINDING_CATEGORIES = [
-  "nutrient_deficiency",
-  "nutrient_toxicity",
-  "pest",
-  "disease",
-  "environmental",
-  "training",
-  "general",
-  "positive",
-] as const;
-const FINDING_SEVERITIES = [
-  "info",
-  "low",
-  "medium",
-  "high",
-  "critical",
-] as const;
-
-const ComparePlantsArgs = z.object({
-  plantIds: z.array(z.string().min(1)).min(2).max(4),
-  sinceDays: z.number().optional(),
-});
-
-const GetGrowSummaryArgs = z.object({
-  growId: z.string().min(1),
-});
-
-const FindGrowArgs = z.object({
-  query: z.string().min(1).max(120),
-  includeArchived: z.boolean().optional(),
-  limit: z.number().optional(),
-});
-
-const FindPlantArgs = z.object({
-  query: z.string().min(1).max(120),
-  growId: z.string().min(1).optional(),
-  includeArchived: z.boolean().optional(),
-  limit: z.number().optional(),
-});
-
-// PostgREST `ilike` requires us to escape the % and _ wildcards so a user
-// query like "50%" matches the literal characters rather than acting as a
-// wildcard. Belt-and-braces — also caps the query length to keep the LIKE
-// pattern bounded.
-function escapeIlikePattern(input: string): string {
-  return input.slice(0, 120).replace(/[%_\\]/g, (m) => `\\${m}`);
-}
-
-const GetPlantTimelineArgs = z.object({
-  plantId: z.string().min(1),
-  limit: z.number().optional(),
-});
-
-const TriggerPlantAnalysisArgs = z.object({
-  plantId: z.string().min(1),
-  imageId: z.string().min(1).optional(),
-});
-
-const RecordImageFindingArgs = z.object({
-  plantId: z.string().min(1),
-  growId: z.string().min(1),
-  category: z.enum(FINDING_CATEGORIES),
-  severity: z.enum(FINDING_SEVERITIES),
-  title: z.string().min(1).max(200),
-  description: z.string().max(MAX_NOTES_LENGTH).optional(),
-  recommendation: z.string().max(MAX_NOTES_LENGTH).optional(),
-  imageId: z.string().min(1).optional(),
-});
-
-const UpdatePlantArgs = z
-  .object({
-    plantId: z.string().min(1),
-    name: z.string().min(1).max(120).optional(),
-    strain: z.string().max(120).optional(),
-    batchLabel: z.string().max(120).optional(),
-    notes: z.string().max(MAX_NOTES_LENGTH).optional(),
-    archived: z.boolean().optional(),
-  })
-  .refine(
-    (v) =>
-      v.name !== undefined ||
-      v.strain !== undefined ||
-      v.batchLabel !== undefined ||
-      v.notes !== undefined ||
-      v.archived !== undefined,
-    { message: "supply at least one field to update" },
-  );
-
-// Tools whose names start the model down a write path. The executor logs
-// arg keys (never values) for these so we have an audit trail without
-// retaining free-text user content in the request log.
-const WRITE_TOOLS = new Set<string>([
-  "log_grow_event",
-  "log_plant_observation",
-  "mark_finding_resolved",
-  "update_grow_stage",
-  "update_task_status",
-  "create_grow",
-  "create_plants",
-  "create_grow_task",
-  "update_grow",
-  "update_plant",
-  "record_image_finding",
-  "trigger_plant_analysis",
-]);
 
 type ChatToolContext = {
   userId: string | null;

--- a/apps/web/src/lib/server/chat-tools.ts
+++ b/apps/web/src/lib/server/chat-tools.ts
@@ -9,7 +9,6 @@ import {
   CreateGrowArgs,
   CreateGrowTaskArgs,
   CreatePlantsArgs,
-  escapeIlikePattern,
   EventsArgs,
   FindGrowArgs,
   FindingsArgs,
@@ -24,6 +23,7 @@ import {
   LogPlantObservationArgs,
   MarkFindingResolvedArgs,
   ObservationsArgs,
+  quotedIlikeOrValue,
   RecordImageFindingArgs,
   TriggerPlantAnalysisArgs,
   UpdateGrowArgs,
@@ -854,7 +854,7 @@ export async function executeChatTool(
                 error: error.message,
               },
             );
-            const pattern = `%${escapeIlikePattern(args.query)}%`;
+            const pattern = quotedIlikeOrValue(args.query);
             let q = supabase
               .from("grows")
               .select(
@@ -890,7 +890,7 @@ export async function executeChatTool(
                 error: error.message,
               },
             );
-            const pattern = `%${escapeIlikePattern(args.query)}%`;
+            const pattern = quotedIlikeOrValue(args.query);
             let q = supabase
               .from("plants")
               .select(

--- a/docs/playbooks/contract-safe-change-playbook.md
+++ b/docs/playbooks/contract-safe-change-playbook.md
@@ -8,12 +8,12 @@ client depends on.
 
 A contract is anything observed across a process boundary:
 
-| Boundary                          | Contract surface                                |
-| --------------------------------- | ----------------------------------------------- |
-| Browser ⇄ `apps/web` Route Handler | Request/response JSON shape; status codes       |
+| Boundary                           | Contract surface                                  |
+| ---------------------------------- | ------------------------------------------------- |
+| Browser ⇄ `apps/web` Route Handler | Request/response JSON shape; status codes         |
 | `apps/web` ⇄ `apps/analysis`       | `apps/analysis/app/models/**` ↔ `packages/shared` |
-| `apps/web` ⇄ Supabase Postgres     | Migration column names/types ↔ `packages/shared` |
-| `apps/web` ⇄ Supabase Storage      | Bucket name + path convention                   |
+| `apps/web` ⇄ Supabase Postgres     | Migration column names/types ↔ `packages/shared`  |
+| `apps/web` ⇄ Supabase Storage      | Bucket name + path convention                     |
 
 ## The Rule
 

--- a/docs/supabase-guide.md
+++ b/docs/supabase-guide.md
@@ -41,10 +41,10 @@ Supabase provides a managed PgBouncer instance on every project. No installation
 
 You will see two connection strings:
 
-| Mode | Port | Use for |
-|---|---|---|
-| Direct (Postgres) | `5432` | Migrations, long-lived admin sessions |
-| Pooler (PgBouncer) | `6543` | All application traffic |
+| Mode               | Port   | Use for                               |
+| ------------------ | ------ | ------------------------------------- |
+| Direct (Postgres)  | `5432` | Migrations, long-lived admin sessions |
+| Pooler (PgBouncer) | `6543` | All application traffic               |
 
 ### Recommended settings
 
@@ -116,12 +116,12 @@ PITR is available on **Supabase Pro** and above.
 
 ### Retention period recommendations
 
-| Stage | Retention | Rationale |
-|---|---|---|
-| Development / staging | 7 days | Minimal cost; enough to catch mistakes |
-| Early production (< 1k users) | 14 days | Covers a two-week sprint cycle |
-| Growth (1k–10k users) | 30 days | Covers month-end billing disputes, slow-burn data corruption |
-| Enterprise | 90 days | Compliance, audit requirements |
+| Stage                         | Retention | Rationale                                                    |
+| ----------------------------- | --------- | ------------------------------------------------------------ |
+| Development / staging         | 7 days    | Minimal cost; enough to catch mistakes                       |
+| Early production (< 1k users) | 14 days   | Covers a two-week sprint cycle                               |
+| Growth (1k–10k users)         | 30 days   | Covers month-end billing disputes, slow-burn data corruption |
+| Enterprise                    | 90 days   | Compliance, audit requirements                               |
 
 Start with **14 days** for production. Increase as user data becomes more valuable.
 
@@ -247,13 +247,13 @@ rm test_restore.sql
 
 ### Key metrics to watch
 
-| Metric | Warning threshold | Critical threshold | Where to find it |
-|---|---|---|---|
-| Active connections | > 70% of `max_connections` | > 90% | Supabase Dashboard → Reports → Database |
-| Query latency (p99) | > 500ms | > 2s | Supabase Dashboard → Reports → Queries |
-| Cache hit ratio | < 95% | < 90% | `pg_stat_bgwriter` (see query below) |
-| Disk usage | > 70% | > 85% | Supabase Dashboard → Settings → Database |
-| Replication lag | > 10s | > 60s | Supabase Dashboard → Reports |
+| Metric              | Warning threshold          | Critical threshold | Where to find it                         |
+| ------------------- | -------------------------- | ------------------ | ---------------------------------------- |
+| Active connections  | > 70% of `max_connections` | > 90%              | Supabase Dashboard → Reports → Database  |
+| Query latency (p99) | > 500ms                    | > 2s               | Supabase Dashboard → Reports → Queries   |
+| Cache hit ratio     | < 95%                      | < 90%              | `pg_stat_bgwriter` (see query below)     |
+| Disk usage          | > 70%                      | > 85%              | Supabase Dashboard → Settings → Database |
+| Replication lag     | > 10s                      | > 60s              | Supabase Dashboard → Reports             |
 
 ### Checking cache hit ratio
 
@@ -711,11 +711,11 @@ The `IVFFlat` index divides the vector space into `lists` clusters. At query tim
 
 **Choosing `lists`:**
 
-| Row count | Recommended `lists` |
-|---|---|
-| < 1,000 | No index needed — use sequential scan |
+| Row count       | Recommended `lists`                   |
+| --------------- | ------------------------------------- |
+| < 1,000         | No index needed — use sequential scan |
 | 1,000 – 100,000 | `sqrt(rows)` — e.g., 100 for 10k rows |
-| > 100,000 | `rows / 1000` |
+| > 100,000       | `rows / 1000`                         |
 
 **Choosing `probes` at query time:**
 
@@ -1015,6 +1015,7 @@ SELECT auth.uid();  -- confirm you are authenticated as the right user
 ```
 
 Common causes:
+
 - `user_id` field not set to `auth.uid()` on insert
 - Trying to insert into a service-role-only table (e.g., `plant_findings`) with the anon key
 - Missing grow membership record
@@ -1166,12 +1167,12 @@ SELECT indexname, idx_scan FROM pg_stat_user_indexes WHERE idx_scan = 0 ORDER BY
 
 ### Supabase Dashboard shortcuts
 
-| Task | Path |
-|---|---|
-| Enable PITR | Settings → Backups → Point in Time Recovery |
-| Download backup | Settings → Backups → Database Backups |
-| Enable PgBouncer | Settings → Database → Connection pooling |
-| View slow queries | Reports → Queries |
-| Set up alerts | Settings → Alerts |
-| Rotate service role key | Settings → API → Service Role Key |
-| Run SQL | SQL Editor |
+| Task                    | Path                                        |
+| ----------------------- | ------------------------------------------- |
+| Enable PITR             | Settings → Backups → Point in Time Recovery |
+| Download backup         | Settings → Backups → Database Backups       |
+| Enable PgBouncer        | Settings → Database → Connection pooling    |
+| View slow queries       | Reports → Queries                           |
+| Set up alerts           | Settings → Alerts                           |
+| Rotate service role key | Settings → API → Service Role Key           |
+| Run SQL                 | SQL Editor                                  |

--- a/scripts/check-route-boundaries.mjs
+++ b/scripts/check-route-boundaries.mjs
@@ -13,7 +13,10 @@
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1");
+const ROOT = new URL("..", import.meta.url).pathname.replace(
+  /^\/([A-Za-z]:)/,
+  "$1",
+);
 const WEB_SRC = join(ROOT, "apps", "web", "src");
 
 const errors = [];
@@ -32,7 +35,8 @@ function* walk(dir) {
   }
 }
 
-const SERVER_IMPORT_RE = /from\s+["'](?:@\/lib\/server\/[^"']+|server-only)["']/;
+const SERVER_IMPORT_RE =
+  /from\s+["'](?:@\/lib\/server\/[^"']+|server-only)["']/;
 const USE_CLIENT_RE = /^\s*["']use client["']/m;
 const RAILWAY_FETCH_RE = /https?:\/\/[^"'\s]*\.railway\.app/;
 


### PR DESCRIPTION
## Summary

Two motivations bundled together because the security-review pass surfaced the second one mid-flight.

### 1. File-budget headroom for `chat-tools.ts` (pure refactor)

`apps/web/src/lib/server/chat-tools.ts` was at **1499 of 1500** lines against the configured `check-file-budgets` cap — a recurring near-miss flagged across multiple worklog entries. Extracted the pure data into a focused module:

- **New** `apps/web/src/lib/server/chat-tool-schemas.ts` — Zod arg schemas, enum literal arrays (`EVENT_TYPES`, `GROW_STAGES`, `TASK_STATUSES`, `GROW_MEDIA`, `LIGHT_TYPES`, `TASK_PRIORITIES`, `FINDING_CATEGORIES`, `FINDING_SEVERITIES`), shared refinements (`isoDatetimeNotFuture`, `isoDateNotFarFuture`, `isoDateOrEmpty`), helpers (`buildBulkPlantNames`, `escapeIlikePattern`, new `quotedIlikeOrValue`), `MAX_NOTES_LENGTH`, and the `WRITE_TOOLS` audit allowlist.
- `chat-tools.ts` now imports those names. **1499 → 1184 lines** (~315 lines of headroom).
- Public exports unchanged: `CHAT_TOOL_DEFINITIONS`, `executeChatTool`.

### 2. Behavior changes landed in follow-up commits (not pure refactor — calling out per @Copilot review)

These are *not* schema-only changes. Reviewers should treat them as a small security/UX patch riding alongside the refactor:

- **PostgREST `.or()` injection hardening (high).** `escapeIlikePattern` only escaped SQL ILIKE wildcards. Its output was interpolated raw into `.or("name.ilike.<value>,...")` strings in the `find_grow` / `find_plant` fallback paths, and PostgREST's `.or()` parser treats `,` `.` `(` `)` `"` as delimiters. New `quotedIlikeOrValue(input)` wraps the escaped pattern in `"..."` (PostgREST literal-string mode) and double-escapes `\` and `"` so neither character can break the quoted form. **Wire-format change:** `.or()` strings now look like `name.ilike."%north%",description.ilike."%north%"` instead of `name.ilike.%north%,description.ilike.%north%`. The primary path uses the `search_grows` / `search_plants` RPCs (typed parameters) and was never affected.
- **Whitespace-only notes rejected (medium).** `LogPlantObservationArgs` previously accepted `"   "` because the check was `v.notes && v.notes.length > 0`. Switched to `(v.notes?.trim().length ?? 0) > 0`. **Validation change:** observations with only whitespace in `notes` and no `heightCm` now return a validation error instead of being stored.
- **CodeQL #185 follow-up.** Initial `quotedIlikeOrValue` only escaped `"`; CodeQL correctly flagged that `\` also needs escaping inside PostgREST's quoted-value form. Fixed by using `/[\\"]/g` with `\\$&` replacement and added a dedicated test for raw-`\` input.

### 3. Pre-existing Prettier drift swept up

`pnpm run format:check` was failing on these five files since the Tier 3 semantic-findings work:

- `apps/web/src/app/globals.css`
- `apps/web/src/lib/server/analysis-config.ts`
- `docs/playbooks/contract-safe-change-playbook.md`
- `docs/supabase-guide.md`
- `scripts/check-route-boundaries.mjs`

### Validation

- `pnpm run validate` — env contract, route boundaries, imports, code-scanning patterns, file budgets all OK
- `pnpm turbo run type-check lint test` — **704/704 tests pass** (+11 new in `chat-tool-schemas.test.ts`, +1 backslash escaping case for CodeQL)
- `pnpm run security:audit` — OK
- `pnpm run format:check` — clean for the first time since the Tier 3 work

## Test plan

- [ ] CI green (turbo type-check + lint + test, validate, security:audit, format:check, CodeQL)
- [ ] `find_grow` / `find_plant` fallback paths still return results for normal queries via a preview environment if available — wire format changed but semantics for plain-text input are identical
- [ ] `log_plant_observation` rejects whitespace-only notes with the same field error shape it already used for missing fields
- [ ] `check-file-budgets` reports OK with headroom (1184/1500 for chat-tools.ts)
