### PR TITLE
fix(dashboard): add missing /plants escape hatch in error boundary

### DIFF
--- a/apps/web/src/app/(app)/dashboard/error.tsx
+++ b/apps/web/src/app/(app)/dashboard/error.tsx
@@ -51,6 +51,12 @@ export default function DashboardError({
           </Link>
           <Link
             className={buttonStyles({ size: "md", variant: "surface" })}
+            href="/plants"
+          >
+            Open plants
+          </Link>
+          <Link
+            className={buttonStyles({ size: "md", variant: "surface" })}
             href="/assistant"
           >
             Open copilot


### PR DESCRIPTION
Follow-up to #182 addressing Copilot's review comment on `/dashboard/error.tsx`:

> The copy says users can "jump straight to a grow, plant, or the copilot", but the actions provided only link to /grows and /assistant (no direct /plants link).

Adds an `Open plants` button next to the existing `Open grows` and `Open copilot` buttons. Now the three buttons match the sentence and cover the same set of surfaces the user would otherwise reach from the bottom-nav tabs.

## Validation

- `pnpm turbo run type-check lint` — OK
- One-file, six-line addition; no tests to update.

## Test plan

- [ ] CI green
- [ ] Preview deploy: visit `/dashboard` with a forced throw → expect three escape-hatch buttons (Open grows, Open plants, Open copilot) below the "Refresh dashboard" primary button.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_