### PR TITLE
fix(supabase): break grows ↔ grow_members RLS recursion (42P17) — migration 022

### DIFF
--- a/supabase/migrations/022_fix_grow_rls_recursion.sql
+++ b/supabase/migrations/022_fix_grow_rls_recursion.sql
@@ -1,0 +1,108 @@
+-- Migration: 022_fix_grow_rls_recursion
+--
+-- BLOCKER FIX. Restores `INSERT INTO public.grows` for authenticated
+-- users by breaking the RLS-policy recursion cycle introduced (latently)
+-- by migration 001:
+--
+--   * `grows: member read` (SELECT on grows) → EXISTS subquery against
+--     `grow_members`.
+--   * `grow_members: grow owner manage` (ALL on grow_members) → EXISTS
+--     subquery against `grows`.
+--
+-- When a server action runs `.insert(...).select("id").single()`,
+-- supabase-js issues `INSERT ... RETURNING id`, which Postgres evaluates
+-- under both the `grows` INSERT policy AND the `grows` SELECT policy
+-- (because RETURNING reads rows back). The SELECT half triggers
+-- `grows: member read`, whose subquery evaluates `grow_members`'s ALL
+-- policy, whose subquery re-evaluates the `grows` policies — infinite
+-- recursion, terminated by Postgres with `42P17`.
+--
+-- This was a latent bug from migration 001. It only began firing in
+-- production after #173 + #174 fixed the "use server" + try/catch issues
+-- in createGrowAction — before those landed the action never reached
+-- Supabase at all, so the recursion never executed.
+--
+-- Fix: wrap the cross-table EXISTS check in a SECURITY DEFINER function
+-- that runs with the function owner's privileges, bypassing RLS on the
+-- inner query and breaking the cycle. This is the Supabase-recommended
+-- pattern for cross-table RLS predicates — see
+-- https://supabase.com/docs/guides/database/postgres/row-level-security#authorize-functions-with-security-definer
+--
+-- The fix preserves both existing access patterns:
+--   * Grow owners can manage their grow_members (now via the helper).
+--   * Grow owners can read their own grows (`grows: owner write` ALL
+--     policy already grants SELECT — unchanged).
+--   * Grow MEMBERS can read shared grows (`grows: member read` —
+--     replaced with a non-recursive form via a sibling helper).
+
+-- ─── private schema ────────────────────────────────────────────────────
+-- Housing for SECURITY DEFINER helpers so they don't leak into PostgREST
+-- discovery (only public is exposed by default). Idempotent.
+create schema if not exists private;
+
+-- Lock down execute so only authenticated callers (or service role)
+-- can invoke. Public should not be able to execute these.
+revoke all on schema private from public;
+grant usage on schema private to authenticated, service_role;
+
+-- ─── private.is_grow_owner ─────────────────────────────────────────────
+-- True iff the calling auth.uid() owns the given grow. SECURITY DEFINER
+-- so the inner SELECT bypasses RLS on `grows`, which is what breaks the
+-- recursive cycle with `grow_members: grow owner manage`.
+create or replace function private.is_grow_owner(p_grow_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1 from public.grows
+    where id = p_grow_id and owner_id = auth.uid()
+  );
+$$;
+
+revoke all on function private.is_grow_owner(uuid) from public;
+grant execute on function private.is_grow_owner(uuid) to authenticated, service_role;
+
+-- ─── private.is_grow_member ────────────────────────────────────────────
+-- True iff the calling auth.uid() has a grow_members row for the grow.
+-- SECURITY DEFINER so the inner SELECT bypasses RLS on `grow_members`,
+-- preventing the symmetric recursion in case any future write to
+-- grow_members happens with RETURNING (Supabase-js does this by default
+-- for insert/upsert/update/delete + select).
+create or replace function private.is_grow_member(p_grow_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, pg_temp
+as $$
+  select exists (
+    select 1 from public.grow_members
+    where grow_id = p_grow_id and user_id = auth.uid()
+  );
+$$;
+
+revoke all on function private.is_grow_member(uuid) from public;
+grant execute on function private.is_grow_member(uuid) to authenticated, service_role;
+
+-- ─── Replace the recursive policies ────────────────────────────────────
+-- Drop-then-create rather than alter because CREATE OR REPLACE POLICY
+-- doesn't exist in current Postgres.
+
+drop policy if exists "grow_members: grow owner manage" on public.grow_members;
+create policy "grow_members: grow owner manage"
+  on public.grow_members
+  for all
+  using ( private.is_grow_owner(grow_id) )
+  with check ( private.is_grow_owner(grow_id) );
+
+drop policy if exists "grows: member read" on public.grows;
+create policy "grows: member read"
+  on public.grows
+  for select
+  using (
+    auth.uid() = owner_id
+    or private.is_grow_member(id)
+  );


### PR DESCRIPTION
## Production blocker — applied to prod, this PR brings the repo in sync

`POST /grows/new` returned 200 with no row created in 4 consecutive user tests. Production logs showed `create grow attempt` + `create grow insert failed` at error level; a direct simulated INSERT under `role=authenticated` returned:

```
ERROR: 42P17: infinite recursion detected in policy for relation "grows"
```

## Root cause

Latent in migration 001 since day one. Two RLS policies form a cycle:

```
grows: member read   (SELECT on grows)
  └─ EXISTS (SELECT 1 FROM grow_members WHERE grow_id = grows.id ...)
       └─ triggers grow_members policies (PostgREST evaluates RLS on
          the sub-query)
grow_members: grow owner manage   (ALL on grow_members)
  └─ EXISTS (SELECT 1 FROM grows WHERE g.id = grow_members.grow_id ...)
       └─ triggers grows policies again ← cycle
```

supabase-js's `.insert(...).select("id").single()` desugars to `INSERT … RETURNING`, which Postgres evaluates under BOTH the INSERT and SELECT policies on `grows`. The SELECT half ignites the cycle. Before #173 + #174, the action never reached Supabase (it died at the "use server" gate), so the cycle never executed. Once those fixes shipped, every authenticated INSERT into `grows` died with `42P17`.

## Fix

Supabase-recommended SECURITY DEFINER pattern. Add two helpers in a new `private` schema (not exposed by PostgREST):

- `private.is_grow_owner(uuid)` — checks ownership without re-entering RLS on `grows`.
- `private.is_grow_member(uuid)` — checks membership without re-entering RLS on `grow_members`.

Then rewrite the two recursive policies to call the helpers:

| Policy | Old | New |
|---|---|---|
| `grow_members: grow owner manage` | `EXISTS (SELECT 1 FROM grows g WHERE …)` | `private.is_grow_owner(grow_id)` |
| `grows: member read` | `EXISTS (SELECT 1 FROM grow_members gm WHERE …)` | `private.is_grow_member(id)` |

The `grows: owner write` policy (`ALL`, `qual = auth.uid() = owner_id`) is untouched, so the simple owner-only path continues to work via that policy.

## Already applied to production

Per "act as lead operator" authorization, the migration was applied via Supabase MCP at 2026-05-16. Verification:

```sql
-- Before
INSERT INTO grows … under role=authenticated
  → ERROR 42P17: infinite recursion detected in policy for relation "grows"

-- After (same insert, rolled back)
INSERT INTO grows … under role=authenticated
  → 1 row inserted (RETURNING id worked)
```

Security advisor scan post-apply: no new findings against the `private.*` functions. All 7 pre-existing advisor warnings are unrelated (`public.handle_new_user`, `public.rls_auto_enable`, search-path drift, leaked-password protection toggle).

## Test plan

- [ ] CI green
- [ ] User-side verification: submit `/grows/new` with a unique name → expect redirect to `/grows/{id}?just_created=1` and a `create grow inserted` log line in Vercel runtime logs.
- [ ] Member-read path: an owner adds a row to `grow_members` for another user; that other user can SELECT the shared grow (covered by the new `private.is_grow_member` helper, currently untested in app code — owner-only is the default).

## Reference

- https://supabase.com/docs/guides/database/postgres/row-level-security#authorize-functions-with-security-definer
- PostgREST recursion in cross-table policies — known footgun, documented in Supabase recipes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_