### PR TITLE
fix(grows): top-level try/catch + branch logs so create-grow can't fail silently

### DIFF
--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -426,6 +426,15 @@ describe("createGrowAction", () => {
     expect(result.message).toMatch(/temporarily unavailable/i);
   });
 
+  it("surfaces the outer-timeout path with the same 'took longer than expected' copy as the insert path", async () => {
+    const err = new Error("aborted");
+    err.name = "TimeoutError";
+    mocks.getServerUser.mockRejectedValueOnce(err);
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/took longer than expected/i);
+  });
+
   it("still re-throws Next framework signals from the outer guard so redirect/notFound work", async () => {
     const redirectErr = new Error("NEXT_REDIRECT");
     (redirectErr as Error & { digest?: string }).digest = "NEXT_REDIRECT;0;/x";

--- a/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
+++ b/apps/web/src/app/(app)/grows/__tests__/actions.test.ts
@@ -368,4 +368,68 @@ describe("createGrowAction", () => {
       expect.objectContaining({ requestId: "req-abc-123" }),
     );
   });
+
+  it("emits an info-level attempt log on entry so on-call can confirm the action ran", async () => {
+    mocks.single.mockResolvedValue({ data: { id: "grow-1" }, error: null });
+    await createGrowAction(buildFormData());
+    expect(mocks.logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "create grow attempt",
+      expect.objectContaining({ requestId: expect.any(String) }),
+    );
+  });
+
+  it("emits a success log with the new grow id on the happy path", async () => {
+    mocks.single.mockResolvedValue({ data: { id: "grow-xyz" }, error: null });
+    await createGrowAction(buildFormData());
+    expect(mocks.logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "create grow inserted",
+      expect.objectContaining({
+        growId: "grow-xyz",
+        userId: "user-1",
+      }),
+    );
+  });
+
+  it("logs which fields tripped validation so silent 200s are no longer indistinguishable from successes", async () => {
+    await createGrowAction(buildFormData({ name: "", stage: "not-a-stage" }));
+    expect(mocks.logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "create grow validation rejected",
+      expect.objectContaining({
+        fields: expect.arrayContaining(["name", "stage"]),
+      }),
+    );
+  });
+
+  it("converts a thrown getServerUser() into a structured error result instead of bubbling to the error boundary", async () => {
+    const err = new Error("Supabase auth unreachable");
+    err.name = "FetchError";
+    mocks.getServerUser.mockRejectedValueOnce(err);
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/refresh the page/i);
+    expect(mocks.logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "create grow action top-level threw",
+      expect.objectContaining({ errorName: "FetchError" }),
+    );
+  });
+
+  it("surfaces the AuthConfigError path with distinct user copy", async () => {
+    const err = new Error("env var rotated");
+    err.name = "AuthConfigError";
+    mocks.getServerUser.mockRejectedValueOnce(err);
+    const result = await createGrowAction(buildFormData());
+    expect(result.status).toBe("error");
+    expect(result.message).toMatch(/temporarily unavailable/i);
+  });
+
+  it("still re-throws Next framework signals from the outer guard so redirect/notFound work", async () => {
+    const redirectErr = new Error("NEXT_REDIRECT");
+    (redirectErr as Error & { digest?: string }).digest = "NEXT_REDIRECT;0;/x";
+    mocks.getServerUser.mockRejectedValueOnce(redirectErr);
+    await expect(createGrowAction(buildFormData())).rejects.toBe(redirectErr);
+  });
 });

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -431,12 +431,21 @@ export async function createGrowAction(
     });
     // AuthConfigError carries an explicit name and means an env var is
     // missing/rotated — distinguishing it in the response copy gives
-    // on-call a clearer user-report signal.
+    // on-call a clearer user-report signal. TimeoutError / AbortError
+    // can also reach the outer catch when `getServerUser()` or
+    // `createSupabaseServerClient()` hit network-level timeouts before
+    // we even get to the insert; surface the same "took longer than
+    // expected" copy the inner catch uses for the insert-timeout path,
+    // so the user sees consistent language regardless of which stage
+    // timed out.
     const isAuthConfig = errName === "AuthConfigError";
+    const isTimeout = errName === "TimeoutError" || errName === "AbortError";
     return {
       message: isAuthConfig
         ? "Grow creation is temporarily unavailable. Our team has been notified — please try again in a few minutes."
-        : "We couldn't save the grow right now. Please refresh the page, sign in again if prompted, and try once more.",
+        : isTimeout
+          ? "The request took longer than expected. Please refresh the page and try again."
+          : "We couldn't save the grow right now. Please refresh the page, sign in again if prompted, and try once more.",
       status: "error",
     };
   }

--- a/apps/web/src/app/(app)/grows/actions.ts
+++ b/apps/web/src/app/(app)/grows/actions.ts
@@ -157,150 +157,226 @@ async function resolveRequestId(): Promise<string> {
 export async function createGrowAction(
   formData: FormData,
 ): Promise<CreateGrowActionResult> {
-  const requestId = await resolveRequestId();
-
-  const user = await getServerUser();
-  if (!user) {
-    return {
-      message: "You must be signed in to create a grow.",
-      status: "error",
-    };
-  }
-
-  // ─── Soft idempotency + abuse caps ──────────────────────────────────
-  // Order matters: the tight 2 s window catches double-submits before
-  // we run any validation, so a user spamming the button doesn't get
-  // 5× field-error renders. The 60 s cap is the abuse backstop.
-  const idempotency = await rateLimit({
-    key: `create-grow:idem:u:${user.id}`,
-    limit: IDEMPOTENCY_LIMIT,
-    windowMs: IDEMPOTENCY_WINDOW_MS,
-  });
-  if (!idempotency.ok) {
-    logServerEvent("warn", "create grow rate-limited (idempotency window)", {
-      requestId,
-      resetAt: idempotency.resetAt,
-      userId: user.id,
-    });
-    return {
-      message:
-        "We're already saving your last submission — give it a moment, then try again if it didn't go through.",
-      status: "error",
-    };
-  }
-
-  const abuse = await rateLimit({
-    key: `create-grow:abuse:u:${user.id}`,
-    limit: ABUSE_LIMIT,
-    windowMs: ABUSE_LIMIT_WINDOW_MS,
-  });
-  if (!abuse.ok) {
-    logServerEvent("warn", "create grow rate-limited (abuse cap)", {
-      requestId,
-      resetAt: abuse.resetAt,
-      userId: user.id,
-    });
-    return {
-      message:
-        "You've created a lot of grows in the last minute. Please slow down and try again shortly.",
-      status: "error",
-    };
-  }
-
-  const name = asTrimmedString(formData.get("name"));
-  const description = asTrimmedString(formData.get("description"));
-  const stage = asTrimmedString(formData.get("stage"));
-  const medium = asTrimmedString(formData.get("medium"));
-  const lightType = asTrimmedString(formData.get("lightType"));
-  const startDate = asTrimmedString(formData.get("startDate"));
-  const targetHarvestDate = asTrimmedString(formData.get("targetHarvestDate"));
-
-  const fieldErrors: CreateGrowActionResult["fieldErrors"] = {};
-
-  if (!name) {
-    fieldErrors.name = "Name is required.";
-  } else if (name.length > 120) {
-    fieldErrors.name = "Keep the grow name under 120 characters.";
-  }
-
-  if (description.length > MAX_DESCRIPTION_LENGTH) {
-    fieldErrors.description = `Keep the description under ${MAX_DESCRIPTION_LENGTH} characters.`;
-  }
-
-  if (!validStages.has(stage as GrowStage)) {
-    fieldErrors.stage = "Choose a valid grow stage.";
-  }
-
-  if (!validMedia.has(medium as GrowMedium)) {
-    fieldErrors.medium = "Choose a valid medium.";
-  }
-
-  if (!validLightTypes.has(lightType as LightType)) {
-    fieldErrors.lightType = "Choose a valid light type.";
-  }
-
-  if (!startDate) {
-    fieldErrors.startDate = "Start date is required.";
-  } else if (!isIsoDate(startDate)) {
-    fieldErrors.startDate = "Use a valid start date.";
-  } else if (Date.parse(startDate) > Date.now() + MAX_FUTURE_START_MS) {
-    fieldErrors.startDate =
-      "Start date can't be more than a day in the future.";
-  }
-
-  if (targetHarvestDate) {
-    if (!isIsoDate(targetHarvestDate)) {
-      fieldErrors.targetHarvestDate = "Use a valid target harvest date.";
-    } else if (
-      startDate &&
-      isIsoDate(startDate) &&
-      targetHarvestDate < startDate
-    ) {
-      fieldErrors.targetHarvestDate =
-        "Target harvest date must be on or after the start date.";
-    }
-  }
-
-  if (Object.keys(fieldErrors).length > 0) {
-    return {
-      fieldErrors,
-      message: "Fix the highlighted fields and try again.",
-      status: "error",
-    };
-  }
-
-  let newGrowId: string | null = null;
+  // Top-level try/catch is the load-bearing "professional error handling"
+  // wrapper: every code path inside the action is allowed to throw, and
+  // this catch converts the throw into a structured `{ status: "error" }`
+  // result instead of letting it bubble to React's error boundary as the
+  // generic "An error occurred in the Server Components render" message.
+  // Without it, a thrown `getServerUser()` (AuthConfigError on a rotated
+  // Supabase key, fetch-failed during a Supabase incident) or `rateLimit()`
+  // (Redis outage on a misconfigured Upstash backend) takes the form
+  // offline silently. Next.js framework control-flow signals are re-thrown
+  // so redirect / notFound still work.
+  let requestId = "unknown";
+  let userId: string | null = null;
   try {
-    const supabase = await createSupabaseServerClient();
-    // Per-attempt deadline. AbortSignal.timeout fires at INSERT_TIMEOUT_MS
-    // and supabase-js v2 forwards it to its underlying fetch via
-    // .abortSignal(). On fire we treat it as a retryable timeout — the
-    // INSERT either landed (and we never see the row) or it didn't; the
-    // (owner_id, lower(name)) UNIQUE index converts a phantom-success
-    // double into a friendly 23505 on retry.
-    const timeoutSignal = AbortSignal.timeout(INSERT_TIMEOUT_MS);
-    const { data, error } = await supabase
-      .from("grows")
-      .insert({
-        description: description || null,
-        light_type: lightType as LightType,
-        medium: medium as GrowMedium,
-        name,
-        owner_id: user.id,
-        stage: stage as GrowStage,
-        start_date: startDate,
-        target_harvest_date: targetHarvestDate || null,
-      })
-      .select("id")
-      .abortSignal(timeoutSignal)
-      .single();
+    requestId = await resolveRequestId();
 
-    if (error || !data) {
-      logServerEvent("error", "create grow insert failed", {
-        error: error?.message ?? "no row returned",
-        errorCode: error?.code ?? null,
+    // Single attempt log at the very top so we can confirm in production
+    // logs that the action was reached. Pre-fix the symptom was a 500 at
+    // the runtime "use server" gate so this never ran; with the fix in,
+    // a missing attempt log is itself a meaningful signal.
+    logServerEvent("info", "create grow attempt", { requestId });
+
+    const user = await getServerUser();
+    if (!user) {
+      logServerEvent("warn", "create grow unauthenticated", { requestId });
+      return {
+        message: "You must be signed in to create a grow.",
+        status: "error",
+      };
+    }
+    userId = user.id;
+
+    // ─── Soft idempotency + abuse caps ──────────────────────────────────
+    // Order matters: the tight 2 s window catches double-submits before
+    // we run any validation, so a user spamming the button doesn't get
+    // 5× field-error renders. The 60 s cap is the abuse backstop.
+    const idempotency = await rateLimit({
+      key: `create-grow:idem:u:${user.id}`,
+      limit: IDEMPOTENCY_LIMIT,
+      windowMs: IDEMPOTENCY_WINDOW_MS,
+    });
+    if (!idempotency.ok) {
+      logServerEvent("warn", "create grow rate-limited (idempotency window)", {
+        requestId,
+        resetAt: idempotency.resetAt,
+        userId: user.id,
+      });
+      return {
+        message:
+          "We're already saving your last submission — give it a moment, then try again if it didn't go through.",
+        status: "error",
+      };
+    }
+
+    const abuse = await rateLimit({
+      key: `create-grow:abuse:u:${user.id}`,
+      limit: ABUSE_LIMIT,
+      windowMs: ABUSE_LIMIT_WINDOW_MS,
+    });
+    if (!abuse.ok) {
+      logServerEvent("warn", "create grow rate-limited (abuse cap)", {
+        requestId,
+        resetAt: abuse.resetAt,
+        userId: user.id,
+      });
+      return {
+        message:
+          "You've created a lot of grows in the last minute. Please slow down and try again shortly.",
+        status: "error",
+      };
+    }
+
+    const name = asTrimmedString(formData.get("name"));
+    const description = asTrimmedString(formData.get("description"));
+    const stage = asTrimmedString(formData.get("stage"));
+    const medium = asTrimmedString(formData.get("medium"));
+    const lightType = asTrimmedString(formData.get("lightType"));
+    const startDate = asTrimmedString(formData.get("startDate"));
+    const targetHarvestDate = asTrimmedString(
+      formData.get("targetHarvestDate"),
+    );
+
+    const fieldErrors: CreateGrowActionResult["fieldErrors"] = {};
+
+    if (!name) {
+      fieldErrors.name = "Name is required.";
+    } else if (name.length > 120) {
+      fieldErrors.name = "Keep the grow name under 120 characters.";
+    }
+
+    if (description.length > MAX_DESCRIPTION_LENGTH) {
+      fieldErrors.description = `Keep the description under ${MAX_DESCRIPTION_LENGTH} characters.`;
+    }
+
+    if (!validStages.has(stage as GrowStage)) {
+      fieldErrors.stage = "Choose a valid grow stage.";
+    }
+
+    if (!validMedia.has(medium as GrowMedium)) {
+      fieldErrors.medium = "Choose a valid medium.";
+    }
+
+    if (!validLightTypes.has(lightType as LightType)) {
+      fieldErrors.lightType = "Choose a valid light type.";
+    }
+
+    if (!startDate) {
+      fieldErrors.startDate = "Start date is required.";
+    } else if (!isIsoDate(startDate)) {
+      fieldErrors.startDate = "Use a valid start date.";
+    } else if (Date.parse(startDate) > Date.now() + MAX_FUTURE_START_MS) {
+      fieldErrors.startDate =
+        "Start date can't be more than a day in the future.";
+    }
+
+    if (targetHarvestDate) {
+      if (!isIsoDate(targetHarvestDate)) {
+        fieldErrors.targetHarvestDate = "Use a valid target harvest date.";
+      } else if (
+        startDate &&
+        isIsoDate(startDate) &&
+        targetHarvestDate < startDate
+      ) {
+        fieldErrors.targetHarvestDate =
+          "Target harvest date must be on or after the start date.";
+      }
+    }
+
+    if (Object.keys(fieldErrors).length > 0) {
+      // Validation surface log: tells on-call which field tripped without
+      // leaking the free-text contents. Previously this branch logged
+      // nothing, which meant a silent return looked indistinguishable
+      // from a successful insert in the request trace.
+      logServerEvent("info", "create grow validation rejected", {
+        requestId,
+        userId: user.id,
+        fields: Object.keys(fieldErrors).sort(),
+      });
+      return {
+        fieldErrors,
+        message: "Fix the highlighted fields and try again.",
+        status: "error",
+      };
+    }
+
+    let newGrowId: string | null = null;
+    try {
+      const supabase = await createSupabaseServerClient();
+      // Per-attempt deadline. AbortSignal.timeout fires at INSERT_TIMEOUT_MS
+      // and supabase-js v2 forwards it to its underlying fetch via
+      // .abortSignal(). On fire we treat it as a retryable timeout — the
+      // INSERT either landed (and we never see the row) or it didn't; the
+      // (owner_id, lower(name)) UNIQUE index converts a phantom-success
+      // double into a friendly 23505 on retry.
+      const timeoutSignal = AbortSignal.timeout(INSERT_TIMEOUT_MS);
+      const { data, error } = await supabase
+        .from("grows")
+        .insert({
+          description: description || null,
+          light_type: lightType as LightType,
+          medium: medium as GrowMedium,
+          name,
+          owner_id: user.id,
+          stage: stage as GrowStage,
+          start_date: startDate,
+          target_harvest_date: targetHarvestDate || null,
+        })
+        .select("id")
+        .abortSignal(timeoutSignal)
+        .single();
+
+      if (error || !data) {
+        logServerEvent("error", "create grow insert failed", {
+          error: error?.message ?? "no row returned",
+          errorCode: error?.code ?? null,
+          hasDescription: description.length > 0,
+          hasTargetHarvestDate: targetHarvestDate.length > 0,
+          lightType,
+          medium,
+          nameLength: name.length,
+          requestId,
+          stage,
+          userId: user.id,
+        });
+        return {
+          message: describePostgresError(error?.code ?? null),
+          status: "error",
+        };
+      }
+
+      newGrowId = data.id;
+
+      // Success log — closes the observability loop. With this, "POST
+      // /grows/new returned 200 but the row is missing" can be triaged
+      // by a single grep for `create grow inserted` + the requestId.
+      logServerEvent("info", "create grow inserted", {
+        requestId,
+        userId: user.id,
+        growId: newGrowId,
+      });
+
+      revalidatePath("/dashboard");
+      revalidatePath("/grows");
+      revalidatePath("/plants");
+    } catch (err) {
+      // Re-throw Next framework control-flow signals untouched.
+      if (isNextFrameworkError(err)) throw err;
+      // Differentiate the timeout/abort path so the user gets actionable
+      // copy ("took too long") instead of a generic "something went wrong".
+      // AbortSignal.timeout fires a DOMException with name "TimeoutError";
+      // a caller-cancelled abort fires "AbortError". Either way the
+      // database state is uncertain — see the UNIQUE-index backstop note
+      // above the insert.
+      const errName = err instanceof Error ? err.name : "";
+      const isTimeout = errName === "TimeoutError" || errName === "AbortError";
+      logServerEvent("error", "create grow action threw", {
+        error: err instanceof Error ? err.message : String(err),
+        errorName: errName || null,
         hasDescription: description.length > 0,
         hasTargetHarvestDate: targetHarvestDate.length > 0,
+        isTimeout,
         lightType,
         medium,
         nameLength: name.length,
@@ -309,64 +385,59 @@ export async function createGrowAction(
         userId: user.id,
       });
       return {
-        message: describePostgresError(error?.code ?? null),
+        message: isTimeout
+          ? "The save took longer than expected. Please try again — your input is preserved."
+          : "We couldn't save the grow right now. Please try again in a moment — if it keeps failing, your sign-in may have expired.",
         status: "error",
       };
     }
 
-    newGrowId = data.id;
-
-    revalidatePath("/dashboard");
-    revalidatePath("/grows");
-    revalidatePath("/plants");
-  } catch (err) {
-    // Re-throw Next framework control-flow signals untouched.
-    if (isNextFrameworkError(err)) throw err;
-    // Differentiate the timeout/abort path so the user gets actionable
-    // copy ("took too long") instead of a generic "something went wrong".
-    // AbortSignal.timeout fires a DOMException with name "TimeoutError";
-    // a caller-cancelled abort fires "AbortError". Either way the
-    // database state is uncertain — see the UNIQUE-index backstop note
-    // above the insert.
-    const errName = err instanceof Error ? err.name : "";
-    const isTimeout = errName === "TimeoutError" || errName === "AbortError";
-    logServerEvent("error", "create grow action threw", {
-      error: err instanceof Error ? err.message : String(err),
-      errorName: errName || null,
-      hasDescription: description.length > 0,
-      hasTargetHarvestDate: targetHarvestDate.length > 0,
-      isTimeout,
-      lightType,
-      medium,
-      nameLength: name.length,
-      requestId,
-      stage,
-      userId: user.id,
-    });
+    // Return a redirectTo instead of calling redirect() here. When this server
+    // action is invoked from a client-side `await` inside startTransition, a
+    // NEXT_REDIRECT throw cannot be intercepted by the framework and surfaces
+    // as an error boundary hit. Letting the client perform router.push avoids
+    // that entire failure mode.
+    //
+    // Land on the grow detail page so the user immediately sees the grow
+    // they just created with plant intake one click away. The form's
+    // useActionWithRecovery falls back to /grows if /grows/[id] is
+    // unreachable for any reason, so users are never stranded.
+    const redirectTo = newGrowId
+      ? `/grows/${encodeURIComponent(newGrowId)}?just_created=1`
+      : "/grows";
     return {
-      message: isTimeout
-        ? "The save took longer than expected. Please try again — your input is preserved."
-        : "We couldn't save the grow right now. Please try again in a moment — if it keeps failing, your sign-in may have expired.",
+      message: "Grow created.",
+      redirectTo,
+      status: "success",
+    };
+  } catch (err) {
+    // ─── Outer defensive guard ──────────────────────────────────────────
+    // Anything that escapes the inner blocks lands here — typically
+    // `getServerUser()` or `rateLimit()` throwing because of misconfigured
+    // env (AuthConfigError on a rotated Supabase key), a Supabase auth
+    // outage (fetch-failed), or a Redis blowup on a misconfigured Upstash
+    // backend. Without this guard the throw bubbles to React's error
+    // boundary as the generic "Server Components render" message — the
+    // exact failure mode the user reported. Re-throw framework signals
+    // so Next can finish redirect / notFound control flow.
+    if (isNextFrameworkError(err)) throw err;
+    const errName = err instanceof Error ? err.name : "";
+    const errMessage = err instanceof Error ? err.message : String(err);
+    logServerEvent("error", "create grow action top-level threw", {
+      error: errMessage,
+      errorName: errName || null,
+      requestId,
+      userId,
+    });
+    // AuthConfigError carries an explicit name and means an env var is
+    // missing/rotated — distinguishing it in the response copy gives
+    // on-call a clearer user-report signal.
+    const isAuthConfig = errName === "AuthConfigError";
+    return {
+      message: isAuthConfig
+        ? "Grow creation is temporarily unavailable. Our team has been notified — please try again in a few minutes."
+        : "We couldn't save the grow right now. Please refresh the page, sign in again if prompted, and try once more.",
       status: "error",
     };
   }
-
-  // Return a redirectTo instead of calling redirect() here. When this server
-  // action is invoked from a client-side `await` inside startTransition, a
-  // NEXT_REDIRECT throw cannot be intercepted by the framework and surfaces
-  // as an error boundary hit. Letting the client perform router.push avoids
-  // that entire failure mode.
-  //
-  // Land on the grow detail page so the user immediately sees the grow
-  // they just created with plant intake one click away. The form's
-  // useActionWithRecovery falls back to /grows if /grows/[id] is
-  // unreachable for any reason, so users are never stranded.
-  const redirectTo = newGrowId
-    ? `/grows/${encodeURIComponent(newGrowId)}?just_created=1`
-    : "/grows";
-  return {
-    message: "Grow created.",
-    redirectTo,
-    status: "success",
-  };
 }


### PR DESCRIPTION
## Symptom (continuing from #173)

User reports `POST /grows/new` returns 200 but **no error surfaces and no row is created**. The first fix (#173) removed the runtime `"use server"` throw that was masking everything. With that gone, the second-layer bug is now visible: the action is reaching a non-success branch silently. Every branch that *isn't* a rate-limit or insert failure logs nothing.

## Root causes addressed

### 1. Silent branches (observability)

`createGrowAction` only logged on:
- `rate-limited (idempotency window)` (warn)
- `rate-limited (abuse cap)` (warn)
- `create grow insert failed` (error)
- `create grow action threw` (error)

The auth-missing, validation-rejected, and **happy-path** branches logged nothing. The Vercel runtime trace for the user's submission shows only the rate-limit *fallback* warning ("UPSTASH_REDIS_REST_URL/TOKEN not set") — not the rate-limit *blocked* path — so by elimination the action reached either:
- auth check returned no user (silent return)
- validation produced fieldErrors (silent return)
- the insert succeeded (silent return)

The trace is the same for all three. That's the observability gap this fix closes.

New info-level logs:
- `create grow attempt` at the top of the action (confirms it ran).
- `create grow validation rejected` with the sorted list of fields that tripped (free-text contents never logged).
- `create grow inserted` with the new `growId` after a successful insert.

After this lands, a single grep for the user's request id tells you exactly which branch the action took.

### 2. Throws bypassing error mapping

`getServerUser()` (line 162 pre-fix) and both `rateLimit()` calls sat **outside** the existing try/catch (which only covered the insert block). If any of them threw — AuthConfigError on a rotated Supabase key, fetch-failed during a Supabase auth incident, Redis blowup on a misconfigured Upstash backend — the throw bubbled to React's error boundary and rendered the generic "An error occurred in the Server Components render" message. Same UI symptom as the `"use server"` bug fixed in #173, different cause.

Top-level `try/catch` around the whole action body:
- Logs `create grow action top-level threw` with `errorName` + `errorMessage` + `requestId`.
- Returns a structured error result so the form re-renders inline.
- Distinguishes `AuthConfigError` in user-facing copy ("temporarily unavailable" vs "refresh and try again").
- Re-throws `isNextFrameworkError(err)` so `redirect()` / `notFound()` still work.

## Why this is a permanent solution

The two-axis fix means: from now on, every code path through `createGrowAction` either logs what happened or fails through the outer guard. There is no longer a branch where the action returns silently or throws into the React error boundary.

The audit branch (`claude/review-audit-document-cASys`, unmerged) had already proposed this exact hardening on top of additional changes; this PR adapts the audit branch's `createGrowAction` rewrite to the post-#173 main while keeping the diff narrowly scoped to the user-reported failure. Settings actions and the audit branch's RLS-policy migration (021) are intentionally out of scope for follow-ups.

## Validation

- `pnpm run validate` (incl. `check:server-actions`) — OK
- `pnpm turbo run type-check lint test` — **710/710** (was 704; +6 new tests in `__tests__/actions.test.ts`)
- `pnpm run security:audit` — OK
- `pnpm run format:check` — clean

## Test plan

- [ ] CI green
- [ ] Preview deploy: submit `/grows/new` with all required fields → `create grow inserted` log appears with a fresh growId, redirect to `/grows/{id}?just_created=1` lands.
- [ ] Preview deploy: submit `/grows/new` with empty name → `create grow validation rejected` log lists `["name"]` and the form shows the field error.
- [ ] Preview deploy: revoke the Supabase key temporarily (or wait for any auth hiccup) → `create grow action top-level threw` log appears with `errorName`, form shows the AuthConfigError copy, page does NOT render the "Server Components render" error.
- [ ] Vercel runtime log search for `create grow inserted` shows the green path; search for `create grow action top-level threw` shows any future regressions to the throw-bypassing path.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_