### PR TITLE
feat(analysis): retry storage + model calls; production-readiness plan

### DIFF
--- a/apps/analysis/app/services/image_analysis.py
+++ b/apps/analysis/app/services/image_analysis.py
@@ -29,7 +29,18 @@ from app.models.analysis import (
 )
 from app.services.image_quality import assess_image_quality
 from app.services.prompts import SYSTEM_PROMPT, build_analysis_prompt
+from app.services.retry import with_retry
 from app.services.scoring import compute_health_score
+
+# Bounded retries for transient upstream failures. Storage gets one extra
+# attempt over the model because it is dramatically cheaper to re-run and
+# the failure mode (Supabase blip) clears in single-digit seconds. The
+# model call is more expensive, so we cap retries tighter — and the OpenAI
+# SDK already does its own internal retry on connection errors, so we are
+# strictly adding a second outer ring around the *classified* failure
+# (rate-limit, 5xx, timeout).
+_STORAGE_FETCH_MAX_ATTEMPTS = 3
+_MODEL_CALL_MAX_ATTEMPTS = 2
 
 MODEL_VERSION = "gpt-4o-mini-vision"
 logger = logging.getLogger(__name__)
@@ -254,17 +265,32 @@ async def _run_model_analysis(
 
 async def run_analysis(request: AnalyzeRequest) -> AnalyzeResponse:
     try:
-        image_bytes, content_type = await _fetch_storage_image(request.storage_path)
+        # Bounded retry on transient storage failures (5xx / network /
+        # timeout). Non-retryable errors — ConfigurationError, an invalid
+        # storage path — propagate on the first attempt because retrying
+        # an operator-action error wastes time and amplifies log noise.
+        image_bytes, content_type = await with_retry(
+            lambda: _fetch_storage_image(request.storage_path),
+            operation="storage.fetch",
+            max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
+        )
         # Pre-vision quality gate: refuse unanalysable images here so the
         # outcome is an explicit *inconclusive* envelope rather than a
         # low-confidence diagnosis from the vision model. ImageQuality-
         # Inconclusive is an AnalysisError subclass, so it's routed by the
         # except branch below into the same fallback path.
         assess_image_quality(image_bytes)
-        response = await _run_model_analysis(
-            request,
-            image_bytes=image_bytes,
-            content_type=content_type,
+        # Retry the model call on rate-limit / 5xx / timeout only. The
+        # bytes and content type are captured by the closure so a retry
+        # does not re-download the image — only the model call repeats.
+        response = await with_retry(
+            lambda: _run_model_analysis(
+                request,
+                image_bytes=image_bytes,
+                content_type=content_type,
+            ),
+            operation="model.analyze",
+            max_attempts=_MODEL_CALL_MAX_ATTEMPTS,
         )
         log_event(
             logging.INFO,

--- a/apps/analysis/app/services/image_comparison.py
+++ b/apps/analysis/app/services/image_comparison.py
@@ -1,11 +1,13 @@
-"""
-Image comparison service.
+"""Image-comparison stub (Milestone 2).
 
-TODO (Milestone 2):
-  - Accept two images and their analysis results
-  - Use GPT-4o Vision to describe visible changes between images
-  - Return a structured comparison summary
-  - Identify improvement/regression trends
+Intentionally unimplemented. The active analysis path in
+``image_analysis.run_analysis`` hardcodes ``comparison_summary=None`` and
+the web client only renders a comparison block when that field is truthy
+(see ``apps/web/src/app/(app)/plants/[plantId]/page.tsx``), so users
+never see a placeholder string. The defensive sentinel below ensures
+this function cannot be wired into a production path by accident — a
+future PR that ships real comparison logic must replace the body
+wholesale, not extend it.
 """
 
 from __future__ import annotations
@@ -17,13 +19,17 @@ async def compare_images(
     image_id_b: str,
     storage_path_b: str,
 ) -> str:
-    """
-    Compare two plant images and return a descriptive summary of changes.
-    """
-    # TODO: Fetch both images from Supabase Storage
-    # TODO: Build comparison prompt
-    # TODO: Call OpenAI Vision API
-    # TODO: Return structured comparison text
+    """Compare two plant images and return a descriptive summary of changes.
 
+    Raises
+    ------
+    NotImplementedError
+        Always. Until Milestone 2 implements real comparison, calling this
+        from a production path is a bug — surface it loudly instead of
+        returning a misleading placeholder string.
+    """
     _ = (image_id_a, storage_path_a, image_id_b, storage_path_b)
-    return "Image comparison not yet implemented."
+    raise NotImplementedError(
+        "Image comparison is not yet implemented (Milestone 2). "
+        "The active analysis path must not call this function."
+    )

--- a/apps/analysis/app/services/retry.py
+++ b/apps/analysis/app/services/retry.py
@@ -33,8 +33,6 @@ T = TypeVar("T")
 # ``asyncio.sleep`` globally.
 _DEFAULT_SLEEP: Callable[[float], Awaitable[None]] = asyncio.sleep
 
-logger = logging.getLogger(__name__)
-
 
 def _full_jitter_delay(
     attempt: int,

--- a/apps/analysis/app/services/retry.py
+++ b/apps/analysis/app/services/retry.py
@@ -1,0 +1,140 @@
+"""Async retry helper with bounded attempts and full-jitter exponential backoff.
+
+Mirrors the policy used by ``apps/web/src/lib/server/resilience.ts`` so the
+two services behave consistently when an upstream is transiently degraded:
+
+  * Only ``AnalysisError`` subclasses with ``retryable=True`` are retried.
+    Configuration errors, programmer defects (``TypeError`` etc.), and
+    non-retryable analysis errors propagate immediately — never silently
+    swallowed into a fake fallback diagnosis.
+  * Backoff uses full jitter: ``delay = random(0, min(max_delay, base * 2^n))``.
+  * The first attempt runs immediately; sleeps occur **between** attempts.
+  * Sleep is injectable so tests do not pay real wall-clock time.
+
+No third-party dependency: ``tenacity`` would work but is overkill for the
+single call site we have here, and adding a dep to the analysis service
+should be a deliberate decision documented in the PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from app.errors import AnalysisError
+from app.middleware import get_request_id, log_event
+
+T = TypeVar("T")
+
+# Module-level so tests can monkeypatch a no-op without monkeypatching
+# ``asyncio.sleep`` globally.
+_DEFAULT_SLEEP: Callable[[float], Awaitable[None]] = asyncio.sleep
+
+logger = logging.getLogger(__name__)
+
+
+def _full_jitter_delay(
+    attempt: int,
+    *,
+    base_delay_s: float,
+    max_delay_s: float,
+) -> float:
+    """Compute the sleep between ``attempt`` (just failed) and the next one.
+
+    ``attempt`` is 1-indexed. ``secrets.randbelow`` is used instead of
+    ``random.random`` to satisfy the repo's "no ``Math.random``-style
+    non-cryptographic RNG in production code" guardrail consistently across
+    both the TS and Python services.
+    """
+    exp = base_delay_s * (2 ** (attempt - 1))
+    ceiling = min(max_delay_s, exp)
+    if ceiling <= 0:
+        return 0.0
+    # randbelow(n) returns [0, n). Scale by ceiling / n to get a float in
+    # [0, ceiling). A million buckets is plenty of resolution for jitter.
+    return float(ceiling * (secrets.randbelow(1_000_000) / 1_000_000))
+
+
+async def with_retry(  # noqa: UP047 - PEP 695 generics require Python 3.12; local dev is 3.11
+    fn: Callable[[], Awaitable[T]],
+    *,
+    operation: str,
+    max_attempts: int = 3,
+    base_delay_s: float = 0.1,
+    max_delay_s: float = 2.0,
+    sleep: Callable[[float], Awaitable[None]] | None = None,
+) -> T:
+    """Run ``fn`` with bounded retries on retryable ``AnalysisError``s.
+
+    ``fn`` is a zero-argument async callable so callers can close over the
+    exact arguments they need without this helper having to be generic over
+    them. On success returns ``fn``'s value. On exhaustion re-raises the
+    final ``AnalysisError``. On non-retryable errors raises immediately.
+
+    Parameters
+    ----------
+    operation:
+        Stable, low-cardinality label used in retry / failure logs (e.g.
+        ``"storage.fetch"``, ``"model.analyze"``).
+    max_attempts:
+        Total attempts including the first. Must be >= 1. ``1`` disables
+        retries; the helper still classifies / logs the error.
+    base_delay_s, max_delay_s:
+        Bounds for the jittered backoff between attempts.
+    sleep:
+        Override the async sleep function (test seam). Defaults to
+        ``asyncio.sleep``.
+    """
+    if max_attempts < 1:
+        raise ValueError(f"max_attempts must be >= 1 (operation={operation!r})")
+
+    sleep_fn = sleep if sleep is not None else _DEFAULT_SLEEP
+    last_error: AnalysisError | None = None
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return await fn()
+        except AnalysisError as exc:
+            if not exc.retryable or attempt == max_attempts:
+                log_event(
+                    logging.WARNING if exc.retryable else logging.ERROR,
+                    "upstream call failed",
+                    operation=operation,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    upstream_code=exc.code,
+                    retryable=exc.retryable,
+                    request_id=get_request_id(),
+                )
+                raise
+            last_error = exc
+            delay = _full_jitter_delay(
+                attempt,
+                base_delay_s=base_delay_s,
+                max_delay_s=max_delay_s,
+            )
+            log_event(
+                logging.WARNING,
+                "upstream call retrying",
+                operation=operation,
+                attempt=attempt,
+                max_attempts=max_attempts,
+                upstream_code=exc.code,
+                backoff_ms=int(delay * 1000),
+                request_id=get_request_id(),
+            )
+            await sleep_fn(delay)
+        # Non-AnalysisError exceptions intentionally propagate — see
+        # ``run_analysis``'s docstring re: programmer-defect discipline.
+
+    # Defensive: the loop must always return or raise. ``last_error`` is
+    # populated whenever we reach this point because every iteration either
+    # returns, raises, or assigns ``last_error`` before sleeping.
+    assert last_error is not None  # pragma: no cover - defensive
+    raise last_error
+
+
+__all__ = ["with_retry"]

--- a/apps/analysis/app/services/retry.py
+++ b/apps/analysis/app/services/retry.py
@@ -90,15 +90,18 @@ async def with_retry(  # noqa: UP047 - PEP 695 generics require Python 3.12; loc
         raise ValueError(f"max_attempts must be >= 1 (operation={operation!r})")
 
     sleep_fn = sleep if sleep is not None else _DEFAULT_SLEEP
-    last_error: AnalysisError | None = None
 
     for attempt in range(1, max_attempts + 1):
         try:
             return await fn()
         except AnalysisError as exc:
             if not exc.retryable or attempt == max_attempts:
+                # Both terminal cases — non-retryable failure and retry
+                # exhaustion — are logged at ERROR so monitoring that
+                # alerts on ERROR-level logs catches persistent upstream
+                # degradation, not just one-shot misconfiguration.
                 log_event(
-                    logging.WARNING if exc.retryable else logging.ERROR,
+                    logging.ERROR,
                     "upstream call failed",
                     operation=operation,
                     attempt=attempt,
@@ -108,7 +111,6 @@ async def with_retry(  # noqa: UP047 - PEP 695 generics require Python 3.12; loc
                     request_id=get_request_id(),
                 )
                 raise
-            last_error = exc
             delay = _full_jitter_delay(
                 attempt,
                 base_delay_s=base_delay_s,
@@ -128,11 +130,12 @@ async def with_retry(  # noqa: UP047 - PEP 695 generics require Python 3.12; loc
         # Non-AnalysisError exceptions intentionally propagate — see
         # ``run_analysis``'s docstring re: programmer-defect discipline.
 
-    # Defensive: the loop must always return or raise. ``last_error`` is
-    # populated whenever we reach this point because every iteration either
-    # returns, raises, or assigns ``last_error`` before sleeping.
-    assert last_error is not None  # pragma: no cover - defensive
-    raise last_error
+    # Unreachable: every iteration either returns, raises, or sleeps and
+    # continues. The loop bound itself guarantees the final iteration
+    # hits the `attempt == max_attempts` branch above and raises.
+    raise AssertionError(  # pragma: no cover - defensive
+        f"with_retry exited loop without returning or raising (operation={operation!r})"
+    )
 
 
 __all__ = ["with_retry"]

--- a/apps/analysis/app/services/scoring.py
+++ b/apps/analysis/app/services/scoring.py
@@ -1,10 +1,7 @@
-"""
-Health scoring service.
+"""Severity-weighted health score.
 
-TODO (Milestone 2):
-  - Accept a list of AnalysisFinding objects
-  - Apply weighted scoring based on severity and category
-  - Return a 0–100 health score
+Penalises each finding by its severity (info contributes nothing) and
+subtracts the total from 100. Capped at 0.
 """
 
 from __future__ import annotations

--- a/apps/analysis/tests/test_image_analysis.py
+++ b/apps/analysis/tests/test_image_analysis.py
@@ -413,19 +413,165 @@ async def test_run_analysis_falls_back_when_storage_fetch_fails(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    calls = 0
+
     async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        nonlocal calls
+        calls += 1
         raise image_analysis.StorageUnavailable("simulated outage")
 
+    # No-op sleep so we don't pay real backoff time in unit tests.
+    async def _no_sleep(_: float) -> None:
+        return None
+
     monkeypatch.setattr(image_analysis, "_fetch_storage_image", fake_fetch)
+    monkeypatch.setattr(
+        "app.services.retry._DEFAULT_SLEEP",
+        _no_sleep,
+    )
 
     with caplog.at_level("WARNING", logger="phenosage.analysis"):
         response = await image_analysis.run_analysis(_request())
 
+    # Storage fetch is retried (default 3 attempts) before falling back.
+    assert calls == 3
     assert response.is_fallback is True
     assert response.analysis_mode == "fallback"
     # Stable, redaction-safe code — never the raw exception class name.
     assert response.fallback_reason == "STORAGE_UNAVAILABLE"
     assert "analysis fallback triggered" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_retries_storage_fetch_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single transient storage blip must not surface as a fallback.
+
+    Locks in the Phase 1 reliability behaviour: the user-visible result
+    after one retryable failure should be a real analysis, not the
+    inconclusive fallback envelope.
+    """
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    attempts = 0
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise image_analysis.StorageUnavailable("transient blip")
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_analysis, "_fetch_storage_image", fake_fetch)
+
+    async def _no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("app.services.retry._DEFAULT_SLEEP", _no_sleep)
+
+    class FakeCompletions:
+        async def create(self, **kwargs: object) -> object:
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=json.dumps(
+                                {
+                                    "overall_health_score": 91,
+                                    "summary": "Healthy.",
+                                    "findings": [],
+                                }
+                            )
+                        )
+                    )
+                ]
+            )
+
+    class FakeAsyncOpenAI:
+        def __init__(self, *, api_key: str) -> None:
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(AsyncOpenAI=FakeAsyncOpenAI),
+    )
+
+    response = await image_analysis.run_analysis(_request())
+
+    assert attempts == 2
+    assert response.is_fallback is False
+    assert response.analysis_mode == "model"
+    assert response.overall_health_score == 91.0
+
+
+@pytest.mark.asyncio
+async def test_run_analysis_retries_model_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single model rate-limit must be absorbed by the retry layer.
+
+    The image bytes are captured by the closure, so a retried model call
+    must not re-download the image — exercised by asserting the storage
+    fetch ran exactly once.
+    """
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    fetch_calls = 0
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        nonlocal fetch_calls
+        fetch_calls += 1
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_analysis, "_fetch_storage_image", fake_fetch)
+
+    async def _no_sleep(_: float) -> None:
+        return None
+
+    monkeypatch.setattr("app.services.retry._DEFAULT_SLEEP", _no_sleep)
+
+    model_calls = 0
+
+    class FakeCompletions:
+        async def create(self, **kwargs: object) -> object:
+            nonlocal model_calls
+            model_calls += 1
+            if model_calls == 1:
+                raise image_analysis.ModelRateLimited("burst")
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content=json.dumps(
+                                {
+                                    "overall_health_score": 80,
+                                    "summary": "Recovered.",
+                                    "findings": [],
+                                }
+                            )
+                        )
+                    )
+                ]
+            )
+
+    class FakeAsyncOpenAI:
+        def __init__(self, *, api_key: str) -> None:
+            self.chat = SimpleNamespace(completions=FakeCompletions())
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(AsyncOpenAI=FakeAsyncOpenAI),
+    )
+
+    response = await image_analysis.run_analysis(_request())
+
+    assert fetch_calls == 1, "storage must not be re-fetched on a model retry"
+    assert model_calls == 2
+    assert response.is_fallback is False
+    assert response.overall_health_score == 80.0
 
 
 @pytest.mark.asyncio

--- a/apps/analysis/tests/test_image_comparison.py
+++ b/apps/analysis/tests/test_image_comparison.py
@@ -17,25 +17,20 @@ from app.services.image_comparison import compare_images
 
 
 @pytest.mark.asyncio
-async def test_compare_images_returns_string() -> None:
-    result = await compare_images(
-        image_id_a="img-a",
-        storage_path_a="plants/p/img-a.jpg",
-        image_id_b="img-b",
-        storage_path_b="plants/p/img-b.jpg",
-    )
-    assert isinstance(result, str)
-    assert result  # non-empty
+async def test_compare_images_raises_not_implemented() -> None:
+    """The stub must fail loudly if it's ever called from a production path.
 
-
-@pytest.mark.asyncio
-async def test_compare_images_current_stub_marker() -> None:
+    Returning a placeholder string previously hid the unfinished state from
+    callers. Raising ``NotImplementedError`` instead makes accidental
+    wiring an observable bug rather than a silent UX defect.
     """
-    The stub returns a known sentinel string. When the real implementation
-    lands this test should be replaced — its failure is the intended signal.
-    """
-    result = await compare_images("a", "p/a", "b", "p/b")
-    assert "not yet implemented" in result.lower()
+    with pytest.raises(NotImplementedError, match="Milestone 2"):
+        await compare_images(
+            image_id_a="img-a",
+            storage_path_a="plants/p/img-a.jpg",
+            image_id_b="img-b",
+            storage_path_b="plants/p/img-b.jpg",
+        )
 
 
 def test_compare_images_signature_is_stable() -> None:

--- a/apps/analysis/tests/test_retry.py
+++ b/apps/analysis/tests/test_retry.py
@@ -1,0 +1,208 @@
+"""Tests for ``app.services.retry.with_retry``."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from app.errors import (
+    ConfigurationError,
+    ModelBadResponse,
+    ModelRateLimited,
+    StorageUnavailable,
+)
+from app.services import retry
+
+
+def _no_sleep() -> Callable[[float], Awaitable[None]]:
+    """A sleep stub that records calls without actually delaying."""
+    calls: list[float] = []
+
+    async def sleep(seconds: float) -> None:
+        calls.append(seconds)
+
+    sleep.calls = calls  # type: ignore[attr-defined]
+    return sleep
+
+
+@pytest.mark.asyncio
+async def test_returns_immediately_on_success() -> None:
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        return "ok"
+
+    sleep = _no_sleep()
+    result = await retry.with_retry(fn, operation="t", sleep=sleep)
+    assert result == "ok"
+    assert attempts == 1
+    assert sleep.calls == []  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_retries_retryable_error_then_succeeds() -> None:
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        if attempts < 3:
+            raise StorageUnavailable("simulated blip")
+        return "ok"
+
+    sleep = _no_sleep()
+    result = await retry.with_retry(
+        fn,
+        operation="storage.fetch",
+        max_attempts=3,
+        sleep=sleep,
+    )
+    assert result == "ok"
+    assert attempts == 3
+    # Two sleeps between three attempts.
+    assert len(sleep.calls) == 2  # type: ignore[attr-defined]
+    # Each sleep is bounded by the jitter ceiling at the corresponding attempt.
+    for call in sleep.calls:  # type: ignore[attr-defined]
+        assert call >= 0.0
+        assert call < 2.0  # max_delay_s default
+
+
+@pytest.mark.asyncio
+async def test_exhausts_and_raises_last_retryable_error() -> None:
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise ModelRateLimited(f"attempt {attempts}")
+
+    sleep = _no_sleep()
+    with pytest.raises(ModelRateLimited):
+        await retry.with_retry(
+            fn,
+            operation="model.analyze",
+            max_attempts=2,
+            sleep=sleep,
+        )
+    assert attempts == 2
+    # One sleep between two attempts.
+    assert len(sleep.calls) == 1  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_non_retryable_analysis_error() -> None:
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise ConfigurationError("missing key")
+
+    sleep = _no_sleep()
+    with pytest.raises(ConfigurationError):
+        await retry.with_retry(
+            fn,
+            operation="storage.fetch",
+            max_attempts=5,
+            sleep=sleep,
+        )
+    assert attempts == 1
+    assert sleep.calls == []  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_non_retryable_model_bad_response() -> None:
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise ModelBadResponse("garbage json")
+
+    sleep = _no_sleep()
+    with pytest.raises(ModelBadResponse):
+        await retry.with_retry(
+            fn,
+            operation="model.analyze",
+            max_attempts=5,
+            sleep=sleep,
+        )
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_propagates_unexpected_exception_without_retry() -> None:
+    """Programmer defects must surface immediately — never be retried.
+
+    Retrying a ``TypeError`` would (a) waste time and (b) mask the bug
+    behind a "transient failure" log, exactly the discipline failure that
+    ``run_analysis`` and the audit guidance forbid.
+    """
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise TypeError("programmer bug")
+
+    sleep = _no_sleep()
+    with pytest.raises(TypeError, match="programmer bug"):
+        await retry.with_retry(
+            fn,
+            operation="storage.fetch",
+            max_attempts=5,
+            sleep=sleep,
+        )
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_max_attempts_one_disables_retry_but_still_logs() -> None:
+    attempts = 0
+
+    async def fn() -> str:
+        nonlocal attempts
+        attempts += 1
+        raise StorageUnavailable("blip")
+
+    sleep = _no_sleep()
+    with pytest.raises(StorageUnavailable):
+        await retry.with_retry(
+            fn,
+            operation="storage.fetch",
+            max_attempts=1,
+            sleep=sleep,
+        )
+    assert attempts == 1
+    assert sleep.calls == []  # type: ignore[attr-defined]
+
+
+def test_max_attempts_zero_is_rejected() -> None:
+    async def fn() -> str:
+        return "ok"
+
+    with pytest.raises(ValueError, match="max_attempts"):
+        # ``with_retry`` is async but the validation happens before the
+        # first await, so the ValueError propagates synchronously when the
+        # coroutine is awaited. We exercise the underlying constructor by
+        # calling the async fn through ``asyncio.run`` indirectly.
+        import asyncio
+
+        asyncio.run(
+            retry.with_retry(fn, operation="t", max_attempts=0),
+        )
+
+
+def test_full_jitter_delay_is_bounded() -> None:
+    """The internal jitter helper must never exceed ``max_delay_s``."""
+    for attempt in range(1, 10):
+        for _ in range(50):
+            delay = retry._full_jitter_delay(
+                attempt,
+                base_delay_s=0.1,
+                max_delay_s=2.0,
+            )
+            assert 0.0 <= delay < 2.0

--- a/docs/optimization-plan.md
+++ b/docs/optimization-plan.md
@@ -1,0 +1,209 @@
+# PhenoSage Production-Readiness & Optimization Plan
+
+**Status:** Phase 0 + Phase 1 in progress on `claude/app-optimization-review-VxsEM`.
+**Owner:** Lead engineering.
+**Audit basis:** Full-codebase survey performed 2026-05-17 — see WORKLOG for the
+raw notes.
+
+This plan is sequenced by **risk-to-revenue**. Phase 0 and Phase 1 prevent the
+most user-visible failures and are the only phases meant to land on the current
+optimization branch; later phases are tracked as follow-up issues / PRs.
+
+---
+
+## Phase 0 — Triage: stop silent failures
+
+Stubbed code paths that look like they work but return synthetic/null data
+erode user trust without any error signal. After the audit, the actual state
+of these items is:
+
+| # | Item | Actual state | Action |
+|---|------|-------------|--------|
+| 0.1 | Image-comparison stub returns "not yet implemented" | `image_comparison.compare_images` is never wired into `run_analysis`; the active code path hardcodes `comparison_summary=None`. UI conditionally renders only when truthy. | Add a comment + lint to keep it that way until Milestone 2 ships. |
+| 0.2 | UI must clearly mark fallback results | Already implemented: `plants/[plantId]/page.tsx` renders a warning-toned `<StatusPill>` and explanatory copy when `isFallback === true`. | No change needed; covered by E2E expansion in Phase 6. |
+| 0.3 | Severity-weighted health score | Already implemented in `scoring.py` with weights `info:0, low:5, medium:15, high:30, critical:50`. The TODO docstring is stale. | Remove stale TODO comment so it isn't audited as a gap again. |
+| 0.4 | Other `TODO (Milestone 2)` markers | `image_comparison.py` and `prompts.py` are the only two. Neither is reachable from prod UI. | Track in Milestone 2 issue, not on this branch. |
+
+---
+
+## Phase 1 — Reliability & resilience
+
+The single biggest production risk is transient upstream failures becoming
+permanent user-visible errors. Web side already has bounded retries and a
+circuit breaker (`apps/web/src/lib/server/resilience.ts`,
+`circuit-breaker.ts`, applied via `analysis-proxy.ts:380`). The remaining
+hole is the **analysis service itself**, which has no retries on its
+Supabase fetch or OpenAI call.
+
+### 1.1 Backend retries (this branch)
+
+- New: `apps/analysis/app/services/retry.py` — async `with_retry` helper.
+  - Bounded attempts with full-jitter exponential backoff.
+  - Retries only `AnalysisError` subclasses where `retryable=True` (already
+    set on `StorageUnavailable`, `ModelUnavailable`, `ModelRateLimited`).
+  - Never retries `ConfigurationError`, `ModelBadResponse`,
+    `InvalidStoragePath`, `ImageQualityInconclusive` — those need an
+    operator/user action, not a retry.
+  - No new third-party dep; we don't need `tenacity` for this scope.
+  - Injectable `sleep` for tests.
+- Wire it around `_fetch_storage_image` and `_run_model_analysis` in
+  `run_analysis()`.
+- Structured log on every retry (`upstream call retrying`) and on
+  exhaustion (`upstream call failed`).
+
+### 1.2 Idempotency at the DB layer (follow-up PR)
+
+- New migration adding `UNIQUE (user_id, idempotency_key)` to
+  `analysis_jobs` and `chat_messages`.
+- App treats `23505` (unique violation) as "already accepted" and returns
+  the existing row.
+
+### 1.3 Rate-limit hardening (follow-up PR)
+
+- The current fail-open behavior in `rate-limit.ts` is **intentional** and
+  documented; we don't change it for read endpoints.
+- Add a stricter, fail-closed limiter for **auth** routes (5 sign-in
+  attempts / 15 min / IP).
+- Add per-endpoint quotas separate from the default.
+
+### 1.4 Signed-URL auto-refresh (follow-up PR)
+
+- New endpoint `POST /api/uploads/refresh` that re-signs a path after
+  validating ownership.
+- New client component `<SignedImage>` that catches a 403 once and
+  refetches via the refresh endpoint.
+
+---
+
+## Phase 2 — Observability (follow-up PRs)
+
+- Promote `SENTRY_DSN` to required when `NEXT_PUBLIC_APP_ENV=production`
+  (`apps/web/src/lib/server/env.ts`).
+- W3C `traceparent` propagation: browser → Next route handler →
+  FastAPI → OpenAI.
+- Structured per-route timing logs: `{requestId, userId, route, durationMs, status}`.
+- Sentry alerts: `/api/analyze` p95 > 15s for 5 min, error rate > 2% over
+  10 min, any 5xx on `/api/internal/cron/*`.
+- `/api/ready` probes Supabase, Upstash, analysis service individually.
+
+---
+
+## Phase 3 — Performance (follow-up PRs)
+
+- Bundle analysis pass (`@next/bundle-analyzer`); target first-load JS
+  < 200 KB on `/dashboard`.
+- Eliminate N+1 in `plants.ts:340-353` via a `get_plant_timeline` RPC.
+- Cursor pagination on `/api/plants/[plantId]/timeline`,
+  `/api/grows/[id]/plants`, `/api/notifications`.
+- Streaming chat response (`ReadableStream` + Vercel AI SDK).
+- `Cache-Control: private, no-store` on every authed API route;
+  `public, max-age=60, stale-while-revalidate=300` on health/marketing.
+- `EXPLAIN ANALYZE` sweep on top-10 queries; missing indexes added.
+- pgvector switch to HNSW once >10k embeddings exist.
+- Move runtime-safe routes to `runtime = "edge"`.
+
+---
+
+## Phase 4 — Error handling & UX (follow-up PRs)
+
+- Move zod schemas from `lib/server/schemas.ts` to
+  `packages/shared/src/schemas.ts` (the project's shared package
+  intentionally has no runtime deps — adding zod is a justified
+  exception, since contract drift is a known risk).
+- Forms adopt `react-hook-form` + `@hookform/resolvers/zod` against the
+  shared schemas. Field-level errors render immediately.
+- One `<Toaster />` at the root layout. Every fetch wrapper maps the
+  `{error: {code, message, requestId}}` envelope to a coded toast with a
+  "Details" disclosure exposing `requestId`.
+- Mutations use `useMutation` with optimistic update and a one-tap retry.
+- Granular `<Suspense>` boundaries inside `(app)/grows/[id]/page.tsx` and
+  `(app)/plants/[plantId]/page.tsx`.
+- Realtime subscription to `notifications` so resolve/dismiss propagates
+  across tabs.
+- Upload progress bar via `XMLHttpRequest.onprogress`; exponential-backoff
+  retry up to 3 attempts on transient failures.
+
+---
+
+## Phase 5 — Security hardening (follow-up PRs)
+
+| # | Item |
+|---|------|
+| 5.1 | Auth rate-limit: 5 failed sign-ins / 15 min / IP. |
+| 5.2 | Magic-bytes MIME sniffing on uploads (first 12 bytes), not just `Content-Type`/extension. |
+| 5.3 | `Content-Length` cap enforced in the shared `parseJsonBody` wrapper (10 MB image, 64 KB JSON). |
+| 5.4 | Nonce-based CSP — generated per-response, no global `middleware.ts`. |
+| 5.5 | Key-rotation runbook in `docs/runbooks/key-rotation.md`. |
+| 5.6 | `pnpm run security:routes` made a required PR check. |
+
+---
+
+## Phase 6 — Testing expansion (follow-up PRs)
+
+- Playwright specs for: invalid login, expired session, analysis 5xx,
+  rate-limit hit, multi-user grow collaboration (RLS), signed-URL
+  refresh, offline retry.
+- 80% line coverage threshold on `apps/web/src/lib/server/**` and
+  `apps/analysis/app/**` enforced in CI.
+- k6 script at `tests/load/analyze.js` — 50 RPS for 5 min, p95 < 8s,
+  error rate < 1%.
+- Cross-language contract test: same JSON sample feeds the pydantic
+  `AnalyzeRequest` and the zod `AnalyzeRequestSchema`; both must accept
+  or reject identically.
+
+---
+
+## Phase 7 — CI/CD & deploy safety (follow-up PRs)
+
+- Migration dry-run job: `supabase db diff --linked` + `supabase db lint`
+  on PR; blocks merge on errors.
+- Post-deploy smoke runs within 60s of prod deploy; on failure, opens a
+  rollback PR or hits the Vercel rollback API.
+- New `deploy-analysis.yml` workflow tied to `apps/analysis/**` changes.
+- Lockstep check: block merges to main if `packages/shared` changes
+  without a matching pydantic update.
+- Pre-commit hook (`.husky/pre-commit`) runs `pnpm run validate`.
+
+---
+
+## Phase 8 — Runbook & documentation (follow-up PRs)
+
+- `docs/runbooks/incident-response.md` — high-error-rate, OpenAI outage,
+  Supabase degradation.
+- `docs/runbooks/rollback.md` — Vercel, Railway, migration rollback.
+- `docs/runbooks/key-rotation.md`.
+- `docs/runbooks/onboarding-call.md` — dashboards, log queries, Sentry
+  links.
+
+---
+
+## Effort summary
+
+| Phase | Eng-days | Risk if skipped |
+|-------|---------|-----------------|
+| 0 — Triage | 1 | High — silent failures |
+| 1 — Reliability | 3–5 | High — transient outages become user errors |
+| 2 — Observability | 2–3 | High — flying blind in prod |
+| 3 — Performance | 3–5 | Medium |
+| 4 — Error UX | 3–4 | Medium |
+| 5 — Security | 2 | Medium-High |
+| 6 — Testing | 3–4 | Medium |
+| 7 — CI/CD | 2 | Medium |
+| 8 — Docs | 1 | Low (but cheap) |
+| **Total** | **~20–28 days** | |
+
+---
+
+## What's landing on `claude/app-optimization-review-VxsEM`
+
+1. This plan doc.
+2. Stale TODO removed from `scoring.py`.
+3. Defensive guard on `image_comparison.compare_images` so it cannot be
+   wired into a production path by accident.
+4. New `apps/analysis/app/services/retry.py` — async `with_retry` helper.
+5. `run_analysis` retries `_fetch_storage_image` and `_run_model_analysis`
+   on retryable `AnalysisError`s.
+6. Tests covering: retry-then-succeed, retry-then-exhaust, non-retryable
+   passes through immediately, programmer defects still propagate.
+
+Everything else is tracked here for follow-up PRs.


### PR DESCRIPTION
## Summary

Phase 0 + Phase 1 of the production-readiness plan in `docs/optimization-plan.md`. Closes the highest-risk hole surfaced by the audit: the FastAPI analysis service had **no retries** on its Supabase storage fetch or OpenAI call, so a single transient blip became a user-visible fallback envelope.

- New `apps/analysis/app/services/retry.py` — small async `with_retry` helper (no new dep). Retries only `AnalysisError`s where `retryable=True`; propagates non-retryable errors and programmer defects immediately.
- `run_analysis()` now retries `_fetch_storage_image` (3 attempts) and `_run_model_analysis` (2 attempts) with full-jitter exponential backoff. The image bytes are captured by the closure so a model retry does **not** re-download the image.
- `scoring.py`: drop stale `TODO (Milestone 2)` — the severity-weighted score is already implemented.
- `image_comparison.compare_images`: raise `NotImplementedError` instead of a placeholder string so accidental wiring is observable. The active path hardcodes `comparison_summary=None`, so user-facing behaviour is unchanged.
- `docs/optimization-plan.md`: full audit + 8-phase sequenced plan tracking the follow-up PRs (observability, perf, error UX, security, testing, CI/CD, runbooks).

## Test plan

- [x] `pytest` — 113 passed (9 new in `test_retry.py`, 2 new in `test_image_analysis.py` covering retry-then-succeed for storage and model).
- [x] `ruff check` clean.
- [x] `mypy` clean.
- [x] Existing fallback envelope behaviour preserved on retry exhaustion.
- [x] `test_run_analysis_does_not_swallow_programmer_errors` still passes — `TypeError` is not caught by `with_retry`.

## Phases tracked but not in this PR

| Phase | Scope |
|-------|-------|
| 1.2 | DB-level idempotency unique constraint on `analysis_jobs` / `chat_messages` |
| 1.3 | Auth-route rate-limit (fail-closed, 5 / 15 min / IP) |
| 1.4 | Signed-URL auto-refresh endpoint + `<SignedImage>` component |
| 2 | Sentry mandatory in prod, OTel `traceparent`, latency/error alerts |
| 3 | Bundle analysis, N+1 elimination, cursor pagination, streaming chat |
| 4 | Shared zod schemas, RHF + Zod resolver, root toaster, optimistic mutations |
| 5 | Magic-bytes MIME, Content-Length cap, nonce CSP, key-rotation runbook |
| 6 | E2E breadth, 80% coverage gate, k6 load, cross-language contract test |
| 7 | Migration dry-run gate, post-deploy smoke rollback, Railway CI deploy |
| 8 | Runbooks: incident response, rollback, key rotation, on-call |

See `docs/optimization-plan.md` for the full plan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_