### PR TITLE
perf(web): Next standalone output + slim Dockerfile.web runner

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -26,9 +26,20 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
     READINESS_PROBE_SECRET=$READINESS_PROBE_SECRET
 RUN pnpm --filter web build
 
-FROM base AS runner
+# Runner ships only the Next.js standalone trace (server.js + the traced
+# subset of node_modules) plus static + public assets the standalone
+# entrypoint doesn't bundle. Drops the image from ~900 MB (full pnpm
+# install of the workspace) to ~60 MB. No pnpm in the runner.
+FROM node:20-alpine AS runner
+WORKDIR /app
 ENV NODE_ENV=production \
-    PORT=3000
-COPY --from=build /app /app
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+RUN addgroup --system --gid 1001 nodejs \
+  && adduser --system --uid 1001 --ingroup nodejs nextjs
+COPY --from=build --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+COPY --from=build --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=build --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+USER nextjs
 EXPOSE 3000
-CMD ["pnpm", "--filter", "web", "start"]
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -9,6 +9,11 @@
  *  - Referrer + Permissions Policy restricting sensors
  */
 
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 function parseOrigin(value) {
   if (!value) return null;
   try {
@@ -44,6 +49,15 @@ function buildCSP() {
 const nextConfig = {
   reactStrictMode: true,
   poweredByHeader: false,
+  // Emit a self-contained server tree under `.next/standalone` so non-Vercel
+  // deploys (Docker / Railway) ship only the files Next's tracer determined
+  // are reachable instead of the full pnpm workspace node_modules. Vercel
+  // ignores this and bundles via its own tracer, so this is a no-op there.
+  // `outputFileTracingRoot` is required in a pnpm workspace so the tracer
+  // walks up out of `apps/web` and follows the workspace:* symlinks into
+  // `packages/shared`.
+  output: "standalone",
+  outputFileTracingRoot: path.join(__dirname, "../.."),
   serverExternalPackages: [],
   images: {
     remotePatterns: [


### PR DESCRIPTION
## Summary

Two paired optimizations that drop the deployed web runtime image dramatically with **no Vercel impact** (Vercel ignores `output` and traces functions itself):

1. **`apps/web/next.config.mjs`** — set `output: "standalone"` so Next emits a self-contained server tree at `.next/standalone/` containing only the files the tracer determined are reachable. Added `outputFileTracingRoot` pointed at the monorepo root so the tracer follows the pnpm workspace symlink into `packages/shared`.
2. **`Dockerfile.web`** — replace the runner stage. Previously it copied the entire `/app` tree (full pnpm install of the workspace, ~917 MB) and ran `pnpm --filter web start`. Now it copies only `apps/web/.next/standalone` + `apps/web/.next/static` + `apps/web/public` into a fresh `node:20-alpine`, runs as a dedicated `nextjs` user, and starts with `node apps/web/server.js`.

## Size impact (measured locally)

| | Before | After |
|---|---|---|
| Runner image source (`/app`) | **917 MB** (full pnpm install) | **~60 MB** (standalone + static + public) |
| Runtime: pnpm in image | yes | no |
| Runtime: user | implicit root | `nextjs:nodejs` (uid 1001) |

This is a ~15× reduction in runner-image content. The win flows to:
- CI `Containers — Build + SBOM` job (faster build + smaller SBOM)
- docker-compose smoke stack
- Future Railway / self-host deploys

## Verification

- [x] `rm -rf apps/web/.next && pnpm turbo run build --filter=web` — emits all 26 routes
- [x] Standalone server boots and serves traffic: `node apps/web/server.js` → ready in 0 ms; `/api/health` → 200; `/dashboard` (unauth) → 307; `/` → 200
- [x] `pnpm run validate` green (smoke-script skipped — no pwsh in sandbox, expected)
- [x] `pnpm turbo run type-check lint test --filter=web --filter=@phenosage/shared` — 5/5 tasks, 730/730 web tests, 7/7 shared
- [x] `pnpm run security:routes` — 20 route files clean
- [ ] Container CI job builds + healthchecks the new image

## Test plan

- [ ] Confirm `Containers — Build + SBOM` job is green on this PR (proves the new Dockerfile + healthcheck still work end-to-end with docker-compose)
- [ ] Confirm Vercel preview deploys identically (standalone is ignored by Vercel, so should be a no-op)

https://claude.ai/code/session_01ULFdLaaDnZAqkz2PiQqovg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULFdLaaDnZAqkz2PiQqovg)_