### PR TITLE
feat(deploy): phase 1 deployment process hardening — auto-rollback, release tags, Discord alerts, SLO doc

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -2,7 +2,23 @@ name: Post-deploy smoke test
 
 # Runs scripts/smoke-test-prod.ps1 against production whenever a Vercel
 # deploy_status event marks the production environment as success.
+# On failure: auto-rollback to the previous production deployment via the
+# Vercel API, then open a tracking issue, then notify Discord.
 # Also runnable on demand against any URL.
+#
+# Required repository secrets:
+#   * VERCEL_TOKEN              — personal access token from Vercel
+#                                  Account Settings → Tokens (scope:
+#                                  full account or limited to the
+#                                  pheno-sage-web project).
+#   * VERCEL_PROJECT_ID         — `prj_XtNTJz3FT3PGokPxlyE3bm5XHp2V`
+#   * VERCEL_TEAM_ID            — `team_1jHeAEF8oKm2Z46fqRMdu5uL`
+#   * DISCORD_WEBHOOK_URL       — Discord channel webhook (any channel).
+#   * VERCEL_PROTECTION_BYPASS  — optional; see in-line comment below.
+#
+# Missing VERCEL_TOKEN or VERCEL_PROJECT_ID safely disables the rollback
+# step (smoke + issue + notification continue to work). Missing
+# DISCORD_WEBHOOK_URL safely disables the notification step.
 
 on:
   deployment_status:
@@ -49,6 +65,7 @@ jobs:
           echo "Smoke target: $URL"
 
       - name: Run smoke tests
+        id: smoke
         shell: pwsh
         env:
           # Optional: Vercel "Protection Bypass for Automation" token. When set,
@@ -59,6 +76,59 @@ jobs:
           VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
         run: pwsh scripts/smoke-test-prod.ps1 -Base "${{ steps.target.outputs.url }}"
 
+      # ─── Auto-rollback on smoke failure ──────────────────────────────────
+      # When the smoke step fails on a real deployment_status event, promote
+      # the most recent prior successful production deployment back into the
+      # alias. This collapses MTTR from "however long until you see the
+      # issue" to seconds. Manual workflow_dispatch runs are exempt because
+      # operators are already in the loop.
+      - name: Auto-rollback to previous production deploy
+        id: rollback
+        if: failure() && steps.smoke.conclusion == 'failure' && github.event_name == 'deployment_status'
+        shell: bash
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
+          BAD_SHA: ${{ github.event.deployment_status.deployment.sha }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_TOKEN:-}" ] || [ -z "${VERCEL_PROJECT_ID:-}" ]; then
+            echo "::warning::VERCEL_TOKEN or VERCEL_PROJECT_ID missing — auto-rollback skipped"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          TEAM_QS=""
+          if [ -n "${VERCEL_TEAM_ID:-}" ]; then
+            TEAM_QS="&teamId=${VERCEL_TEAM_ID}"
+          fi
+
+          # Find the most recent READY production deployment that is NOT
+          # the failing one. Vercel returns deployments newest-first, so
+          # we take the first match.
+          DEPS_URL="https://api.vercel.com/v6/deployments?projectId=${VERCEL_PROJECT_ID}&target=production&state=READY&limit=20${TEAM_QS}"
+          PAYLOAD=$(curl -fsS -H "Authorization: Bearer ${VERCEL_TOKEN}" "${DEPS_URL}")
+          PREV_ID=$(echo "$PAYLOAD" | jq -r --arg bad "$BAD_SHA" '
+            .deployments
+            | map(select(.meta.githubCommitSha != $bad))
+            | .[0].uid // empty
+          ')
+          if [ -z "$PREV_ID" ]; then
+            echo "::error::No previous READY production deployment found to roll back to"
+            exit 1
+          fi
+          echo "Rolling back to previous deployment: $PREV_ID"
+          echo "previous_id=$PREV_ID" >> "$GITHUB_OUTPUT"
+
+          # Promote = re-alias production to the previous deployment.
+          # Vercel's promote endpoint: POST /v10/projects/:projectId/promote/:deploymentId
+          PROMOTE_URL="https://api.vercel.com/v10/projects/${VERCEL_PROJECT_ID}/promote/${PREV_ID}?${TEAM_QS#&}"
+          curl -fsS -X POST -H "Authorization: Bearer ${VERCEL_TOKEN}" "${PROMOTE_URL}" || {
+            echo "::error::Promote API call failed"
+            exit 1
+          }
+          echo "::notice::Rolled back production alias to $PREV_ID"
+
       - name: Open issue on failure
         if: failure() && github.event_name == 'deployment_status'
         uses: actions/github-script@v9
@@ -67,6 +137,10 @@ jobs:
             const url = "${{ steps.target.outputs.url }}";
             const sha = context.payload.deployment.sha || context.sha;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const rolledBackTo = `${{ steps.rollback.outputs.previous_id || '' }}`;
+            const rollbackLine = rolledBackTo
+              ? `**Auto-rollback:** production alias promoted back to \`${rolledBackTo}\` — users are no longer on the bad deploy.`
+              : `**Auto-rollback:** skipped (missing VERCEL_TOKEN / VERCEL_PROJECT_ID, or no previous deployment found). Roll back manually per docs/runbooks/rollback.md.`;
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -76,7 +150,84 @@ jobs:
                 `**Target URL:** ${url}`,
                 `**Workflow run:** ${runUrl}`,
                 "",
-                "Investigate and either roll back the deployment or fix forward."
+                rollbackLine,
+                "",
+                "**Next steps:**",
+                "1. Confirm the alias is now serving the previous deploy (`curl /api/health`).",
+                "2. Investigate the failing smoke step in the workflow logs.",
+                "3. Fix forward in a new PR — never re-promote the broken deploy.",
               ].join("\n"),
               labels: ["bug", "production", "smoke-test"]
             });
+
+      # ─── Discord notifications ───────────────────────────────────────────
+      # Fires on both success (so you have a heartbeat that prod deploys
+      # actually went green) and failure (so an outage hits your phone, not
+      # an email digest). Skipped silently when the secret isn't set.
+      - name: Notify Discord — success
+        if: success() && github.event_name == 'deployment_status'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "::notice::DISCORD_WEBHOOK_URL not set — notification skipped"
+            exit 0
+          fi
+          SHA="${{ github.event.deployment_status.deployment.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          URL="${{ steps.target.outputs.url }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          curl -fsS -H "Content-Type: application/json" -X POST -d @- "${DISCORD_WEBHOOK_URL}" <<JSON
+          {
+            "username": "PhenoSage Deploy",
+            "embeds": [{
+              "title": "✅ Production smoke passed",
+              "url": "${URL}",
+              "color": 5763719,
+              "fields": [
+                { "name": "Commit", "value": "\`${SHORT_SHA}\`", "inline": true },
+                { "name": "Target", "value": "${URL}", "inline": true }
+              ],
+              "footer": { "text": "Workflow run" },
+              "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            }]
+          }
+          JSON
+
+      - name: Notify Discord — failure
+        if: failure() && github.event_name == 'deployment_status'
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        shell: bash
+        run: |
+          if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
+            echo "::notice::DISCORD_WEBHOOK_URL not set — notification skipped"
+            exit 0
+          fi
+          SHA="${{ github.event.deployment_status.deployment.sha }}"
+          SHORT_SHA="${SHA:0:7}"
+          URL="${{ steps.target.outputs.url }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ROLLED_BACK="${{ steps.rollback.outputs.previous_id }}"
+          ROLLBACK_LINE="Auto-rollback skipped or unavailable."
+          if [ -n "$ROLLED_BACK" ]; then
+            ROLLBACK_LINE="Auto-rollback fired → production now serving \`${ROLLED_BACK:0:12}\`."
+          fi
+          curl -fsS -H "Content-Type: application/json" -X POST -d @- "${DISCORD_WEBHOOK_URL}" <<JSON
+          {
+            "username": "PhenoSage Deploy",
+            "embeds": [{
+              "title": "🚨 Production smoke FAILED",
+              "url": "${RUN_URL}",
+              "color": 15548997,
+              "description": "${ROLLBACK_LINE}",
+              "fields": [
+                { "name": "Bad commit", "value": "\`${SHORT_SHA}\`", "inline": true },
+                { "name": "Target", "value": "${URL}", "inline": true }
+              ],
+              "footer": { "text": "Click title to open the failing workflow run" },
+              "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            }]
+          }
+          JSON

--- a/.github/workflows/release-on-prod-deploy.yml
+++ b/.github/workflows/release-on-prod-deploy.yml
@@ -19,8 +19,14 @@ on:
 permissions:
   contents: write
 
+# Singleton concurrency group across all production deploys so the
+# "find latest tag + compute next -N suffix + push tag" sequence runs
+# atomically. A per-SHA group would let two same-day deploys race on
+# tag computation and one would fail to push (or worse, both would
+# pick the same vYYYY.MM.DD-N). cancel-in-progress: false so a fast
+# second deploy can't skip its own release entry.
 concurrency:
-  group: release-tag-${{ github.event.deployment_status.deployment.sha }}
+  group: release-tag-production
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-on-prod-deploy.yml
+++ b/.github/workflows/release-on-prod-deploy.yml
@@ -1,0 +1,104 @@
+name: Release tag on production deploy
+
+# Auto-creates a date-based release tag (e.g. v2026.05.16-1) and a
+# GitHub Release page on every successful Vercel production deploy.
+# The release notes are auto-generated from PRs merged since the
+# previous tag, giving you a fast answer to "what's in prod right now?"
+# and "what changed since the last good deploy?".
+#
+# Why date-based instead of semver? Semver implies a contract about
+# breaking changes that solo apps shipping continuously don't really
+# have. Date.run pinpoints any tag to a specific deploy in seconds
+# without manual version-bump discipline.
+#
+# Required: GITHUB_TOKEN (provided automatically). No secrets needed.
+
+on:
+  deployment_status:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-tag-${{ github.event.deployment_status.deployment.sha }}
+  cancel-in-progress: false
+
+jobs:
+  tag-and-release:
+    name: Tag + release
+    runs-on: ubuntu-latest
+    if: |
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment_status.environment == 'Production'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so we can compute "changed since last tag".
+          fetch-depth: 0
+
+      - name: Compute next tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y.%m.%d)
+          PREFIX="v${DATE}"
+          # Find the highest -N suffix already used today, increment.
+          LAST_N=$(git tag -l "${PREFIX}-*" \
+            | awk -F- '{print $NF}' \
+            | sort -n \
+            | tail -1)
+          if [ -z "$LAST_N" ]; then
+            NEXT_N=1
+          else
+            NEXT_N=$((LAST_N + 1))
+          fi
+          TAG="${PREFIX}-${NEXT_N}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Computed next tag: ${TAG}"
+
+      - name: Find previous tag (for release notes)
+        id: prev
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Most recent existing tag, ignoring lightweight refs created
+          # in this run. Empty string is fine — release notes will fall
+          # back to "all commits".
+          PREV=$(git tag -l 'v*' --sort=-creatordate | head -1 || true)
+          echo "prev=${PREV}" >> "$GITHUB_OUTPUT"
+          echo "Previous tag: ${PREV:-<none>}"
+
+      - name: Create tag at deployed SHA
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          SHA: ${{ github.event.deployment_status.deployment.sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" "${SHA}" -m "Production deploy ${TAG}"
+          git push origin "${TAG}"
+
+      - name: Create GitHub Release with auto-generated notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          PREV: ${{ steps.prev.outputs.prev }}
+        run: |
+          set -euo pipefail
+          # Use GitHub's auto-generated release notes endpoint. When PREV
+          # is empty, GitHub will pick the previous tag chronologically.
+          if [ -n "$PREV" ]; then
+            gh release create "$TAG" \
+              --target "${{ github.event.deployment_status.deployment.sha }}" \
+              --title "$TAG" \
+              --generate-notes \
+              --notes-start-tag "$PREV"
+          else
+            gh release create "$TAG" \
+              --target "${{ github.event.deployment_status.deployment.sha }}" \
+              --title "$TAG" \
+              --generate-notes
+          fi
+          echo "::notice::Created release $TAG"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -375,8 +375,9 @@ following workflows then fire automatically:
 | `DISCORD_WEBHOOK_URL`      | Channel webhook for ✅ / 🚨 deploy alerts.                      | Discord channel → Edit Channel → Integrations → Webhooks → Copy URL                                 |
 | `VERCEL_PROTECTION_BYPASS` | Optional — lets smoke reach pages behind Deployment Protection. | Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation → Add        |
 
-All five are safe to leave unset — the workflows degrade gracefully
-(skip the step + log a warning) instead of failing the deploy.
+All five listed secrets, including `VERCEL_PROTECTION_BYPASS`, are safe
+to leave unset — any workflow that depends on one will skip that step and
+log a warning instead of failing the deploy.
 
 ### Enabling Vercel Rolling Releases
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -349,6 +349,55 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push/PR:
 - **Analysis**: ruff lint, mypy type-check, pytest
 - **Shared**: type-check
 
+## Production deploy lifecycle
+
+Every push to `main` triggers Vercel to build and deploy production. The
+following workflows then fire automatically:
+
+1. **`post-deploy-smoke.yml`** — runs `scripts/smoke-test-prod.ps1`
+   against the new deployment. On failure it:
+   - Auto-rolls-back to the previous successful production deploy via
+     Vercel's promote API (requires `VERCEL_TOKEN` +
+     `VERCEL_PROJECT_ID` secrets).
+   - Opens a GitHub issue with the bad SHA + rollback receipt.
+   - Posts to Discord (requires `DISCORD_WEBHOOK_URL` secret).
+2. **`release-on-prod-deploy.yml`** — tags the deployed SHA as
+   `vYYYY.MM.DD-N` and creates a GitHub Release with auto-generated
+   notes (PRs merged since the previous tag).
+
+### Required GitHub secrets
+
+| Secret                     | Purpose                                                         | How to get it                                                                                       |
+| -------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `VERCEL_TOKEN`             | Auto-rollback can call the promote API.                         | Vercel → Account Settings → Tokens → Create (full scope, or scoped to the `pheno-sage-web` project) |
+| `VERCEL_PROJECT_ID`        | Identifies the project for the promote call.                    | `prj_XtNTJz3FT3PGokPxlyE3bm5XHp2V` (visible in any deployment metadata)                             |
+| `VERCEL_TEAM_ID`           | Team scope for the promote call.                                | `team_1jHeAEF8oKm2Z46fqRMdu5uL`                                                                     |
+| `DISCORD_WEBHOOK_URL`      | Channel webhook for ✅ / 🚨 deploy alerts.                      | Discord channel → Edit Channel → Integrations → Webhooks → Copy URL                                 |
+| `VERCEL_PROTECTION_BYPASS` | Optional — lets smoke reach pages behind Deployment Protection. | Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation → Add        |
+
+All four are safe to leave unset — the workflows degrade gracefully
+(skip the step + log a warning) instead of failing the deploy.
+
+### Enabling Vercel Rolling Releases
+
+Rolling Releases gradually shift traffic from the previous production
+deploy to the new one (e.g. 5% → 25% → 100%) instead of cutting over
+instantly. A bad deploy then affects only the canary cohort, and you
+can use Vercel's built-in **Instant Rollback** to revert before more
+users hit it.
+
+To enable:
+
+1. Vercel → `pheno-sage-web` → Settings → Rolling Releases → Enable.
+2. Start with a single stage: **5% canary for 10 min, then 100%**.
+3. Over time, layer Speed Insights / Sentry comparisons into the
+   promotion gate (see `docs/runbooks/slo.md` for the SLO numbers
+   that should drive auto-promote vs auto-rollback decisions).
+
+Docs: https://vercel.com/docs/rolling-releases · https://vercel.com/docs/instant-rollback
+
+## Pre-deploy readiness
+
 Preview and production deploys should be considered ready only after `/api/ready` on the web app and `/ready` on the analysis service both return healthy responses with the expected request IDs in headers.
 
 Run the repo-level readiness check before the authenticated smoke so missing

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -375,7 +375,7 @@ following workflows then fire automatically:
 | `DISCORD_WEBHOOK_URL`      | Channel webhook for ✅ / 🚨 deploy alerts.                      | Discord channel → Edit Channel → Integrations → Webhooks → Copy URL                                 |
 | `VERCEL_PROTECTION_BYPASS` | Optional — lets smoke reach pages behind Deployment Protection. | Vercel → Project → Settings → Deployment Protection → Protection Bypass for Automation → Add        |
 
-All four are safe to leave unset — the workflows degrade gracefully
+All five are safe to leave unset — the workflows degrade gracefully
 (skip the step + log a warning) instead of failing the deploy.
 
 ### Enabling Vercel Rolling Releases

--- a/docs/runbooks/slo.md
+++ b/docs/runbooks/slo.md
@@ -52,9 +52,17 @@ A request is an "error" if:
 - A client component throws during hydration, caught by the same
   boundaries (these don't carry a server-side digest — see PR #182).
 
-Measured via Vercel runtime logs + Sentry (when configured). A bad
-deploy that immediately spikes errors past 1% should auto-rollback —
-see `post-deploy-smoke.yml`.
+Measured via Vercel runtime logs + Sentry (when configured).
+
+> **Today:** there is no automated error-rate gate. `post-deploy-smoke.yml`
+> checks endpoint health, headers, and secret-leak patterns — not error
+> volume. If a bad deploy doesn't break those checks but quietly spikes
+> client- or server-side throws, you'll see it via Sentry / Vercel logs
+> rather than auto-rollback.
+>
+> **Phase 2 follow-up:** wire an error-rate probe (Vercel runtime-log
+> count or Sentry release-comparison) into the smoke step so a deploy
+> that immediately crosses 1% errors triggers the same rollback path.
 
 ## Deploy reliability — `change failure rate < 15%`
 

--- a/docs/runbooks/slo.md
+++ b/docs/runbooks/slo.md
@@ -17,8 +17,13 @@ across:
 
 - `GET /` — landing page renders 200 (public).
 - `GET /api/health` — returns 200 with `{ status: "ok" }`.
-- `GET /api/ready` — returns 200 with `status: "ok"` (deeper check
-  that Supabase, the analysis service, and required env are reachable).
+- `GET /api/ready` — returns 200 with `status: "ok"` when the
+  required backend env vars (`NEXT_PUBLIC_SUPABASE_URL`,
+  `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `ANALYSIS_SERVICE_URL`,
+  `ANALYSIS_SERVICE_API_KEY`) are present; `status: "not_ready"` with
+  HTTP 503 if any are missing. Note: this is a config-presence check,
+  not an upstream reachability probe — Supabase / analysis-service
+  availability is tracked separately (see §"What we don't promise").
 
 A request that completes with a 4xx that the user _caused_ (e.g. 401
 because they're logged out) does not count against availability. A 5xx

--- a/docs/runbooks/slo.md
+++ b/docs/runbooks/slo.md
@@ -1,0 +1,105 @@
+# Service Level Objectives — PhenoSage
+
+The numbers below define what "healthy" means in production. They exist
+so post-deploy smoke can fail / auto-rollback on an objective threshold
+instead of vibes, and so on-call has a clear bar for "is this an
+incident?".
+
+> Solo-maintainer reality check: SLOs aren't there to punish missed
+> targets. They're a forcing function for asking "did this deploy make
+> things worse?" and a tripwire for catching slow regressions before
+> users do.
+
+## Availability — `99.5%` monthly
+
+The browser must be able to load the dashboard and act on it. Measured
+across:
+
+- `GET /` — landing page renders 200 (public).
+- `GET /api/health` — returns 200 with `{ status: "ok" }`.
+- `GET /api/ready` — returns 200 with `status: "ready"` (deeper check
+  that Supabase, the analysis service, and required env are reachable).
+
+A request that completes with a 4xx that the user _caused_ (e.g. 401
+because they're logged out) does not count against availability. A 5xx
+or a timeout does.
+
+99.5% over 30 days = budget of **~3h 36m** of unavailability per month.
+If that budget is exhausted, the next deploy goes through a heavier
+pre-merge gate (manual approval + explicit "I read the failing-deploy
+post-mortem" checkbox).
+
+## Latency — `p95 < 1.2s` server response
+
+Measured via Vercel Speed Insights on the production deployment.
+Server response time only (TTFB), not full page load, since asset
+delivery is dominated by the CDN.
+
+If the p95 server response time for `/dashboard`, `/grows`, or
+`/grows/[id]` rises above 1.2 s over a 24h window, treat it as a
+latency regression — open an issue and bisect.
+
+Mobile users on 5G should not experience > 2.5s LCP on any (app)
+surface. This is the Core Web Vitals "good" threshold per Google.
+
+## Error rate — `< 1%` of authenticated requests
+
+A request is an "error" if:
+
+- The server returns 5xx.
+- A Server Component throws, surfacing as `(app)/error.tsx` or a
+  route-specific boundary.
+- A client component throws during hydration, caught by the same
+  boundaries (these don't carry a server-side digest — see PR #182).
+
+Measured via Vercel runtime logs + Sentry (when configured). A bad
+deploy that immediately spikes errors past 1% should auto-rollback —
+see `post-deploy-smoke.yml`.
+
+## Deploy reliability — `change failure rate < 15%`
+
+> A failed deployment is one where the production smoke step fails or
+> a hotfix has to ship within 6 hours of the deploy.
+
+DORA categorises 0-15% CFR as **elite** for small teams. This is the
+metric to push down over time. The `track-followups.yml` workflow can
+post the rolling 30-day number to a CHANGELOG block weekly once Phase 2
+ships.
+
+## Recovery — `< 15 min` MTTR for SEV-1 / SEV-2
+
+If `/api/health` is failing or auth is broken, the rollback path
+should be under 15 minutes from "I'm aware" to "production is healthy
+again". With the auto-rollback step in `post-deploy-smoke.yml`, the
+common case is now sub-minute — the long pole is the operator noticing
+the Discord alert.
+
+See `docs/runbooks/rollback.md` for the manual procedure when
+auto-rollback didn't fire.
+
+## What we don't promise
+
+- **Realtime updates have no SLO.** The `useLiveAnalysis` hook fails
+  open — if Supabase Realtime is unreachable, the dashboard still
+  renders but no longer auto-refreshes. The user can refresh manually.
+- **Daily summary cron has no SLO.** If the cron misses a day, the
+  user notices the missing email but no other surface degrades. This
+  is intentional — we don't page anyone over a missed digest.
+- **Analysis service availability is decoupled.** The web app stays up
+  even if Railway is down; analysis requests degrade per the Sentry
+  hooks in `analysis-proxy.ts`. SEV-2 not SEV-1.
+
+## Where to look
+
+- Vercel Speed Insights (latency, error rate).
+- Vercel runtime logs (error counts per route).
+- Supabase project metrics (RLS denials, slow queries).
+- Sentry (client + server exceptions, once the DSN is set).
+- `docs/runbooks/on-call.md` for daily 60-second check.
+
+## Changing these numbers
+
+SLO changes require a PR. Don't tune them down to make the dashboard
+look green — that defeats the point. If a target is consistently
+missed, fix the underlying issue or document why the target was wrong
+in the first place.

--- a/docs/runbooks/slo.md
+++ b/docs/runbooks/slo.md
@@ -17,7 +17,7 @@ across:
 
 - `GET /` — landing page renders 200 (public).
 - `GET /api/health` — returns 200 with `{ status: "ok" }`.
-- `GET /api/ready` — returns 200 with `status: "ready"` (deeper check
+- `GET /api/ready` — returns 200 with `status: "ok"` (deeper check
   that Supabase, the analysis service, and required env are reachable).
 
 A request that completes with a 4xx that the user _caused_ (e.g. 401


### PR DESCRIPTION
Phase 1 of the deployment-process hardening plan we just scoped. Five complementary changes, all workflow YAML + docs — zero runtime code touched.

## What's in this PR

### 1. Auto-rollback on smoke failure
`post-deploy-smoke.yml` now reacts to a failed production smoke by calling Vercel's promote API:

```
POST /v10/projects/${VERCEL_PROJECT_ID}/promote/${PREVIOUS_DEPLOYMENT_ID}
```

The previous deployment is the most recent `state=READY` production deploy *other than* the failing one. The flow becomes: smoke fails → rollback → open issue (with rollback receipt) → notify Discord. **MTTR drops from "human notices the issue" to seconds.**

Manual `workflow_dispatch` runs skip the rollback (operator is already in the loop). Missing `VERCEL_TOKEN` / `VERCEL_PROJECT_ID` degrades to today's behaviour (issue + notification only).

### 2. Discord deploy notifications
Rich embeds posted to a Discord webhook on both ✅ success (heartbeat that prod deploys actually went green) and 🚨 failure (with the rollback receipt). Wired through a `DISCORD_WEBHOOK_URL` secret; skipped silently when unset.

### 3. Auto-tag + GitHub Release on every prod deploy
New `release-on-prod-deploy.yml`:
- Tags the deployed SHA as `vYYYY.MM.DD-N` (date-based — semver implies a contract continuous-deploy apps don't really have).
- Pushes the tag.
- Creates a GitHub Release with auto-generated notes covering PRs merged since the previous tag.

Answers two questions in one click: *what version is in prod right now?* and *what changed since the last good deploy?*

### 4. SLO definition
New `docs/runbooks/slo.md` with concrete numbers:
- **Availability:** 99.5%/mo (= ~3h 36m budget)
- **Latency:** p95 < 1.2s server, < 2.5s LCP mobile
- **Error rate:** < 1% of authenticated requests
- **Deploy reliability:** CFR < 15% (DORA elite for small teams)
- **Recovery:** MTTR < 15 min for SEV-1/2

Plus an explicit "what we don't promise" list (realtime updates, daily-summary cron, analysis-service availability) so SEV grading isn't vibes.

### 5. Deployment guide expansion
`docs/deployment.md` gets a new **Production deploy lifecycle** section, a **Required GitHub secrets** table (with the actual project + team IDs visible so you can wire the secrets directly), and a walkthrough for enabling **Vercel Rolling Releases**.

## Required GitHub secrets (you wire these once)

| Secret | What for | Where to get it |
|---|---|---|
| `VERCEL_TOKEN` | Auto-rollback | Vercel → Account Settings → Tokens |
| `VERCEL_PROJECT_ID` | Auto-rollback | `prj_XtNTJz3FT3PGokPxlyE3bm5XHp2V` |
| `VERCEL_TEAM_ID` | Auto-rollback | `team_1jHeAEF8oKm2Z46fqRMdu5uL` |
| `DISCORD_WEBHOOK_URL` | Notifications | Discord channel → Integrations → Webhooks |

All four are safe to leave unset — the workflows degrade gracefully.

## Validation

- `pnpm run validate` — **OK** across all 7 guardrails
- No runtime code changed; CI for type-check/lint/test will replay against the existing main + new workflow files
- `pnpm run format:check` — clean for tracked files

## Test plan

- [ ] CI green
- [ ] Add the four GitHub secrets (or any subset — workflows skip gracefully)
- [ ] Enable Vercel Rolling Releases in the dashboard (5% canary for 10 min → 100% is the recommended starting profile)
- [ ] On the next merge to main, watch the Discord channel — expect ✅ within a few minutes of the Vercel deploy
- [ ] Optional: deliberately break a smoke check on a non-prod branch + run `workflow_dispatch` to confirm the issue-opening path (rollback won't fire on dispatch runs — by design)

## What's deliberately deferred (Phase 2 items)

- `/internal/status` consolidated dashboard
- Vercel Flags integration scaffold
- Sentry verification
- DORA-metrics-to-CHANGELOG automation
- Pre-deploy checklist gate as a required status check

Each of those wants its own focused PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_