### PR TITLE
fix(dashboard): make the surface resilient + add route-scoped error boundary

### DIFF
--- a/apps/web/src/app/(app)/dashboard/error.tsx
+++ b/apps/web/src/app/(app)/dashboard/error.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import Link from "next/link";
+import { buttonStyles } from "@/components/ui/button";
+
+// Route-scoped error boundary for /dashboard. With the dashboard page's
+// post-#175 Promise.allSettled defences, the server-side render of this
+// page should never throw — getCurrentProfile falls back to null and
+// getWorkspaceOverview returns EMPTY_WORKSPACE_OVERVIEW on any error.
+// The only realistic remaining failure modes are:
+//
+//   1. A client-side throw during hydration (e.g., a realtime hook
+//      can't initialise because public Supabase env vars haven't
+//      finished syncing). These show `digest === undefined`.
+//   2. A truly unexpected Server Component throw that escapes the
+//      defences (defence-in-depth backstop, not the expected path).
+//      These show a populated `digest` we can grep in Vercel logs.
+//
+// This boundary keeps the user moving — they can refresh the page,
+// jump to a known-good surface, or read off the digest for support.
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <main className="app-page">
+      <section className="rounded-[1.15rem] border border-warning/40 bg-warning/10 px-5 py-5 text-sm leading-6 text-foreground">
+        <p className="text-base font-semibold">
+          We hit a snag loading your dashboard.
+        </p>
+        <p className="mt-2 text-muted-foreground">
+          Your data is safe. Refresh this surface, or jump straight to a grow,
+          plant, or the copilot — they&apos;re all reachable from here.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            className={buttonStyles({ size: "md" })}
+            onClick={reset}
+            type="button"
+          >
+            Refresh dashboard
+          </button>
+          <Link
+            className={buttonStyles({ size: "md", variant: "surface" })}
+            href="/grows"
+          >
+            Open grows
+          </Link>
+          <Link
+            className={buttonStyles({ size: "md", variant: "surface" })}
+            href="/assistant"
+          >
+            Open copilot
+          </Link>
+        </div>
+        {error.digest ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Reference: <code className="font-mono">{error.digest}</code>
+          </p>
+        ) : (
+          <p className="mt-3 text-xs text-muted-foreground">
+            This looked like a client-side hiccup (no server reference). A
+            refresh almost always fixes it.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -18,7 +18,11 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { SectionHeader } from "@/components/ui/section-header";
 import { StatCard } from "@/components/ui/stat-card";
 import { getCurrentProfile } from "@/lib/server/profile";
-import { getWorkspaceOverview } from "@/lib/server/workspace-overview";
+import { logServerEvent } from "@/lib/server/request-id";
+import {
+  EMPTY_WORKSPACE_OVERVIEW,
+  getWorkspaceOverview,
+} from "@/lib/server/workspace-overview";
 
 export const metadata: Metadata = { title: "Dashboard" };
 
@@ -51,10 +55,43 @@ function formatTodayLabel(now: Date) {
 }
 
 export default async function DashboardPage() {
-  const [profile, overview] = await Promise.all([
+  // Use Promise.allSettled so a profile-load blip (transient Supabase
+  // auth error, expired cookie mid-request) can't take the entire
+  // dashboard page down. The layout already loaded the profile to
+  // render the AppShell, so any failure here is by definition a fresh
+  // hiccup on the page's second call — the right move is to render
+  // with anonymous copy, not throw into the workspace error boundary.
+  // getWorkspaceOverview is internally defended (Promise.allSettled
+  // around each query, returns EMPTY_WORKSPACE_OVERVIEW on failure)
+  // and never throws.
+  const [profileSettled, overviewSettled] = await Promise.allSettled([
     getCurrentProfile(),
     getWorkspaceOverview(),
   ]);
+  const profile =
+    profileSettled.status === "fulfilled" ? profileSettled.value : null;
+  if (profileSettled.status === "rejected") {
+    logServerEvent("warn", "dashboard: profile reload failed, rendering anon", {
+      error:
+        profileSettled.reason instanceof Error
+          ? profileSettled.reason.message
+          : String(profileSettled.reason),
+    });
+  }
+  const overview =
+    overviewSettled.status === "fulfilled"
+      ? overviewSettled.value
+      : EMPTY_WORKSPACE_OVERVIEW;
+  if (overviewSettled.status === "rejected") {
+    // Defence in depth — getWorkspaceOverview catches internally, but
+    // future refactors could break that contract. Log + degrade.
+    logServerEvent("error", "dashboard: workspace overview threw", {
+      error:
+        overviewSettled.reason instanceof Error
+          ? overviewSettled.reason.message
+          : String(overviewSettled.reason),
+    });
+  }
   const operator =
     profile?.displayName?.trim() ||
     profile?.email

--- a/apps/web/src/components/error-fallback.tsx
+++ b/apps/web/src/components/error-fallback.tsx
@@ -79,7 +79,17 @@ export function ErrorFallback({
               <p className="text-xs text-muted-foreground/80">
                 Reference code: <code className="font-mono">{digest}</code>
               </p>
-            ) : null}
+            ) : (
+              // No digest means the throw didn't originate in a Server
+              // Component render — React caught it client-side (typically
+              // during hydration or a useEffect). A refresh almost
+              // always clears it because the new HTML is freshly hydrated
+              // against the latest deployment + cookie state.
+              <p className="text-xs text-muted-foreground/80">
+                This looked like a client-side hiccup. A page refresh usually
+                clears it.
+              </p>
+            )}
           </div>
           <div className="flex flex-wrap gap-3">
             {reset ? (

--- a/apps/web/src/lib/server/workspace-overview.ts
+++ b/apps/web/src/lib/server/workspace-overview.ts
@@ -78,7 +78,7 @@ export type WorkspaceOverview = {
   };
 };
 
-const EMPTY_WORKSPACE_OVERVIEW: WorkspaceOverview = {
+export const EMPTY_WORKSPACE_OVERVIEW: WorkspaceOverview = {
   grows: [],
   openFindings: 0,
   recentActivity: {

--- a/apps/web/src/lib/use-live-analysis.ts
+++ b/apps/web/src/lib/use-live-analysis.ts
@@ -30,7 +30,24 @@ export function useLiveAnalysis({ growIds }: { growIds: string[] }) {
 
   useEffect(() => {
     if (growIds.length === 0) return;
-    const supabase = createSupabaseBrowserClient();
+    // `createSupabaseBrowserClient` throws when the public env vars
+    // aren't bundled (e.g. a Vercel deploy that built before the
+    // Supabase integration synced its keys). Swallow that throw so a
+    // live-update side-effect can never take the entire dashboard
+    // page down via React's error boundary — losing realtime is a
+    // graceful degradation; losing the page isn't.
+    let supabase;
+    try {
+      supabase = createSupabaseBrowserClient();
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.warn(
+          "useLiveAnalysis: browser supabase client unavailable, realtime disabled",
+          err,
+        );
+      }
+      return;
+    }
 
     const scheduleRefresh = () => {
       setLastEventAt(Date.now());


### PR DESCRIPTION
## Symptom

User reported "the whole app is not working" with the `(app)/error.tsx` boundary showing **"We couldn't load this workspace view"** on `/dashboard`. The bottom nav still rendered (layout passed), only the page content was the error UI.

## What the logs actually showed

The user's session (2026-05-16 20:49 UTC) made *thirteen* requests across `/dashboard`, `/grows`, `/plants`, `/assistant`, `/settings`, `/notifications`, `/grows/new`, `/grows/{id}/...`. **Every single one returned 200 with no error-level log.** The 307+error log entry on `/dashboard` at 20:55:35 was my own unauthenticated probe via `web_fetch_vercel_url`.

The screenshot also had **no "Reference code" line** under the error description. The `ErrorFallback` component renders the digest when present; an absent digest means `error.digest === undefined`, which Next.js only does when **the throw came from a client component**, not a Server Component render.

## Likely vector

`useLiveAnalysis` (mounted via `LiveAnalysisRefresher` at the bottom of `dashboard/page.tsx`) calls `createSupabaseBrowserClient()` inside a `useEffect`. That helper **throws** when `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` aren't bundled into the client JS — exactly the failure mode you'd get if a Vercel build ran before the Supabase ↔ Vercel integration finished syncing env vars to that deployment. The throw escapes the effect, React catches it in the nearest error boundary (`(app)/error.tsx`), and the user sees a dead-end UI for what should be a soft "no realtime updates" degrade.

I couldn't *prove* this is the exact cause — there's no client-side telemetry — but it's the most consistent fit, and the fixes below address every plausible variant.

## Four defenses (all in this PR)

### 1. `useLiveAnalysis` no longer throws

Wrap `createSupabaseBrowserClient()` in `try/catch`. On failure, `console.warn` and bail. The hook becomes a true side-effect: it adds realtime if it can, and is invisible if it can't. The dashboard never sees the throw.

### 2. Dashboard page uses `Promise.allSettled`

The page was calling `getCurrentProfile()` a *second* time (the layout already loaded it) inside a bare `Promise.all`. Any transient failure on that second call — expired cookie mid-request, Supabase auth blip — would throw into the workspace boundary instead of just rendering anonymous copy. Switch to `Promise.allSettled` and fall back to `null` profile + `EMPTY_WORKSPACE_OVERVIEW` on rejection, logging the cause via `logServerEvent` so future hits are debuggable from Vercel logs.

Required exporting `EMPTY_WORKSPACE_OVERVIEW` from `workspace-overview.ts` (was previously file-private).

### 3. Route-scoped `/dashboard/error.tsx`

Mirrors `/grows/[id]/error.tsx` from #175. Tailored copy + jump-out links to `/grows` and `/assistant` so a stuck dashboard never strands the user. Renders the digest when present, surfaces "this looked like a client-side hiccup, a refresh almost always fixes it" when absent.

### 4. `ErrorFallback` surfaces the no-digest case

Same hint added to the (app)-wide boundary so the user always gets actionable advice in either branch.

## Validation

- `pnpm run validate` (env, route boundaries, imports, code-scanning, file budgets, action pins, server-action exports) — **OK**
- `pnpm turbo run type-check lint test` — **730/730** (no test changes; existing dashboard tests still pass against the new `allSettled` flow because the happy-path resolution is unchanged)
- `pnpm run security:audit` would also pass; format is clean

Note: `pnpm run check:smoke-script` fails locally in my sandbox only because PowerShell isn't installed (the new smoke test spawns `pwsh`). CI runners have it.

## Test plan

- [ ] CI green
- [ ] Preview deploy: load `/dashboard` while signed in. Expect successful render (no boundary).
- [ ] Preview deploy: open browser devtools → Application → Local Storage → delete the Supabase auth cookie → navigate to `/dashboard`. Expect graceful redirect to `/auth` (layout boundary), not the workspace error UI.
- [ ] Preview deploy: in devtools console, run `throw new Error("test")` from inside `useEffect` of any dashboard child (or temporarily add one). Expect `/dashboard/error.tsx` to render its tailored copy with the "client-side hiccup" hint instead of the generic workspace error.
- [ ] Vercel runtime logs: search for `dashboard: profile reload failed` — should be absent in normal traffic. If it ever appears, the structured log carries enough detail (error message) to triage the underlying auth/Supabase issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_