### PR TITLE
fix(validate): skip pwsh smoke-script test when PowerShell is missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,10 @@ pwsh scripts/smoke-test-prod.ps1
 ```
 
 It exits non-zero if any endpoint, security header, or secret-leak check fails.
+PowerShell Core (`pwsh`) is preinstalled on GitHub-hosted runners. On a Linux
+or macOS dev machine without it, `pnpm run validate` will skip the
+`check:smoke-script` step with a clear reason rather than failing — install
+`pwsh` (e.g., `brew install --cask powershell`) to exercise it locally.
 
 For the authenticated persisted-flow smoke, run the Playwright suite with the
 Supabase service role available to the test runner:

--- a/scripts/__tests__/smoke-test-prod.test.mjs
+++ b/scripts/__tests__/smoke-test-prod.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { test } from "node:test";
@@ -10,6 +10,24 @@ const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "../..",
 );
+
+// PowerShell Core is preinstalled on GitHub-hosted runners but not on most
+// Linux/macOS dev machines or sandboxes. Skip rather than fail so a fresh
+// checkout can run `pnpm run validate` without an extra dependency.
+function pwshAvailable() {
+  try {
+    const r = spawnSync("pwsh", ["-NoLogo", "-Command", "exit 0"], {
+      stdio: "ignore",
+    });
+    return r.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+const skipReason = pwshAvailable()
+  ? false
+  : "pwsh (PowerShell Core) not on PATH — install it to exercise scripts/smoke-test-prod.ps1";
 
 function runSmoke(baseUrl) {
   return new Promise((resolve, reject) => {
@@ -57,64 +75,72 @@ function writeRoot(res) {
   res.end("<!doctype html><title>PhenoSage</title>");
 }
 
-test("production smoke treats expected protected-page redirects as passing", async () => {
-  await withServer(
-    (req, res) => {
-      const url = new URL(req.url ?? "/", "http://127.0.0.1");
-      if (["/", "/auth", "/assistant"].includes(url.pathname)) {
-        writeRoot(res);
-        return;
-      }
-      if (["/dashboard", "/grows", "/settings"].includes(url.pathname)) {
-        res.writeHead(307, { Location: "/auth" });
-        res.end();
-        return;
-      }
-      if (url.pathname === "/api/health") {
-        res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ status: "ok" }));
-        return;
-      }
-      if (
-        [
-          "/api/chat",
-          "/api/uploads/sign",
-          "/api/plants/abc/timeline",
-          "/api/plants/abc/analysis/latest",
-          "/api/internal/cron/daily-summary",
-        ].includes(url.pathname)
-      ) {
-        res.writeHead(401, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "unauthorized" }));
-        return;
-      }
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "not_found" }));
-    },
-    async (baseUrl) => {
-      const result = await runSmoke(baseUrl);
-      assert.equal(result.code, 0, result.stdout + result.stderr);
-      assert.match(result.stdout, /PASSED/);
-      assert.doesNotMatch(result.stdout + result.stderr, /\bERR\b/);
-    },
-  );
-});
+test(
+  "production smoke treats expected protected-page redirects as passing",
+  { skip: skipReason },
+  async () => {
+    await withServer(
+      (req, res) => {
+        const url = new URL(req.url ?? "/", "http://127.0.0.1");
+        if (["/", "/auth", "/assistant"].includes(url.pathname)) {
+          writeRoot(res);
+          return;
+        }
+        if (["/dashboard", "/grows", "/settings"].includes(url.pathname)) {
+          res.writeHead(307, { Location: "/auth" });
+          res.end();
+          return;
+        }
+        if (url.pathname === "/api/health") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ status: "ok" }));
+          return;
+        }
+        if (
+          [
+            "/api/chat",
+            "/api/uploads/sign",
+            "/api/plants/abc/timeline",
+            "/api/plants/abc/analysis/latest",
+            "/api/internal/cron/daily-summary",
+          ].includes(url.pathname)
+        ) {
+          res.writeHead(401, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "unauthorized" }));
+          return;
+        }
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "not_found" }));
+      },
+      async (baseUrl) => {
+        const result = await runSmoke(baseUrl);
+        assert.equal(result.code, 0, result.stdout + result.stderr);
+        assert.match(result.stdout, /PASSED/);
+        assert.doesNotMatch(result.stdout + result.stderr, /\bERR\b/);
+      },
+    );
+  },
+);
 
-test("production smoke reports transport errors without null-header noise", async () => {
-  const server = createServer();
-  server.listen(0, "127.0.0.1");
-  await once(server, "listening");
-  const { port } = server.address();
-  server.close();
-  await once(server, "close");
+test(
+  "production smoke reports transport errors without null-header noise",
+  { skip: skipReason },
+  async () => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address();
+    server.close();
+    await once(server, "close");
 
-  const result = await runSmoke(`http://127.0.0.1:${port}`);
+    const result = await runSmoke(`http://127.0.0.1:${port}`);
 
-  assert.equal(result.code, 1);
-  assert.match(result.stdout, /FAILED/);
-  assert.match(result.stdout, /Unable to fetch root/);
-  assert.doesNotMatch(
-    result.stdout + result.stderr,
-    /Cannot index into a null array/,
-  );
-});
+    assert.equal(result.code, 1);
+    assert.match(result.stdout, /FAILED/);
+    assert.match(result.stdout, /Unable to fetch root/);
+    assert.doesNotMatch(
+      result.stdout + result.stderr,
+      /Cannot index into a null array/,
+    );
+  },
+);


### PR DESCRIPTION
## Summary

`pnpm run validate` was failing at `check:smoke-script` on every Linux/macOS environment without PowerShell Core, surfacing as `spawn pwsh ENOENT`. The WORKLOG documents multiple recent agent sessions blocked by this exact symptom; it is the only failure that reproduces from a clean install (`pnpm install --frozen-lockfile`) in a fresh container — type-check, lint, web tests (730/730), shared tests (7/7), analysis tests (103/103), and the web build all pass.

## Fix

- `scripts/__tests__/smoke-test-prod.test.mjs`: probe for `pwsh` once at load time, then pass `{ skip: reason }` to both `node:test` cases so they report as SKIP with an actionable reason instead of failing.
- `CONTRIBUTING.md`: document that PowerShell is preinstalled in CI but optional locally, and how to install it.

CI on `ubuntu-latest` is unaffected — PowerShell Core is preinstalled on GitHub-hosted runners, so the smoke harness still actually runs there.

## Test plan

- [x] `pnpm run validate` — green locally without `pwsh` (tests report SKIP)
- [x] `pnpm turbo run type-check lint test --filter=web` — green (730/730)
- [x] `pnpm turbo run type-check lint test --filter=@phenosage/shared` — green (7/7)
- [x] `python3 -m pytest` in `apps/analysis` — 103/103
- [x] `pnpm turbo run build --filter=web` — green
- [ ] CI on `ubuntu-latest` still executes the PowerShell smoke harness (pwsh present)

https://claude.ai/code/session_01ULFdLaaDnZAqkz2PiQqovg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULFdLaaDnZAqkz2PiQqovg)_