### PR TITLE
fix(deploy): correct deployment_status SHA path (P1 follow-up to #184)

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -90,7 +90,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           VERCEL_TEAM_ID: ${{ secrets.VERCEL_TEAM_ID }}
-          BAD_SHA: ${{ github.event.deployment_status.deployment.sha }}
+          BAD_SHA: ${{ github.event.deployment.sha }}
         run: |
           set -euo pipefail
           if [ -z "${VERCEL_TOKEN:-}" ] || [ -z "${VERCEL_PROJECT_ID:-}" ]; then
@@ -174,7 +174,7 @@ jobs:
             echo "::notice::DISCORD_WEBHOOK_URL not set — notification skipped"
             exit 0
           fi
-          SHA="${{ github.event.deployment_status.deployment.sha }}"
+          SHA="${{ github.event.deployment.sha }}"
           SHORT_SHA="${SHA:0:7}"
           URL="${{ steps.target.outputs.url }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
@@ -205,7 +205,7 @@ jobs:
             echo "::notice::DISCORD_WEBHOOK_URL not set — notification skipped"
             exit 0
           fi
-          SHA="${{ github.event.deployment_status.deployment.sha }}"
+          SHA="${{ github.event.deployment.sha }}"
           SHORT_SHA="${SHA:0:7}"
           URL="${{ steps.target.outputs.url }}"
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/release-on-prod-deploy.yml
+++ b/.github/workflows/release-on-prod-deploy.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Create tag at deployed SHA
         env:
           TAG: ${{ steps.tag.outputs.tag }}
-          SHA: ${{ github.event.deployment_status.deployment.sha }}
+          SHA: ${{ github.event.deployment.sha }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"
@@ -97,13 +97,13 @@ jobs:
           # is empty, GitHub will pick the previous tag chronologically.
           if [ -n "$PREV" ]; then
             gh release create "$TAG" \
-              --target "${{ github.event.deployment_status.deployment.sha }}" \
+              --target "${{ github.event.deployment.sha }}" \
               --title "$TAG" \
               --generate-notes \
               --notes-start-tag "$PREV"
           else
             gh release create "$TAG" \
-              --target "${{ github.event.deployment_status.deployment.sha }}" \
+              --target "${{ github.event.deployment.sha }}" \
               --title "$TAG" \
               --generate-notes
           fi


### PR DESCRIPTION
**Fix-forward for #184.** Codex review on the merged commit caught a P1 I missed before merge: the new bash + env steps I added were reading the SHA from `github.event.deployment_status.deployment.sha`, but on `deployment_status` events the SHA lives at `github.event.deployment.sha` (top-level `deployment` object). The wrong path resolves to empty string at runtime.

## Impact of the bug live on main right now

1. **Auto-rollback could no-op or hit the wrong target.** `BAD_SHA=""` so the rollback filter `select(.meta.githubCommitSha != "")` does not exclude the failing deploy — the API can return the bad deploy itself as PREV_ID and the "rollback" re-promotes the broken release. Issue + Discord text would still claim recovery happened.

2. **Release tag creation fails 100%.** `git tag -a "${TAG}" ""` is an invalid ref; no production deploy lands a tag or GitHub Release. The feature has been dark since #184 merged.

3. **Discord alerts have blank "Commit" / "Bad commit" fields.** Operational triage signal lost exactly when alerts matter most.

## Fix

`sed`-replace all 6 occurrences across `.github/workflows/post-deploy-smoke.yml` + `.github/workflows/release-on-prod-deploy.yml`. Verified via grep that the new paths now match the (correct) original JavaScript path `context.payload.deployment.sha` already present in the "Open issue on failure" step at line 138 of `post-deploy-smoke.yml` — proving the bug was isolated to my new bash/env additions.

Reference: [GitHub webhook payload for `deployment_status`](https://docs.github.com/en/webhooks/webhook-events-and-payloads#deployment_status) — the deployment_status event payload contains the deployment status object plus the full `deployment` object that received the status.

## Test plan

- [ ] CI green
- [ ] On the next push to main, watch the release-on-prod-deploy workflow — expect a `vYYYY.MM.DD-N` tag to actually land this time
- [ ] If a smoke failure ever fires, confirm the issue body shows the real SHA + the rollback receipt references a *different* deployment ID than the bad one
- [ ] Discord webhook (if you've wired the secret) shows the short SHA in the embed


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6LC7SaoYApuxgDrX8cS64)_