### PR TITLE
perf(ci): BuildKit cache mounts + GHA cache export for container builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,10 +213,33 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@v6
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+      # `load: true` puts the image in the local docker daemon so the
+      # subsequent `docker compose up` and SBOM steps can use it by tag.
+      # `cache-to: type=gha,mode=max` exports BOTH image layers AND the
+      # `--mount=type=cache` data (pnpm store / Next cache / pip cache)
+      # to the GitHub Actions cache backend; the next run pulls them via
+      # `cache-from`. `scope=` partitions the cache per image so the two
+      # builds don't fight for the same key.
       - name: Build web image
-        run: docker build -f Dockerfile.web -t phenosage-web:ci .
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: Dockerfile.web
+          tags: phenosage-web:ci
+          load: true
+          cache-from: type=gha,scope=web
+          cache-to: type=gha,mode=max,scope=web
       - name: Build analysis image
-        run: docker build -f Dockerfile.analysis -t phenosage-analysis:ci .
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: .
+          file: Dockerfile.analysis
+          tags: phenosage-analysis:ci
+          load: true
+          cache-from: type=gha,scope=analysis
+          cache-to: type=gha,mode=max,scope=analysis
       - name: Validate compose config
         run: docker compose -f docker-compose.ci.yml config
       - name: Start containers

--- a/Dockerfile.analysis
+++ b/Dockerfile.analysis
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 FROM python:3.12-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
@@ -6,7 +7,10 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 
 COPY apps/analysis/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt \
+# Cache pip's wheel/HTTP cache across builds. We still install into the
+# image's site-packages — only the download/build artifacts are mounted.
+RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip,sharing=locked \
+    pip install -r requirements.txt \
   && adduser --disabled-password --gecos "" appuser \
   && chown -R appuser:appuser /app
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,12 +1,24 @@
+# syntax=docker/dockerfile:1.7
+# Cache mounts (`--mount=type=cache`) require BuildKit + dockerfile frontend
+# 1.7+. They persist the pnpm content-addressable store and the Next build
+# cache across builds (within a builder instance, or across CI runs when
+# paired with `cache-to=type=gha` on the build invocation).
+
 FROM node:20-alpine AS base
 WORKDIR /app
-RUN corepack enable && corepack prepare pnpm@9.15.9 --activate
+# Pin pnpm to a deterministic store dir so the cache mount target is stable.
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH
+RUN corepack enable && corepack prepare pnpm@9.15.9 --activate \
+  && pnpm config set store-dir /pnpm/store
 
 FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY apps/web/package.json apps/web/package.json
 COPY packages/shared/package.json packages/shared/package.json
-RUN pnpm install --frozen-lockfile
+# Cache the pnpm CAS store so repeat installs only re-link, never re-download.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
+    pnpm install --frozen-lockfile
 
 FROM deps AS build
 COPY . .
@@ -24,7 +36,11 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL \
     ANALYSIS_SERVICE_URL=$ANALYSIS_SERVICE_URL \
     ANALYSIS_SERVICE_API_KEY=$ANALYSIS_SERVICE_API_KEY \
     READINESS_PROBE_SECRET=$READINESS_PROBE_SECRET
-RUN pnpm --filter web build
+# Cache the Next.js incremental build cache (SWC outputs, route trace, etc.)
+# so warm builds skip work the tracer already did last time.
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store,sharing=locked \
+    --mount=type=cache,id=next-cache-web,target=/app/apps/web/.next/cache,sharing=locked \
+    pnpm --filter web build
 
 # Runner ships only the Next.js standalone trace (server.js + the traced
 # subset of node_modules) plus static + public assets the standalone

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -15,6 +15,10 @@ services:
       - "5432:5432"
 
   analysis:
+    # CI pre-builds and loads `phenosage-analysis:ci` via buildx with GHA
+    # cache export. Pinning `image:` here makes compose reuse that image
+    # instead of doing its own uncached `docker build` on `up`.
+    image: phenosage-analysis:ci
     build:
       context: .
       dockerfile: Dockerfile.analysis
@@ -39,6 +43,9 @@ services:
       - "8000:8000"
 
   web:
+    # Mirrors `analysis` above — reuse the pre-built `phenosage-web:ci`
+    # image instead of letting compose rebuild from scratch.
+    image: phenosage-web:ci
     build:
       context: .
       dockerfile: Dockerfile.web


### PR DESCRIPTION
## Summary

Cuts repeat-build cost for the `Containers — Build + SBOM` CI job by combining BuildKit cache mounts inside both Dockerfiles with GHA-backed cache export on the build invocation.

1. **`Dockerfile.web`** — adds `# syntax=docker/dockerfile:1.7`, pins pnpm's store-dir to `/pnpm/store`, and wraps the heavy `RUN` steps with `--mount=type=cache`:
   - pnpm CAS store (shared between the `deps` install and the `build` stage's `pnpm --filter web build`)
   - Next.js incremental build cache (`apps/web/.next/cache`)
2. **`Dockerfile.analysis`** — same syntax directive, plus `--mount=type=cache` for pip's wheel/HTTP cache (`/root/.cache/pip`).
3. **`.github/workflows/ci.yml`** — switches the containers job from `docker build` to `docker/setup-buildx-action` + `docker/build-push-action` with `cache-from: type=gha` / `cache-to: type=gha,mode=max`, partitioned `scope=web` / `scope=analysis`. `load: true` keeps the image in the local daemon so the subsequent compose / SBOM steps still use the local tag.
4. **`docker-compose.ci.yml`** — explicit `image: phenosage-{web,analysis}:ci` on both services so compose reuses the pre-built tagged image instead of doing its own uncached `docker build` on `up`. Previously each container was effectively built twice.

## Expected impact

- **First run** (cold cache): no change; identical to today.
- **Warm runs** (typical PR): pnpm install and `pnpm --filter web build` re-link from the cached pnpm store and skip already-compiled Next chunks via `.next/cache`. Pip skips re-downloading wheels. Expected ~30-60% faster on the container job.
- **Removes a hidden 2x build** of each image (compose previously rebuilt both services on its own).

## Caveats

- `--mount=type=cache` requires BuildKit. Modern Docker (>= 23) and `docker compose v2` enable it by default; older local installs would need `DOCKER_BUILDKIT=1`. The CI job uses `docker/setup-buildx-action` so it's explicit there.
- The new actions are SHA-pinned per the repo's `check-action-pins` rule: `docker/setup-buildx-action@v3.12.0` and `docker/build-push-action@v6.19.2`.

## Test plan

- [ ] `Containers — Build + SBOM` green on this PR
- [ ] Compare wall-clock of containers job vs. recent main runs (warm cache should land second PR onwards)
- [ ] Confirm `phenosage-web:ci` smoke healthcheck still passes (no regression from `image:` pinning)

https://claude.ai/code/session_01ULFdLaaDnZAqkz2PiQqovg

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULFdLaaDnZAqkz2PiQqovg)_