### PR TITLE
feat(chat): idempotency key on chat_messages user inserts

### DIFF
--- a/apps/web/src/app/api/chat/route.ts
+++ b/apps/web/src/app/api/chat/route.ts
@@ -126,6 +126,7 @@ export async function POST(request: NextRequest) {
       plantId?: string;
       history?: unknown;
       attachments?: unknown;
+      idempotencyKey?: string;
     };
     try {
       body = (await request.json()) as typeof body;
@@ -255,6 +256,29 @@ export async function POST(request: NextRequest) {
         requestId,
       );
     }
+    // Optional client-supplied dedup key. Matches the bounds used elsewhere
+    // (AnalyzeRequestSchema, UploadFinalizeRequestSchema) so clients can
+    // reuse a single id-minting helper across endpoints. Empty strings are
+    // rejected by the length check below — they're never useful as a key
+    // and surface as a clear 400 instead of being silently coerced to
+    // "no idempotency".
+    const idempotencyKey =
+      typeof body.idempotencyKey === "string" ? body.idempotencyKey : undefined;
+    if (
+      idempotencyKey !== undefined &&
+      (idempotencyKey.length < 8 || idempotencyKey.length > 128)
+    ) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: "idempotencyKey must be between 8 and 128 characters.",
+            requestId,
+          },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
 
     // Validate optional client-supplied history. We trust role+content shape but
     // not the model identities — the server prepends the canonical system
@@ -314,12 +338,15 @@ export async function POST(request: NextRequest) {
       // Persist the user message before we call out to the model so the
       // transcript is durable even if the stream errors. We capture the
       // returned id so attachment rows can foreign-key to this exact
-      // chat_messages row.
+      // chat_messages row. When the client supplied an idempotencyKey,
+      // a retried request resolves to the same row id rather than
+      // creating a duplicate transcript entry.
       if (threadId) {
         userMessageId = await appendMessage({
           threadId,
           role: "user",
           content: effectiveUserText,
+          ...(idempotencyKey ? { idempotencyKey } : {}),
         });
       }
     }

--- a/apps/web/src/lib/server/__tests__/chat-persistence.test.ts
+++ b/apps/web/src/lib/server/__tests__/chat-persistence.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the auth + db modules so we never reach a real Supabase client.
+const createSupabaseServerClient = vi.fn();
+vi.mock("../auth", () => ({
+  createSupabaseServerClient,
+}));
+
+const getDbClient = vi.fn();
+vi.mock("../db", () => ({
+  getDbClient,
+}));
+
+const logServerEvent = vi.fn();
+vi.mock("../request-id", () => ({
+  logServerEvent,
+}));
+
+beforeEach(() => {
+  getDbClient.mockReset();
+  createSupabaseServerClient.mockReset();
+  logServerEvent.mockReset();
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// appendMessage — idempotency
+// ────────────────────────────────────────────────────────────────────────────
+
+describe("appendMessage idempotency", () => {
+  it("includes idempotency_key in the insert row when provided", async () => {
+    const insertedRows: Record<string, unknown>[] = [];
+    const single = vi.fn().mockResolvedValue({
+      data: { id: "msg-1" },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn((row: Record<string, unknown>) => {
+      insertedRows.push(row);
+      return { select };
+    });
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ insert })) });
+
+    const { appendMessage } = await import("../chat-persistence");
+    const id = await appendMessage({
+      threadId: "thread-1",
+      role: "user",
+      content: "hello",
+      idempotencyKey: "test1234",
+    });
+
+    expect(id).toBe("msg-1");
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0]).toMatchObject({
+      thread_id: "thread-1",
+      role: "user",
+      content: "hello",
+      idempotency_key: "test1234",
+    });
+  });
+
+  it("omits idempotency_key when caller didn't supply one", async () => {
+    const insertedRows: Record<string, unknown>[] = [];
+    const single = vi.fn().mockResolvedValue({
+      data: { id: "msg-1" },
+      error: null,
+    });
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn((row: Record<string, unknown>) => {
+      insertedRows.push(row);
+      return { select };
+    });
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ insert })) });
+
+    const { appendMessage } = await import("../chat-persistence");
+    await appendMessage({
+      threadId: "thread-1",
+      role: "user",
+      content: "hello",
+    });
+
+    expect(insertedRows[0]).not.toHaveProperty("idempotency_key");
+  });
+
+  it("returns the existing row id when insert hits 23505 with an idempotencyKey", async () => {
+    // First call: insert returns a 23505 unique_violation.
+    const insertSingle = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: "23505", message: "duplicate key" },
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSingle }));
+    const insert = vi.fn(() => ({ select: insertSelect }));
+
+    // Second call: the dedup lookup returns the original row.
+    const lookupMaybeSingle = vi
+      .fn()
+      .mockResolvedValue({ data: { id: "msg-original" }, error: null });
+    const lookupEqKey = vi.fn(() => ({ maybeSingle: lookupMaybeSingle }));
+    const lookupEqThread = vi.fn(() => ({ eq: lookupEqKey }));
+    const lookupSelect = vi.fn(() => ({ eq: lookupEqThread }));
+
+    // The `.from("chat_messages")` is called twice: once for the insert,
+    // once for the recovery lookup. Return objects in that order.
+    const from = vi
+      .fn()
+      .mockReturnValueOnce({ insert })
+      .mockReturnValueOnce({ select: lookupSelect });
+
+    getDbClient.mockReturnValue({ from });
+
+    const { appendMessage } = await import("../chat-persistence");
+    const id = await appendMessage({
+      threadId: "thread-1",
+      role: "user",
+      content: "hello",
+      idempotencyKey: "test1234",
+    });
+
+    expect(id).toBe("msg-original");
+    expect(lookupEqThread).toHaveBeenCalledWith("thread_id", "thread-1");
+    expect(lookupEqKey).toHaveBeenCalledWith("idempotency_key", "test1234");
+    // We log an info line on idempotent replay so ops can spot retry storms.
+    // The key is included in the log line so a specific retry burst can be
+    // correlated to a single client request.
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "chat message idempotent replay",
+      expect.objectContaining({
+        threadId: "thread-1",
+        role: "user",
+        idempotencyKey: "test1234",
+      }),
+    );
+  });
+
+  it("does NOT recover on 23505 when caller didn't supply an idempotencyKey", async () => {
+    // Without a key, a unique violation would mean something else has gone
+    // wrong (no other unique constraint on chat_messages should be hit by
+    // an ordinary insert). Surface the failure as null + error log instead
+    // of silently masking it.
+    const insertSingle = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: "23505", message: "duplicate key" },
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSingle }));
+    const insert = vi.fn(() => ({ select: insertSelect }));
+    const from = vi.fn().mockReturnValue({ insert });
+    getDbClient.mockReturnValue({ from });
+
+    const { appendMessage } = await import("../chat-persistence");
+    const id = await appendMessage({
+      threadId: "thread-1",
+      role: "user",
+      content: "hello",
+    });
+
+    expect(id).toBeNull();
+    // The recovery lookup must not run when no key was supplied.
+    expect(from).toHaveBeenCalledTimes(1);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "chat message insert failed",
+      expect.objectContaining({ threadId: "thread-1" }),
+    );
+  });
+
+  it("falls through to error log when 23505 lookup itself fails", async () => {
+    // Belt-and-braces: an idempotencyKey was provided, the insert hit
+    // 23505, but the recovery SELECT also failed (e.g. transient db error).
+    // The function must NOT pretend the write succeeded — return null and
+    // log so the caller can surface the failure.
+    const insertSingle = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: "23505", message: "duplicate key" },
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSingle }));
+    const insert = vi.fn(() => ({ select: insertSelect }));
+
+    const lookupMaybeSingle = vi
+      .fn()
+      .mockResolvedValue({ data: null, error: { message: "db down" } });
+    const lookupEqKey = vi.fn(() => ({ maybeSingle: lookupMaybeSingle }));
+    const lookupEqThread = vi.fn(() => ({ eq: lookupEqKey }));
+    const lookupSelect = vi.fn(() => ({ eq: lookupEqThread }));
+
+    const from = vi
+      .fn()
+      .mockReturnValueOnce({ insert })
+      .mockReturnValueOnce({ select: lookupSelect });
+    getDbClient.mockReturnValue({ from });
+
+    const { appendMessage } = await import("../chat-persistence");
+    const id = await appendMessage({
+      threadId: "thread-1",
+      role: "user",
+      content: "hello",
+      idempotencyKey: "test1234",
+    });
+
+    expect(id).toBeNull();
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "chat message insert failed",
+      expect.objectContaining({ threadId: "thread-1" }),
+    );
+  });
+
+  it("returns null and logs error on generic (non-23505) insert failure", async () => {
+    const insertSingle = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: "42P01", message: "relation does not exist" },
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSingle }));
+    const insert = vi.fn(() => ({ select: insertSelect }));
+    getDbClient.mockReturnValue({ from: vi.fn().mockReturnValue({ insert }) });
+
+    const { appendMessage } = await import("../chat-persistence");
+    const id = await appendMessage({
+      threadId: "thread-1",
+      role: "user",
+      content: "hello",
+      idempotencyKey: "test1234",
+    });
+
+    expect(id).toBeNull();
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "chat message insert failed",
+      expect.objectContaining({ error: "relation does not exist" }),
+    );
+  });
+});

--- a/apps/web/src/lib/server/chat-persistence.ts
+++ b/apps/web/src/lib/server/chat-persistence.ts
@@ -94,6 +94,15 @@ export async function appendMessage(params: {
   role: "user" | "assistant" | "system";
   content: string;
   metadata?: Record<string, unknown>;
+  /**
+   * Optional client-supplied dedup key. When two requests race with the
+   * same `(threadId, idempotencyKey)` pair, the partial unique index
+   * `idx_chat_messages_thread_idem` rejects the second insert with
+   * Postgres `23505` and we recover by returning the id of the row that
+   * already landed. Lets the client safely retry a failed send (network
+   * blip, double-click) without producing two transcript rows.
+   */
+  idempotencyKey?: string;
 }): Promise<string | null> {
   // Allow empty content when an attachment is the user's only payload.
   // (Empty assistant rows are still skipped — the streaming path only calls
@@ -111,16 +120,53 @@ export async function appendMessage(params: {
   if (params.metadata && Object.keys(params.metadata).length > 0) {
     insertRow["metadata"] = params.metadata;
   }
+  if (params.idempotencyKey) {
+    insertRow["idempotency_key"] = params.idempotencyKey;
+  }
   const { data, error } = await db
     .from("chat_messages")
     .insert(insertRow)
     .select("id")
     .single();
-  if (error || !data) {
+  if (error) {
+    // 23505 = unique_violation. Only the partial unique index on
+    // (thread_id, idempotency_key) can produce one for a chat_messages
+    // insert, so when the caller supplied a key we treat it as a replay:
+    // look up the original row and hand its id back to the caller. The
+    // attachment writer downstream depends on this so that attachments
+    // foreign-key to the *first* user message, not a duplicate.
+    if (error.code === "23505" && params.idempotencyKey) {
+      const { data: existing, error: lookupError } = await db
+        .from("chat_messages")
+        .select("id")
+        .eq("thread_id", params.threadId)
+        .eq("idempotency_key", params.idempotencyKey)
+        .maybeSingle();
+      if (!lookupError && existing) {
+        // Include the key in the replay log so ops can correlate a retry
+        // storm to a specific client request — the key is opaque and not
+        // a secret (it's client-minted; the partial unique index is the
+        // only thing that gives it meaning).
+        logServerEvent("info", "chat message idempotent replay", {
+          threadId: params.threadId,
+          role: params.role,
+          idempotencyKey: params.idempotencyKey,
+        });
+        return (existing as { id: string }).id;
+      }
+    }
     logServerEvent("error", "chat message insert failed", {
       threadId: params.threadId,
       role: params.role,
-      error: error?.message ?? "no row",
+      error: error.message,
+    });
+    return null;
+  }
+  if (!data) {
+    logServerEvent("error", "chat message insert failed", {
+      threadId: params.threadId,
+      role: params.role,
+      error: "no row",
     });
     return null;
   }

--- a/supabase/migrations/20260517170000_chat_messages_idempotency.sql
+++ b/supabase/migrations/20260517170000_chat_messages_idempotency.sql
@@ -1,0 +1,29 @@
+-- Migration: chat_messages_idempotency
+-- Purpose:   Add an opt-in idempotency_key column to chat_messages plus a
+--            partial unique index so that retrying the same client request
+--            (e.g. network blip mid-stream, user double-click on send) does
+--            not create duplicate user-message rows in a thread.
+--
+--            Mirrors the pattern established for analysis_jobs in migration
+--            005: a partial unique index on (thread_id, idempotency_key)
+--            WHERE idempotency_key IS NOT NULL means the constraint only
+--            applies to writes that opt into dedup, leaving legacy
+--            assistant-side inserts (which don't carry a key) unaffected.
+--
+-- Writers:   No data written. Schema-only.
+-- Rollback:
+--   begin;
+--   drop index if exists idx_chat_messages_thread_idem;
+--   alter table chat_messages drop column if exists idempotency_key;
+--   commit;
+
+begin;
+
+alter table chat_messages
+  add column if not exists idempotency_key text;
+
+create unique index if not exists idx_chat_messages_thread_idem
+  on chat_messages(thread_id, idempotency_key)
+  where idempotency_key is not null;
+
+commit;


### PR DESCRIPTION
## Summary

Phase 1.2 of the production-readiness plan in `docs/optimization-plan.md`. Prevents duplicate user-message rows when a chat POST is retried (network blip, double-click on send).

- **Migration**: `20260517170000_chat_messages_idempotency.sql` adds `idempotency_key text` column plus a partial unique index `idx_chat_messages_thread_idem` on `(thread_id, idempotency_key) WHERE idempotency_key IS NOT NULL`. Mirrors the analysis_jobs pattern in migration 005 — additive, no backfill needed, legacy rows excluded from the constraint.
- **`appendMessage`** accepts optional `idempotencyKey`. On Postgres `23505` unique_violation, it looks up the existing row by `(thread_id, idempotency_key)` and returns its id — so attachment writers downstream foreign-key to the first row, not a duplicate. When no key is supplied, 23505 is treated as a real failure (returns null + error log), never silently masked.
- **Chat route** parses optional `idempotencyKey` from the request body with the same 8-128 char bounds used by `AnalyzeRequestSchema` and `UploadFinalizeRequestSchema`, so clients can reuse a single id-minting helper across endpoints.

## Scope note

The original audit recommended adding idempotency to **both** `analysis_jobs` and `chat_messages`. After exploring the schema, `analysis_jobs` already has the full pattern (migration 005: partial unique index + `enqueue_analysis_job` security-definer RPC with `ON CONFLICT DO UPDATE SET id = id RETURNING *`). So this PR scopes to the real gap: `chat_messages`.

## Test plan

- [x] 6 new cases in `chat-persistence.test.ts`: insert with key, insert without key, 23505 recovery returns original id, 23505 without key surfaces as failure, lookup-after-23505 failure returns null, non-23505 surfaces as failure.
- [x] Full web vitest suite: 736 passed.
- [x] `pnpm run type-check`: clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 20 route files scanned, OK.
- [x] Reviewed by `contract-guardian` agent — safe to proceed.

## Notes

- No new RLS policy needed: `chat_messages` writes are service-role-only by design (no user-facing insert policy per migration 001:323), so app-level 23505 handling is the right layer.
- No new shared type required: `idempotencyKey` is request-side only and mirrors the existing optional field on `AnalyzeRequestSchema` / `UploadFinalizeRequestSchema`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_