### PR TITLE
fix(actions): extract non-async exports from "use server" files (fixes /grows/new + /settings 500)

### DIFF
--- a/apps/web/src/app/(app)/grows/[id]/action-state.ts
+++ b/apps/web/src/app/(app)/grows/[id]/action-state.ts
@@ -1,0 +1,53 @@
+// Action state lives outside actions.ts so the `"use server"` file can
+// satisfy the React 19 / Next.js 16 contract: it must export only async
+// functions. Constants and types stay here where both the server action
+// implementation and the client forms can import them.
+
+export type ToggleArchiveActionResult = {
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const toggleArchiveActionInitialState: ToggleArchiveActionResult = {
+  status: "idle",
+};
+
+export type UpdateGrowActionResult = {
+  fieldErrors?: {
+    description?: string;
+    lightType?: string;
+    medium?: string;
+    name?: string;
+    stage?: string;
+    startDate?: string;
+    targetHarvestDate?: string;
+  };
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const updateGrowActionInitialState: UpdateGrowActionResult = {
+  status: "idle",
+};
+
+export type AdvanceGrowStageActionResult = {
+  message?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const advanceGrowStageActionInitialState: AdvanceGrowStageActionResult =
+  {
+    status: "idle",
+  };
+
+export type DeleteGrowActionResult = {
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const deleteGrowActionInitialState: DeleteGrowActionResult = {
+  status: "idle",
+};

--- a/apps/web/src/app/(app)/grows/[id]/actions.ts
+++ b/apps/web/src/app/(app)/grows/[id]/actions.ts
@@ -6,6 +6,12 @@ import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { logServerEvent } from "@/lib/server/request-id";
 import { MAX_DESCRIPTION_LENGTH, MAX_FUTURE_START_MS } from "../constants";
+import type {
+  AdvanceGrowStageActionResult,
+  DeleteGrowActionResult,
+  ToggleArchiveActionResult,
+  UpdateGrowActionResult,
+} from "./action-state";
 
 // Stage / medium / light vocabularies are duplicated from
 // new/actions.ts on purpose: keeping the two action files independent
@@ -47,16 +53,6 @@ function asTrimmedString(value: FormDataEntryValue | null) {
 function isIsoDate(value: string) {
   return /^\d{4}-\d{2}-\d{2}$/.test(value) && !Number.isNaN(Date.parse(value));
 }
-
-export type ToggleArchiveActionResult = {
-  message?: string;
-  redirectTo?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const toggleArchiveActionInitialState: ToggleArchiveActionResult = {
-  status: "idle",
-};
 
 // Toggle a grow's `is_archived` flag. Owner-only — enforced by RLS
 // ("grows: owner write" policy from migration 001), so an unauthorised
@@ -153,25 +149,6 @@ export async function toggleGrowArchiveAction(
 // (`grows: owner write`) so non-owners get a 42501 we surface as a
 // clean message. Validation mirrors createGrowAction so a user can't
 // reach an invalid state via either path.
-
-export type UpdateGrowActionResult = {
-  fieldErrors?: {
-    description?: string;
-    lightType?: string;
-    medium?: string;
-    name?: string;
-    stage?: string;
-    startDate?: string;
-    targetHarvestDate?: string;
-  };
-  message?: string;
-  redirectTo?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const updateGrowActionInitialState: UpdateGrowActionResult = {
-  status: "idle",
-};
 
 export async function updateGrowAction(
   growId: string,
@@ -325,16 +302,6 @@ export async function updateGrowAction(
 // lets owners jump backward shouldn't have to introduce a second
 // action. Owner-only via RLS.
 
-export type AdvanceGrowStageActionResult = {
-  message?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const advanceGrowStageActionInitialState: AdvanceGrowStageActionResult =
-  {
-    status: "idle",
-  };
-
 export async function advanceGrowStageAction(
   growId: string,
   nextStage: GrowStage,
@@ -408,16 +375,6 @@ export async function advanceGrowStageAction(
 // images, analyses, jobs, members, tasks, observations, events, and
 // findings. `chat_threads.grow_id` is SET NULL on purpose, so any
 // assistant chat scoped here unscope's rather than disappearing.
-
-export type DeleteGrowActionResult = {
-  message?: string;
-  redirectTo?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const deleteGrowActionInitialState: DeleteGrowActionResult = {
-  status: "idle",
-};
 
 function normaliseName(value: string) {
   return value.trim().toLowerCase();

--- a/apps/web/src/app/(app)/grows/[id]/archive-button.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/archive-button.tsx
@@ -5,9 +5,9 @@ import { Button, buttonStyles } from "@/components/ui/button";
 import { useActionWithRecovery } from "@/lib/client/action-runner";
 import {
   toggleArchiveActionInitialState,
-  toggleGrowArchiveAction,
   type ToggleArchiveActionResult,
-} from "./actions";
+} from "./action-state";
+import { toggleGrowArchiveAction } from "./actions";
 
 // Client island that hosts the archive / restore toggle. The form
 // inherits the same auto-correction pattern as create-grow:

--- a/apps/web/src/app/(app)/grows/[id]/delete-button.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/delete-button.tsx
@@ -4,10 +4,10 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useActionWithRecovery } from "@/lib/client/action-runner";
 import {
-  deleteGrowAction,
   deleteGrowActionInitialState,
   type DeleteGrowActionResult,
-} from "./actions";
+} from "./action-state";
+import { deleteGrowAction } from "./actions";
 
 // Destructive island. Two-step UI: the "Delete grow" CTA reveals an
 // inline confirmation that requires the user to retype the grow name.

--- a/apps/web/src/app/(app)/grows/[id]/edit/edit-form.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/edit/edit-form.tsx
@@ -6,10 +6,10 @@ import { Button, buttonStyles } from "@/components/ui/button";
 import { FormErrorSummary } from "@/components/form-error-summary";
 import { useActionWithRecovery } from "@/lib/client/action-runner";
 import {
-  updateGrowAction,
   updateGrowActionInitialState,
   type UpdateGrowActionResult,
-} from "../actions";
+} from "../action-state";
+import { updateGrowAction } from "../actions";
 
 const FIELD_META = {
   name: { label: "Grow name", targetId: "grow-name" },

--- a/apps/web/src/app/(app)/grows/[id]/stage-stepper.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/stage-stepper.tsx
@@ -4,10 +4,10 @@ import type { GrowStage } from "@phenosage/shared";
 import { Button } from "@/components/ui/button";
 import { useActionWithRecovery } from "@/lib/client/action-runner";
 import {
-  advanceGrowStageAction,
   advanceGrowStageActionInitialState,
   type AdvanceGrowStageActionResult,
-} from "./actions";
+} from "./action-state";
+import { advanceGrowStageAction } from "./actions";
 
 // Linear vocabulary order matches the create-grow form's option list.
 // `dry_cure` is the terminal stage — beyond it there's no "next" step

--- a/apps/web/src/app/(app)/grows/action-state.ts
+++ b/apps/web/src/app/(app)/grows/action-state.ts
@@ -1,0 +1,23 @@
+// Action state lives outside actions.ts so the `"use server"` file can
+// satisfy the React 19 / Next.js 16 contract: it must export only async
+// functions. Constants and types stay here where both the server action
+// implementation and the client form can import them.
+
+export type CreateGrowActionResult = {
+  fieldErrors?: {
+    description?: string;
+    lightType?: string;
+    medium?: string;
+    name?: string;
+    stage?: string;
+    startDate?: string;
+    targetHarvestDate?: string;
+  };
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const createGrowActionInitialState: CreateGrowActionResult = {
+  status: "idle",
+};

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -7,6 +7,7 @@ import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { rateLimit } from "@/lib/server/rate-limit";
 import { logServerEvent, REQUEST_ID_HEADER } from "@/lib/server/request-id";
+import type { CreateGrowActionResult } from "./action-state";
 import { MAX_DESCRIPTION_LENGTH, MAX_FUTURE_START_MS } from "./constants";
 
 const validStages = new Set<GrowStage>([
@@ -60,25 +61,6 @@ const IDEMPOTENCY_LIMIT = 1;
 // well below what a runaway script could cost us.
 const ABUSE_LIMIT_WINDOW_MS = 60_000;
 const ABUSE_LIMIT = 20;
-
-export type CreateGrowActionResult = {
-  fieldErrors?: {
-    description?: string;
-    lightType?: string;
-    medium?: string;
-    name?: string;
-    stage?: string;
-    startDate?: string;
-    targetHarvestDate?: string;
-  };
-  message?: string;
-  redirectTo?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const createGrowActionInitialState: CreateGrowActionResult = {
-  status: "idle",
-};
 
 function asTrimmedString(value: FormDataEntryValue | null) {
   return typeof value === "string" ? value.trim() : "";

--- a/apps/web/src/app/(app)/grows/new/grow-form.tsx
+++ b/apps/web/src/app/(app)/grows/new/grow-form.tsx
@@ -6,10 +6,10 @@ import { Button, buttonStyles } from "@/components/ui/button";
 import { FormErrorSummary } from "@/components/form-error-summary";
 import { useActionWithRecovery } from "@/lib/client/action-runner";
 import {
-  createGrowAction,
   createGrowActionInitialState,
   type CreateGrowActionResult,
-} from "../actions";
+} from "../action-state";
+import { createGrowAction } from "../actions";
 
 const FIELD_META = {
   name: { label: "Grow name", targetId: "grow-name" },

--- a/apps/web/src/app/(app)/plants/action-state.ts
+++ b/apps/web/src/app/(app)/plants/action-state.ts
@@ -1,0 +1,19 @@
+// Action state lives outside actions.ts so the `"use server"` file can
+// satisfy the React 19 / Next.js 16 contract: it must export only async
+// functions. Constants and types stay here where both the server action
+// implementation and the client form can import them.
+
+export type CreatePlantActionResult = {
+  fieldErrors?: {
+    count?: string;
+    growId?: string;
+    name?: string;
+  };
+  message?: string;
+  redirectTo?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const createPlantActionInitialState: CreatePlantActionResult = {
+  status: "idle",
+};

--- a/apps/web/src/app/(app)/plants/actions.ts
+++ b/apps/web/src/app/(app)/plants/actions.ts
@@ -4,22 +4,8 @@ import { revalidatePath } from "next/cache";
 import { createSupabaseServerClient, getServerUser } from "@/lib/server/auth";
 import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { logServerEvent } from "@/lib/server/request-id";
+import type { CreatePlantActionResult } from "./action-state";
 import { MAX_BULK_PLANT_COUNT } from "./constants";
-
-export type CreatePlantActionResult = {
-  fieldErrors?: {
-    count?: string;
-    growId?: string;
-    name?: string;
-  };
-  message?: string;
-  redirectTo?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const createPlantActionInitialState: CreatePlantActionResult = {
-  status: "idle",
-};
 
 function asTrimmedString(value: FormDataEntryValue | null) {
   return typeof value === "string" ? value.trim() : "";

--- a/apps/web/src/app/(app)/plants/new/plant-form.tsx
+++ b/apps/web/src/app/(app)/plants/new/plant-form.tsx
@@ -7,10 +7,10 @@ import { FormErrorSummary } from "@/components/form-error-summary";
 import { useActionWithRecovery } from "@/lib/client/action-runner";
 type GrowRecord = { id: string; name: string; stage: string | null };
 import {
-  createPlantAction,
   createPlantActionInitialState,
   type CreatePlantActionResult,
-} from "../actions";
+} from "../action-state";
+import { createPlantAction } from "../actions";
 import { MAX_BULK_PLANT_COUNT } from "../constants";
 
 const FIELD_META = {

--- a/apps/web/src/app/(app)/settings/action-state.ts
+++ b/apps/web/src/app/(app)/settings/action-state.ts
@@ -1,0 +1,33 @@
+// Action state lives outside actions.ts so the `"use server"` file can
+// satisfy the React 19 / Next.js 16 contract: it must export only async
+// functions. Constants and types stay here where both the server action
+// implementation and the client forms can import them.
+
+export type UpdateDisplayNameActionResult = {
+  message?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const updateDisplayNameActionInitialState: UpdateDisplayNameActionResult =
+  {
+    status: "idle",
+  };
+
+export type UpdateTimezoneActionResult = {
+  message?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const updateTimezoneActionInitialState: UpdateTimezoneActionResult = {
+  status: "idle",
+};
+
+export type UpdateEmailPreferencesActionResult = {
+  message?: string;
+  status: "error" | "idle" | "success";
+};
+
+export const updateEmailPreferencesActionInitialState: UpdateEmailPreferencesActionResult =
+  {
+    status: "idle",
+  };

--- a/apps/web/src/app/(app)/settings/actions.ts
+++ b/apps/web/src/app/(app)/settings/actions.ts
@@ -6,16 +6,11 @@ import { isNextFrameworkError } from "@/lib/server/auth-errors";
 import { getDbClient } from "@/lib/server/db";
 import { logServerEvent } from "@/lib/server/request-id";
 import { isValidTimezone } from "@/lib/server/timezone";
-
-export type UpdateDisplayNameActionResult = {
-  message?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const updateDisplayNameActionInitialState: UpdateDisplayNameActionResult =
-  {
-    status: "idle",
-  };
+import type {
+  UpdateDisplayNameActionResult,
+  UpdateEmailPreferencesActionResult,
+  UpdateTimezoneActionResult,
+} from "./action-state";
 
 function asTrimmedString(value: FormDataEntryValue | null) {
   return typeof value === "string" ? value.trim() : "";
@@ -89,15 +84,6 @@ export async function updateDisplayNameAction(
 }
 
 // ─── Timezone preference ─────────────────────────────────────────────
-
-export type UpdateTimezoneActionResult = {
-  message?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const updateTimezoneActionInitialState: UpdateTimezoneActionResult = {
-  status: "idle",
-};
 
 // Friendly copy for the SQLSTATE codes this path can plausibly throw.
 // `22023` is the migration's validation trigger telling us the IANA
@@ -193,16 +179,6 @@ export async function updateTimezoneAction(
 }
 
 // ─── Email-notification preferences (Tier 2.2) ───────────────────────
-
-export type UpdateEmailPreferencesActionResult = {
-  message?: string;
-  status: "error" | "idle" | "success";
-};
-
-export const updateEmailPreferencesActionInitialState: UpdateEmailPreferencesActionResult =
-  {
-    status: "idle",
-  };
 
 const VALID_EMAIL_SEVERITY_FLOORS = new Set([
   "info",

--- a/apps/web/src/app/(app)/settings/settings-email-form.tsx
+++ b/apps/web/src/app/(app)/settings/settings-email-form.tsx
@@ -6,10 +6,10 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 
 import {
-  updateEmailPreferencesAction,
   updateEmailPreferencesActionInitialState,
   type UpdateEmailPreferencesActionResult,
-} from "./actions";
+} from "./action-state";
+import { updateEmailPreferencesAction } from "./actions";
 
 const checkboxClassName =
   "h-4 w-4 rounded border-border/70 bg-surface text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35";

--- a/apps/web/src/app/(app)/settings/settings-profile-form.tsx
+++ b/apps/web/src/app/(app)/settings/settings-profile-form.tsx
@@ -4,10 +4,10 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
-  updateDisplayNameAction,
   updateDisplayNameActionInitialState,
   type UpdateDisplayNameActionResult,
-} from "./actions";
+} from "./action-state";
+import { updateDisplayNameAction } from "./actions";
 
 const inputClassName =
   "mt-2 block w-full rounded-[1.15rem] border border-border/80 bg-surface px-4 py-3 text-sm text-foreground shadow-soft transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35";

--- a/apps/web/src/app/(app)/settings/settings-timezone-form.tsx
+++ b/apps/web/src/app/(app)/settings/settings-timezone-form.tsx
@@ -4,10 +4,10 @@ import { useEffect, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
-  updateTimezoneAction,
   updateTimezoneActionInitialState,
   type UpdateTimezoneActionResult,
-} from "./actions";
+} from "./action-state";
+import { updateTimezoneAction } from "./actions";
 
 const inputClassName =
   "mt-2 block w-full rounded-[1.15rem] border border-border/80 bg-surface px-4 py-3 text-sm text-foreground shadow-soft transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/35";

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "check:imports": "node scripts/check-imports.mjs",
     "check:code-scanning": "node scripts/check-code-scanning-patterns.mjs",
     "check:budgets": "node scripts/check-file-budgets.mjs",
+    "check:server-actions": "node scripts/check-server-action-exports.mjs",
     "check:scope": "node scripts/check-changed-scope.mjs",
     "security:routes": "node scripts/check-route-security.mjs",
     "security:audit": "node scripts/security-audit.mjs",
     "pr:guardian": "node scripts/pr-guardian.mjs",
     "smoke:preview": "node scripts/smoke-preview.mjs",
-    "validate": "pnpm run check:env && pnpm run check:routes && pnpm run check:imports && pnpm run check:code-scanning && pnpm run check:budgets",
+    "validate": "pnpm run check:env && pnpm run check:routes && pnpm run check:imports && pnpm run check:code-scanning && pnpm run check:budgets && pnpm run check:server-actions",
     "prepare": "husky"
   },
   "engines": {

--- a/scripts/check-server-action-exports.mjs
+++ b/scripts/check-server-action-exports.mjs
@@ -37,10 +37,11 @@
 import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
 import { join, relative, sep } from "node:path";
 
-const ROOT = new URL("..", import.meta.url).pathname.replace(
-  /^\/([A-Za-z]:)/,
-  "$1",
-);
+// URL.pathname is percent-encoded — decode so a repo path containing
+// spaces or other reserved characters still resolves on disk.
+const ROOT = decodeURIComponent(
+  new URL("..", import.meta.url).pathname,
+).replace(/^\/([A-Za-z]:)/, "$1");
 const WEB_SRC = join(ROOT, "apps", "web", "src");
 
 const errors = [];
@@ -97,8 +98,10 @@ function findNonAsyncExports(source) {
     // `export type { ... } from "./..."` re-exports are also erased.
     if (/^\s*export\s+type\s*\{/.test(line)) continue;
 
-    // Allowed: `export async function foo(...)`.
-    if (/^\s*export\s+async\s+function\s/.test(line)) continue;
+    // Allowed: `export async function foo(...)` and the default form
+    // `export default async function foo(...)` — both are valid Server
+    // Actions per the React 19 / Next 16 contract.
+    if (/^\s*export\s+(default\s+)?async\s+function\s/.test(line)) continue;
 
     // Flag the disallowed shapes.
     let kind = null;

--- a/scripts/check-server-action-exports.mjs
+++ b/scripts/check-server-action-exports.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// scripts/check-server-action-exports.mjs
+//
+// Enforces the React 19 / Next.js 16 contract for files with the
+// `"use server"` directive: every value-level export MUST be an async
+// function. Non-async exports (e.g. `*InitialState` const objects, sync
+// helpers, plain types-as-values, TypeScript enums) make the file
+// invalid as a Server Actions module and Next throws at request time
+// with:
+//
+//   Error: A "use server" file can only export async functions, found "<thing>".
+//
+// In production this surfaces as a 500 on the action POST and renders
+// the generic "An error occurred in the Server Components render"
+// fallback — the original failure that motivated this script.
+//
+// What we flag (only inside files whose first non-comment line is
+// `"use server"`):
+//   - `export const ...`   (objects, primitives, sync arrow functions)
+//   - `export let ...`     / `export var ...`
+//   - `export function ...` without `async`
+//   - `export class ...`   (constructors aren't async)
+//   - `export enum ...`    (compiles to a runtime object)
+//   - re-exports via `export { x } from "./y"` or `export * from "./y"`
+//     (we can't statically prove the re-exported binding is async, and
+//     mixing re-exports into a server-actions module is almost always
+//     a code-organisation mistake — move the file or split it)
+//
+// What we allow:
+//   - `export async function ...`
+//   - `export type ...`        (erased at compile time)
+//   - `export interface ...`   (erased at compile time)
+//   - blank lines, comments
+//
+// Run via `pnpm run check:server-actions` (wired into validate).
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname.replace(
+  /^\/([A-Za-z]:)/,
+  "$1",
+);
+const WEB_SRC = join(ROOT, "apps", "web", "src");
+
+const errors = [];
+
+function* walk(dir) {
+  if (!existsSync(dir)) return;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === "node_modules" || entry === ".next") continue;
+      yield* walk(full);
+      continue;
+    }
+    if (st.isFile()) yield full;
+  }
+}
+
+// First non-empty, non-comment-only line check. The directive must be
+// the very first statement of the module (React/Next requirement).
+function hasUseServerDirective(source) {
+  const lines = source.split("\n");
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (line === "") continue;
+    if (line.startsWith("//")) continue;
+    if (line.startsWith("/*")) continue;
+    return /^["']use server["'];?$/.test(line);
+  }
+  return false;
+}
+
+// Strip block comments + line comments so the export-line regexes don't
+// match against documentation. Strings inside comments aren't a concern
+// because we only care about top-of-line `export` keywords.
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+// Per-file scan. Returns an array of human-readable violation strings.
+function findNonAsyncExports(source) {
+  const violations = [];
+  const stripped = stripComments(source);
+  const lines = stripped.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Skip type-only exports — these are erased.
+    if (/^\s*export\s+type\s/.test(line)) continue;
+    if (/^\s*export\s+interface\s/.test(line)) continue;
+    // `export type { ... } from "./..."` re-exports are also erased.
+    if (/^\s*export\s+type\s*\{/.test(line)) continue;
+
+    // Allowed: `export async function foo(...)`.
+    if (/^\s*export\s+async\s+function\s/.test(line)) continue;
+
+    // Flag the disallowed shapes.
+    let kind = null;
+    if (/^\s*export\s+const\s/.test(line)) kind = "const";
+    else if (/^\s*export\s+let\s/.test(line)) kind = "let";
+    else if (/^\s*export\s+var\s/.test(line)) kind = "var";
+    else if (/^\s*export\s+function\s/.test(line)) kind = "non-async function";
+    else if (/^\s*export\s+class\s/.test(line)) kind = "class";
+    else if (/^\s*export\s+enum\s/.test(line)) kind = "enum";
+    else if (/^\s*export\s+default\s/.test(line)) kind = "default export";
+    else if (
+      /^\s*export\s*\{[^}]*\}\s*(from\s+["'].+["']\s*)?;?\s*$/.test(line)
+    )
+      kind = "named re-export";
+    else if (/^\s*export\s*\*\s*from\s+["']/.test(line))
+      kind = "namespace re-export";
+
+    if (kind) {
+      violations.push(`line ${i + 1}: ${kind} — ${line.trim()}`);
+    }
+  }
+
+  return violations;
+}
+
+let scanned = 0;
+for (const file of walk(WEB_SRC)) {
+  if (!/\.(ts|tsx)$/.test(file)) continue;
+  // Test files don't ship to the runtime bundle.
+  if (file.includes(`${sep}__tests__${sep}`)) continue;
+  if (/\.test\.(ts|tsx)$/.test(file)) continue;
+  if (/\.spec\.(ts|tsx)$/.test(file)) continue;
+
+  let source;
+  try {
+    source = readFileSync(file, "utf8");
+  } catch {
+    continue;
+  }
+  if (!hasUseServerDirective(source)) continue;
+  scanned++;
+
+  const violations = findNonAsyncExports(source);
+  if (violations.length === 0) continue;
+
+  const rel = relative(ROOT, file);
+  errors.push(
+    `${rel}:\n` +
+      violations.map((v) => `    ${v}`).join("\n") +
+      `\n    → Move non-async exports to a sibling file without "use server". ` +
+      `See the React 19 / Next 16 rule: "A 'use server' file can only export async functions."`,
+  );
+}
+
+if (errors.length) {
+  console.error("✗ check-server-action-exports: violations\n");
+  for (const e of errors) console.error("  - " + e + "\n");
+  process.exit(1);
+}
+
+console.log(
+  `✓ check-server-action-exports: OK (${scanned} "use server" file${scanned === 1 ? "" : "s"} scanned)`,
+);


### PR DESCRIPTION
## Symptom

`/grows/new` (and `/settings`) submission renders the Next.js production fallback inside the form card:

> An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of the error.

User-reported on production (`pheno-sage-3p1ry0kk5-steven-schlingmans-projects.vercel.app`, deployment `dpl_DhaWfL1kZorSXz5SLmqLRLEALRYM`, commit `a230764` — main).

## Root cause

Vercel runtime logs for the affected deployment, queried via MCP:

| Time | Method | Path | Status | Message |
|------|--------|------|--------|---------|
| 05:17:06 | POST | /grows/new | 500 | `Error: A "use server" file ...` |
| 21:04:23 | POST | /settings | 500 | `Error: A "use server" file ...` |
| 20:59:27 | POST | /grows/new | 500 | `Error: A "use server" file ...` |
| _(and 5 more identical 500s)_ | | | | |

React 19 / Next.js 16 (landed in #169) tightened the contract on `"use server"` files: **every value-level export must be an async function**. Several action files in this repo also export sibling state values (`*ActionInitialState` const objects), which now throws at request time. The throw happens before the action body runs, so SQLSTATE-aware error mapping in `createGrowAction` etc. never gets a chance to fire — the user just sees the generic "Server Components render" fallback.

Reference: https://nextjs.org/docs/messages/invalid-use-server-value

## Fix

For each affected file, extract the `*ActionResult` type **and** the `*ActionInitialState` const into a sibling `action-state.ts` (no `"use server"` directive). The actions file imports the result type back; the client form imports both the initial state (value) and the type from `action-state.ts`, and the action function from `actions.ts`.

| Server-actions file | New sibling | Forms updated |
|---|---|---|
| `apps/web/src/app/(app)/grows/actions.ts` | `…/grows/action-state.ts` | `new/grow-form.tsx` |
| `apps/web/src/app/(app)/grows/[id]/actions.ts` | `…/grows/[id]/action-state.ts` | `archive-button.tsx`, `delete-button.tsx`, `edit/edit-form.tsx`, `stage-stepper.tsx` |
| `apps/web/src/app/(app)/plants/actions.ts` | `…/plants/action-state.ts` | `new/plant-form.tsx` |
| `apps/web/src/app/(app)/settings/actions.ts` | `…/settings/action-state.ts` | `settings-profile-form.tsx`, `settings-timezone-form.tsx`, `settings-email-form.tsx` |

`auth/actions.ts` and `notifications/actions.ts` were already clean — left untouched.

## Guardrail (prevents regression)

- **New** `scripts/check-server-action-exports.mjs` walks `apps/web/src` for `"use server"` files and flags any value-level export that isn't `async function`. Type-only exports (`export type`, `export interface`) are erased and allowed. Re-exports (`export { … } from`, `export * from`) are flagged because static analysis can't prove the re-exported binding is async.
- Wired into `pnpm run validate` as `check:server-actions`. Reports **OK across 6 scanned `"use server"` files** today.

If anyone reintroduces the bug (e.g. adds `export const FOO = …` to a `"use server"` file), `pnpm run validate` and the corresponding CI guardrail step will fail with the file path, line number, and a pointer to the move-to-sibling-file fix — much faster feedback than the production 500 the user actually hit.

## Validation

- `pnpm run validate` (incl. new `check:server-actions`) — OK
- `pnpm turbo run type-check lint test` — **704/704 tests pass**, lint clean
- `pnpm run security:audit` — OK
- `pnpm run format:check` — clean for tracked files

## Test plan

- [ ] CI green (type-check, lint, test, validate, security:audit, format:check)
- [ ] Preview deploy: create a grow on `/grows/new` — should redirect to `/grows/{id}?just_created=1` instead of rendering the error card
- [ ] Preview deploy: update display name / timezone / email prefs on `/settings` — each should land its success copy instead of 500
- [ ] Manual: try adding `export const FOO = {}` to one of the actions files locally and run `pnpm run validate` — should fail with a clear violation message

Sources:
- [Invalid "use server" Value | Next.js](https://nextjs.org/docs/messages/invalid-use-server-value)
- [vercel/next.js#56251 — A "use server" file can only export async functions, found object](https://github.com/vercel/next.js/issues/56251)
- [vercel/next.js#62926 — error when exporting non-async/cache functions](https://github.com/vercel/next.js/issues/62926)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_