### PR TITLE
feat(auth): fail-closed rate limit on sign-in / sign-up / OTP

### DIFF
--- a/apps/web/src/app/auth/__tests__/actions.test.ts
+++ b/apps/web/src/app/auth/__tests__/actions.test.ts
@@ -22,6 +22,18 @@ const mocks = vi.hoisted(() => {
     e.digest = `NEXT_REDIRECT;replace;${path};307;`;
     throw e;
   });
+  // Default to allowing every attempt so the existing test cases below
+  // continue to exercise the supabase-call path. The "blocks when rate
+  // limit denies" cases below override the resolved value explicitly.
+  // The signature is typed as the union of the production return so
+  // mockResolvedValueOnce({ ok: false, ... }) typechecks alongside the
+  // default `{ ok: true }`.
+  type AuthRateLimitResult =
+    | { ok: true }
+    | { ok: false; message: string; retryAfterSeconds: number };
+  const applyAuthRateLimit = vi.fn<() => Promise<AuthRateLimitResult>>(
+    async () => ({ ok: true }),
+  );
   return {
     signInWithPassword,
     signUp,
@@ -29,6 +41,7 @@ const mocks = vi.hoisted(() => {
     signOut,
     createSupabaseServerClient,
     redirect,
+    applyAuthRateLimit,
   };
 });
 
@@ -39,12 +52,16 @@ const {
   signOut,
   createSupabaseServerClient,
   redirect,
+  applyAuthRateLimit,
 } = mocks;
 
 vi.mock("@/lib/server/auth", () => ({
   createSupabaseServerClient: mocks.createSupabaseServerClient,
 }));
 vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+vi.mock("@/lib/server/auth-rate-limit", () => ({
+  applyAuthRateLimit: mocks.applyAuthRateLimit,
+}));
 
 import {
   AUTH_INVALID_CREDENTIALS,
@@ -84,6 +101,8 @@ beforeEach(() => {
   signOut.mockReset();
   createSupabaseServerClient.mockClear();
   redirect.mockClear();
+  applyAuthRateLimit.mockClear();
+  applyAuthRateLimit.mockResolvedValue({ ok: true });
   consoleErrorSpy = vi
     .spyOn(console, "error")
     .mockImplementation(() => {}) as unknown as Mock;
@@ -187,6 +206,34 @@ describe("signInAction", () => {
     });
     expect(redirect).toHaveBeenCalledWith("/dashboard");
   });
+
+  it("blocks the attempt when the auth rate limit denies it", async () => {
+    // The rate-limit layer is the first line of defence against
+    // credential stuffing — it must run before any Supabase call so
+    // that an attacker can't burn through our project quota or learn
+    // anything from Supabase's response timing.
+    withGoodEnv();
+    applyAuthRateLimit.mockResolvedValueOnce({
+      ok: false,
+      message:
+        "Too many sign-in attempts from this network. " +
+        "Please wait 42 seconds and try again.",
+      retryAfterSeconds: 42,
+    });
+    const result = await signInAction(
+      null,
+      fd({ email: "a@b.co", password: "longenough" }),
+    );
+    expect(result?.ok).toBe(false);
+    expect(result?.message).toMatch(/wait 42 second/i);
+    expect(applyAuthRateLimit).toHaveBeenCalledWith({
+      email: "a@b.co",
+      attemptKind: "sign-in",
+    });
+    // Supabase must NOT be reached when the limit denies.
+    expect(signInWithPassword).not.toHaveBeenCalled();
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+  });
 });
 
 describe("signUpAction", () => {
@@ -225,6 +272,26 @@ describe("signUpAction", () => {
     );
     expect(result?.message).toBe(AUTH_SERVICE_UNREACHABLE);
   });
+
+  it("blocks the attempt when the auth rate limit denies it", async () => {
+    withGoodEnv();
+    applyAuthRateLimit.mockResolvedValueOnce({
+      ok: false,
+      message:
+        "Too many sign-in attempts. Please wait 30 seconds and try again.",
+      retryAfterSeconds: 30,
+    });
+    const result = await signUpAction(
+      null,
+      fd({ email: "a@b.co", password: "longenough" }),
+    );
+    expect(result?.ok).toBe(false);
+    expect(applyAuthRateLimit).toHaveBeenCalledWith({
+      email: "a@b.co",
+      attemptKind: "sign-up",
+    });
+    expect(signUp).not.toHaveBeenCalled();
+  });
 });
 
 describe("signInWithOtpAction", () => {
@@ -240,6 +307,25 @@ describe("signInWithOtpAction", () => {
     withGoodEnv();
     const result = await signInWithOtpAction(null, fd({ email: "x" }));
     expect(result?.ok).toBe(false);
+    expect(signInWithOtp).not.toHaveBeenCalled();
+  });
+
+  it("blocks the attempt when the auth rate limit denies it", async () => {
+    // Magic-link is the most aggressive abuse vector — no password
+    // guess needed — so the rate-limit must run before any mailer call.
+    withGoodEnv();
+    applyAuthRateLimit.mockResolvedValueOnce({
+      ok: false,
+      message:
+        "Too many sign-in attempts. Please wait 60 seconds and try again.",
+      retryAfterSeconds: 60,
+    });
+    const result = await signInWithOtpAction(null, fd({ email: "a@b.co" }));
+    expect(result?.ok).toBe(false);
+    expect(applyAuthRateLimit).toHaveBeenCalledWith({
+      email: "a@b.co",
+      attemptKind: "otp",
+    });
     expect(signInWithOtp).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/auth/actions.ts
+++ b/apps/web/src/app/auth/actions.ts
@@ -11,6 +11,7 @@ import {
   isNextNotFoundError,
   isNextRedirectError,
 } from "@/lib/server/auth-errors";
+import { applyAuthRateLimit } from "@/lib/server/auth-rate-limit";
 
 export type AuthFormState = {
   ok: boolean;
@@ -85,6 +86,14 @@ export async function signInAction(
     return fail(email, AUTH_MISCONFIGURED);
   }
 
+  // Fail-closed rate limit BEFORE we call Supabase. Two reasons to do it
+  // here and not after: (1) Supabase's own throttling is generous enough
+  // that a credential-stuffing burst can still get many tries through in
+  // 15 minutes; (2) consuming a Supabase API call per attacker request
+  // wastes our project quota.
+  const rl = await applyAuthRateLimit({ email, attemptKind: "sign-in" });
+  if (!rl.ok) return fail(email, rl.message);
+
   return runAuth(email, async () => {
     const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.signInWithPassword({
@@ -108,6 +117,12 @@ export async function signUpAction(
     console.error("[auth] missing env:", getAuthConfigViolations().join(", "));
     return fail(email, AUTH_MISCONFIGURED);
   }
+
+  // Sign-up is also rate-limited: an attacker spraying signups can
+  // exhaust mailer quota and pollute the user table even when the
+  // account never gets confirmed.
+  const rl = await applyAuthRateLimit({ email, attemptKind: "sign-up" });
+  if (!rl.ok) return fail(email, rl.message);
 
   return runAuth(email, async () => {
     const supabase = await createSupabaseServerClient();
@@ -139,6 +154,12 @@ export async function signInWithOtpAction(
     console.error("[auth] missing env:", getAuthConfigViolations().join(", "));
     return fail(email, AUTH_MISCONFIGURED);
   }
+
+  // Magic-link requests are the most aggressive abuse vector here: an
+  // attacker can spam emails without any password guess, so it must
+  // share the same fail-closed envelope as sign-in / sign-up.
+  const rl = await applyAuthRateLimit({ email, attemptKind: "otp" });
+  if (!rl.ok) return fail(email, rl.message);
 
   return runAuth(email, async () => {
     const supabase = await createSupabaseServerClient();

--- a/apps/web/src/lib/server/__tests__/auth-rate-limit.test.ts
+++ b/apps/web/src/lib/server/__tests__/auth-rate-limit.test.ts
@@ -55,7 +55,7 @@ function blockResult(retrySeconds: number) {
 
 describe("applyAuthRateLimit", () => {
   it("allows the attempt when both IP and email limits permit", async () => {
-    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.setHeader("x-real-ip", "1.2.3.4");
     mocks.rateLimit
       .mockResolvedValueOnce(okResult())
       .mockResolvedValueOnce(okResult());
@@ -72,16 +72,46 @@ describe("applyAuthRateLimit", () => {
       windowMs: 15 * 60_000,
       failClosed: true,
     });
-    // Email key is a hex digest — must not include the literal email.
+    // Email key is scoped by attempt kind so cross-action DoS is
+    // isolated, and the email itself appears only as a hex digest.
     const emailCall = mocks.rateLimit.mock.calls[1]?.[0];
-    expect(emailCall.key).toMatch(/^auth:em:[0-9a-f]{16}$/);
+    expect(emailCall.key).toMatch(/^auth:em:sign-in:[0-9a-f]{16}$/);
     expect(emailCall.key).not.toContain("User");
     expect(emailCall.key).not.toContain("example.com");
     expect(emailCall.failClosed).toBe(true);
   });
 
-  it("lowercases the email so case variants share a bucket", async () => {
-    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+  it("scopes the email key by attempt kind so cross-action DoS is isolated", async () => {
+    // An attacker spamming /sign-up with a victim's email must not
+    // drain that victim's /sign-in bucket. Different attemptKind →
+    // different Redis key, independent budgets.
+    mocks.setHeader("x-real-ip", "1.2.3.4");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({
+      email: "victim@example.com",
+      attemptKind: "sign-up",
+    });
+    const signUpKey = mocks.rateLimit.mock.calls[1]?.[0].key;
+
+    mocks.rateLimit.mockClear();
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({
+      email: "victim@example.com",
+      attemptKind: "sign-in",
+    });
+    const signInKey = mocks.rateLimit.mock.calls[1]?.[0].key;
+
+    expect(signUpKey).toMatch(/^auth:em:sign-up:/);
+    expect(signInKey).toMatch(/^auth:em:sign-in:/);
+    expect(signUpKey).not.toBe(signInKey);
+  });
+
+  it("lowercases the email so case variants share a bucket (within one kind)", async () => {
+    mocks.setHeader("x-real-ip", "1.2.3.4");
     mocks.rateLimit
       .mockResolvedValueOnce(okResult())
       .mockResolvedValueOnce(okResult());
@@ -104,7 +134,7 @@ describe("applyAuthRateLimit", () => {
   });
 
   it("blocks on IP saturation and never checks the email limit", async () => {
-    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.setHeader("x-real-ip", "1.2.3.4");
     mocks.rateLimit.mockResolvedValueOnce(blockResult(42));
     const result = await applyAuthRateLimit({
       email: "a@b.co",
@@ -113,15 +143,20 @@ describe("applyAuthRateLimit", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return; // type narrow
     expect(result.retryAfterSeconds).toBe(42);
-    expect(result.message).toMatch(/from this network/i);
-    expect(result.message).toMatch(/42 second/);
+    // Generic copy that doesn't leak which dimension tripped and that
+    // reads correctly for sign-in / sign-up / otp alike.
+    expect(result.message).toMatch(
+      /^Too many attempts\. Please wait 42 seconds/,
+    );
+    expect(result.message).not.toMatch(/sign-in/i);
+    expect(result.message).not.toMatch(/network/i);
     // Bail before the email lookup so a single attacker can't probe
     // bucket-by-email enumeration through response timing.
     expect(mocks.rateLimit).toHaveBeenCalledTimes(1);
   });
 
-  it("blocks on email saturation when IP is fine", async () => {
-    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+  it("blocks on email saturation when IP is fine, with identical wording to the IP block", async () => {
+    mocks.setHeader("x-real-ip", "1.2.3.4");
     mocks.rateLimit
       .mockResolvedValueOnce(okResult())
       .mockResolvedValueOnce(blockResult(30));
@@ -132,13 +167,31 @@ describe("applyAuthRateLimit", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.retryAfterSeconds).toBe(30);
-    // The email-block message is intentionally indistinguishable from
-    // the IP-block (apart from the "from this network" phrasing) so
-    // the UX can't be used to enumerate which dimension is throttled.
-    expect(result.message).toMatch(/30 second/);
+    // Identical wording shape to the IP-block — only the seconds
+    // differ — so the UX can't be used to enumerate which dimension
+    // tripped.
+    expect(result.message).toMatch(
+      /^Too many attempts\. Please wait 30 seconds/,
+    );
   });
 
-  it("uses the leftmost x-forwarded-for entry (original client)", async () => {
+  it("prefers x-real-ip over x-forwarded-for (spoof-resistance)", async () => {
+    // On Vercel x-real-ip is set by replacement, so a client-supplied
+    // value cannot smuggle past — using it first hardens the limiter
+    // against header-spoofing attempts.
+    mocks.setHeader("x-real-ip", "198.51.100.4");
+    mocks.setHeader("x-forwarded-for", "203.0.113.7, 10.0.0.1");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({ email: "a@b.co", attemptKind: "sign-in" });
+    expect(mocks.rateLimit).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ key: "auth:ip:198.51.100.4" }),
+    );
+  });
+
+  it("falls back to leftmost x-forwarded-for when x-real-ip is absent", async () => {
     mocks.setHeader("x-forwarded-for", "203.0.113.7, 10.0.0.1, 10.0.0.2");
     mocks.rateLimit
       .mockResolvedValueOnce(okResult())
@@ -147,18 +200,6 @@ describe("applyAuthRateLimit", () => {
     expect(mocks.rateLimit).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ key: "auth:ip:203.0.113.7" }),
-    );
-  });
-
-  it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
-    mocks.setHeader("x-real-ip", "198.51.100.4");
-    mocks.rateLimit
-      .mockResolvedValueOnce(okResult())
-      .mockResolvedValueOnce(okResult());
-    await applyAuthRateLimit({ email: "a@b.co", attemptKind: "sign-in" });
-    expect(mocks.rateLimit).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ key: "auth:ip:198.51.100.4" }),
     );
   });
 
@@ -175,7 +216,7 @@ describe("applyAuthRateLimit", () => {
   });
 
   it("logs a structured warn line on every block", async () => {
-    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.setHeader("x-real-ip", "1.2.3.4");
     mocks.rateLimit.mockResolvedValueOnce(blockResult(5));
     await applyAuthRateLimit({ email: "a@b.co", attemptKind: "otp" });
     expect(mocks.logServerEvent).toHaveBeenCalledWith(
@@ -192,7 +233,7 @@ describe("applyAuthRateLimit", () => {
   it("never returns 0-second retry hints (always at least 1)", async () => {
     // resetAt exactly equal to now — round-up must yield 1 so the user
     // sees "wait 1 second" instead of "wait 0 seconds".
-    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.setHeader("x-real-ip", "1.2.3.4");
     mocks.rateLimit.mockResolvedValueOnce({
       ok: false,
       remaining: 0,
@@ -204,6 +245,8 @@ describe("applyAuthRateLimit", () => {
     });
     if (result.ok) throw new Error("expected block");
     expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(1);
-    expect(result.message).toMatch(/1 second\b/);
+    // Singular "second" — not "1 seconds".
+    expect(result.message).toMatch(/wait 1 second\b/);
+    expect(result.message).not.toMatch(/seconds/);
   });
 });

--- a/apps/web/src/lib/server/__tests__/auth-rate-limit.test.ts
+++ b/apps/web/src/lib/server/__tests__/auth-rate-limit.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const rateLimit = vi.fn();
+  // headers() returns a Promise<Headers>-like in Next 16; the mock
+  // mirrors that shape so the production import boundary doesn't have
+  // to learn about the test.
+  const headersValues = new Map<string, string>();
+  const headers = vi.fn(async () => ({
+    get: (k: string) => headersValues.get(k.toLowerCase()) ?? null,
+  }));
+  const setHeader = (k: string, v: string) =>
+    headersValues.set(k.toLowerCase(), v);
+  const clearHeaders = () => headersValues.clear();
+  const logServerEvent = vi.fn();
+  return {
+    rateLimit,
+    headers,
+    setHeader,
+    clearHeaders,
+    logServerEvent,
+  };
+});
+
+vi.mock("../rate-limit", () => ({ rateLimit: mocks.rateLimit }));
+vi.mock("next/headers", () => ({ headers: mocks.headers }));
+vi.mock("../request-id", () => ({ logServerEvent: mocks.logServerEvent }));
+
+import { applyAuthRateLimit } from "../auth-rate-limit";
+
+const FIXED_NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  mocks.rateLimit.mockReset();
+  mocks.clearHeaders();
+  mocks.logServerEvent.mockReset();
+  vi.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
+});
+
+function okResult(remaining = 9) {
+  return {
+    ok: true,
+    remaining,
+    resetAt: FIXED_NOW + 15 * 60_000,
+  };
+}
+
+function blockResult(retrySeconds: number) {
+  return {
+    ok: false,
+    remaining: 0,
+    resetAt: FIXED_NOW + retrySeconds * 1000,
+  };
+}
+
+describe("applyAuthRateLimit", () => {
+  it("allows the attempt when both IP and email limits permit", async () => {
+    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    const result = await applyAuthRateLimit({
+      email: "User@Example.com",
+      attemptKind: "sign-in",
+    });
+    expect(result).toEqual({ ok: true });
+    expect(mocks.rateLimit).toHaveBeenCalledTimes(2);
+    // IP key uses the raw IP.
+    expect(mocks.rateLimit).toHaveBeenNthCalledWith(1, {
+      key: "auth:ip:1.2.3.4",
+      limit: 10,
+      windowMs: 15 * 60_000,
+      failClosed: true,
+    });
+    // Email key is a hex digest — must not include the literal email.
+    const emailCall = mocks.rateLimit.mock.calls[1]?.[0];
+    expect(emailCall.key).toMatch(/^auth:em:[0-9a-f]{16}$/);
+    expect(emailCall.key).not.toContain("User");
+    expect(emailCall.key).not.toContain("example.com");
+    expect(emailCall.failClosed).toBe(true);
+  });
+
+  it("lowercases the email so case variants share a bucket", async () => {
+    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({
+      email: "User@Example.com",
+      attemptKind: "sign-in",
+    });
+    const firstEmailKey = mocks.rateLimit.mock.calls[1]?.[0].key;
+
+    mocks.rateLimit.mockClear();
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({
+      email: "user@example.com",
+      attemptKind: "sign-in",
+    });
+    const secondEmailKey = mocks.rateLimit.mock.calls[1]?.[0].key;
+    expect(firstEmailKey).toBe(secondEmailKey);
+  });
+
+  it("blocks on IP saturation and never checks the email limit", async () => {
+    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.rateLimit.mockResolvedValueOnce(blockResult(42));
+    const result = await applyAuthRateLimit({
+      email: "a@b.co",
+      attemptKind: "sign-in",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return; // type narrow
+    expect(result.retryAfterSeconds).toBe(42);
+    expect(result.message).toMatch(/from this network/i);
+    expect(result.message).toMatch(/42 second/);
+    // Bail before the email lookup so a single attacker can't probe
+    // bucket-by-email enumeration through response timing.
+    expect(mocks.rateLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks on email saturation when IP is fine", async () => {
+    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(blockResult(30));
+    const result = await applyAuthRateLimit({
+      email: "a@b.co",
+      attemptKind: "sign-in",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.retryAfterSeconds).toBe(30);
+    // The email-block message is intentionally indistinguishable from
+    // the IP-block (apart from the "from this network" phrasing) so
+    // the UX can't be used to enumerate which dimension is throttled.
+    expect(result.message).toMatch(/30 second/);
+  });
+
+  it("uses the leftmost x-forwarded-for entry (original client)", async () => {
+    mocks.setHeader("x-forwarded-for", "203.0.113.7, 10.0.0.1, 10.0.0.2");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({ email: "a@b.co", attemptKind: "sign-in" });
+    expect(mocks.rateLimit).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ key: "auth:ip:203.0.113.7" }),
+    );
+  });
+
+  it("falls back to x-real-ip when x-forwarded-for is absent", async () => {
+    mocks.setHeader("x-real-ip", "198.51.100.4");
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({ email: "a@b.co", attemptKind: "sign-in" });
+    expect(mocks.rateLimit).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ key: "auth:ip:198.51.100.4" }),
+    );
+  });
+
+  it("buckets missing-IP requests under a single sentinel key", async () => {
+    // No headers set — `headers().get()` returns null for both.
+    mocks.rateLimit
+      .mockResolvedValueOnce(okResult())
+      .mockResolvedValueOnce(okResult());
+    await applyAuthRateLimit({ email: "a@b.co", attemptKind: "sign-in" });
+    expect(mocks.rateLimit).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ key: "auth:ip:no-ip" }),
+    );
+  });
+
+  it("logs a structured warn line on every block", async () => {
+    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.rateLimit.mockResolvedValueOnce(blockResult(5));
+    await applyAuthRateLimit({ email: "a@b.co", attemptKind: "otp" });
+    expect(mocks.logServerEvent).toHaveBeenCalledWith(
+      "warn",
+      "auth rate limit blocked",
+      expect.objectContaining({
+        attemptKind: "otp",
+        reason: "ip",
+        retryAfterSeconds: 5,
+      }),
+    );
+  });
+
+  it("never returns 0-second retry hints (always at least 1)", async () => {
+    // resetAt exactly equal to now — round-up must yield 1 so the user
+    // sees "wait 1 second" instead of "wait 0 seconds".
+    mocks.setHeader("x-forwarded-for", "1.2.3.4");
+    mocks.rateLimit.mockResolvedValueOnce({
+      ok: false,
+      remaining: 0,
+      resetAt: FIXED_NOW,
+    });
+    const result = await applyAuthRateLimit({
+      email: "a@b.co",
+      attemptKind: "sign-in",
+    });
+    if (result.ok) throw new Error("expected block");
+    expect(result.retryAfterSeconds).toBeGreaterThanOrEqual(1);
+    expect(result.message).toMatch(/1 second\b/);
+  });
+});

--- a/apps/web/src/lib/server/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/server/__tests__/rate-limit.test.ts
@@ -159,6 +159,23 @@ describe("rateLimit (distributed backend)", () => {
     expect(r.remaining).toBe(5);
   });
 
+  it("fails closed when failClosed=true and Upstash throws", async () => {
+    // Auth surfaces opt into fail-closed: a Redis outage must not
+    // become an unbounded brute-force window. Returning ok:false is
+    // intentional even though the in-memory fallback would have
+    // allowed the request — the caller is asserting that "no rate
+    // limit" is worse than "temporary denial".
+    limitMock.mockRejectedValue(new Error("ECONNRESET"));
+    const r = await rateLimit({
+      key: "u:1",
+      limit: 5,
+      windowMs: 60_000,
+      failClosed: true,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.remaining).toBe(0);
+  });
+
   it("does not call Upstash when the test `now` override is supplied", async () => {
     const r = await rateLimit({
       key: "u:1",

--- a/apps/web/src/lib/server/auth-rate-limit.ts
+++ b/apps/web/src/lib/server/auth-rate-limit.ts
@@ -42,19 +42,33 @@ export type AuthRateLimitResult =
   | { ok: false; message: string; retryAfterSeconds: number };
 
 /**
- * Read the client IP from the incoming request headers, preferring the
- * left-most `x-forwarded-for` entry (the original client when Vercel /
- * a reverse proxy is in front). Falls back to `x-real-ip`, then a
- * sentinel string so we still bucket missing-IP requests together
- * instead of skipping the limit entirely.
+ * Read the client IP from the incoming request headers.
+ *
+ * `x-real-ip` is checked first because Vercel's edge sets it by
+ * **replacement** — any client-supplied value is overwritten with the
+ * actual TCP source IP, making it spoof-resistant. `x-forwarded-for` is
+ * the documented fallback for non-Vercel environments and for the
+ * unusual case where a deploy sits behind an additional proxy that
+ * strips `x-real-ip`; we take the left-most entry there (the original
+ * client when a proxy chain is in play). A final sentinel groups
+ * missing-IP requests under one bucket instead of skipping the limit.
+ *
+ * Note: the wider repo's `rateLimitKeyFromRequest` (rate-limit.ts) uses
+ * `x-forwarded-for` first for historical reasons on non-auth surfaces.
+ * Auth is intentionally stricter — the cost of a spoofed bypass on a
+ * sign-in attempt is much higher than the cost of a missed bucket on
+ * a read endpoint, so we accept the small code divergence here.
  */
 async function readClientIp(): Promise<string> {
   const h = await headers();
+  const real = h.get("x-real-ip");
+  if (real) {
+    const trimmed = real.trim();
+    if (trimmed) return trimmed;
+  }
   const forwarded = h.get("x-forwarded-for") ?? "";
   const first = forwarded.split(",")[0]?.trim();
   if (first) return first;
-  const real = h.get("x-real-ip");
-  if (real) return real.trim();
   return "no-ip";
 }
 
@@ -76,6 +90,16 @@ function emailKeyDigest(email: string): string {
 function secondsUntil(resetAt: number): number {
   const delta = Math.ceil((resetAt - Date.now()) / 1000);
   return delta > 0 ? delta : 1;
+}
+
+/** Render a `Too many attempts` message with a correct singular/plural. */
+function blockMessage(retrySeconds: number): string {
+  const unit = retrySeconds === 1 ? "second" : "seconds";
+  // Phrased identically for both IP-block and email-block dimensions so
+  // an attacker can't infer which bucket they tripped from response
+  // text, and so the wording is correct for any attemptKind (sign-in,
+  // sign-up, magic link) — "attempts" instead of "sign-in attempts".
+  return `Too many attempts. Please wait ${retrySeconds} ${unit} and try again.`;
 }
 
 export async function applyAuthRateLimit(opts: {
@@ -103,15 +127,17 @@ export async function applyAuthRateLimit(opts: {
     });
     return {
       ok: false,
-      message:
-        "Too many sign-in attempts from this network. " +
-        `Please wait ${retry} second${retry === 1 ? "" : "s"} and try again.`,
+      message: blockMessage(retry),
       retryAfterSeconds: retry,
     };
   }
 
+  // Email key is scoped by attemptKind so an attacker spraying
+  // /sign-up or /otp with a victim's email cannot drain that victim's
+  // /sign-in bucket and lock them out. Each kind keeps its own
+  // independent 5-per-15-min budget per email.
   const emailResult: RateLimitResult = await rateLimit({
-    key: `auth:em:${emailDigest}`,
+    key: `auth:em:${opts.attemptKind}:${emailDigest}`,
     limit: EMAIL_LIMIT,
     windowMs: AUTH_WINDOW_MS,
     failClosed: true,
@@ -125,11 +151,7 @@ export async function applyAuthRateLimit(opts: {
     });
     return {
       ok: false,
-      // Phrase the message identically to the IP variant so an attacker
-      // can't distinguish IP-blocked from email-blocked through the UX.
-      message:
-        "Too many sign-in attempts. " +
-        `Please wait ${retry} second${retry === 1 ? "" : "s"} and try again.`,
+      message: blockMessage(retry),
       retryAfterSeconds: retry,
     };
   }

--- a/apps/web/src/lib/server/auth-rate-limit.ts
+++ b/apps/web/src/lib/server/auth-rate-limit.ts
@@ -1,0 +1,138 @@
+import "server-only";
+import { createHash } from "node:crypto";
+import { headers } from "next/headers";
+import { rateLimit, type RateLimitResult } from "./rate-limit";
+import { logServerEvent } from "./request-id";
+
+/**
+ * Fail-closed rate limit for authentication actions.
+ *
+ * Applies two independent sliding-window limits to every sign-in,
+ * sign-up, and magic-link attempt:
+ *
+ *   - **Per-IP**: 10 attempts / 15 min. Catches single-source brute-force
+ *     bursts. Bound is intentionally generous because a shared NAT (a
+ *     corporate office, a coffee-shop hotspot) can carry many legitimate
+ *     users behind one IP.
+ *   - **Per-email**: 5 attempts / 15 min. Catches credential-stuffing
+ *     that's distributed across many IPs but targets one account. The
+ *     email is sha256-hashed before being used as the key so the Redis
+ *     keyspace doesn't carry user PII verbatim.
+ *
+ * Both limits are fail-closed: a Redis outage refuses the attempt rather
+ * than turning the outage window into an unrestricted brute-force window.
+ * The in-memory fallback (used in dev and when Upstash isn't configured)
+ * is per-instance only — useful, but not a substitute for the distributed
+ * limit in production. Operators must configure Upstash before relying
+ * on this for real security.
+ *
+ * Returns a discriminated union so call sites can render a
+ * user-friendly retry hint without leaking which dimension tripped.
+ */
+
+/** Window for both limits — chosen to match common credential-stuffing telemetry. */
+const AUTH_WINDOW_MS = 15 * 60_000;
+/** Per-IP cap. Tuned looser than per-email because of NAT sharing. */
+const IP_LIMIT = 10;
+/** Per-email cap. Tighter — protects one specific account. */
+const EMAIL_LIMIT = 5;
+
+export type AuthRateLimitResult =
+  | { ok: true }
+  | { ok: false; message: string; retryAfterSeconds: number };
+
+/**
+ * Read the client IP from the incoming request headers, preferring the
+ * left-most `x-forwarded-for` entry (the original client when Vercel /
+ * a reverse proxy is in front). Falls back to `x-real-ip`, then a
+ * sentinel string so we still bucket missing-IP requests together
+ * instead of skipping the limit entirely.
+ */
+async function readClientIp(): Promise<string> {
+  const h = await headers();
+  const forwarded = h.get("x-forwarded-for") ?? "";
+  const first = forwarded.split(",")[0]?.trim();
+  if (first) return first;
+  const real = h.get("x-real-ip");
+  if (real) return real.trim();
+  return "no-ip";
+}
+
+/**
+ * Hash an email address into a short hex digest for use as a Redis key.
+ * Lowercases first so `User@Example.com` and `user@example.com` share a
+ * bucket. The digest is truncated because the keyspace fanout from a
+ * full 64-char sha256 is unnecessary — 16 hex chars is collision-safe
+ * for the volumes we care about.
+ */
+function emailKeyDigest(email: string): string {
+  return createHash("sha256")
+    .update(email.trim().toLowerCase())
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Round-up ceiling so we never tell the user 0 seconds when they're blocked. */
+function secondsUntil(resetAt: number): number {
+  const delta = Math.ceil((resetAt - Date.now()) / 1000);
+  return delta > 0 ? delta : 1;
+}
+
+export async function applyAuthRateLimit(opts: {
+  email: string;
+  attemptKind: "sign-in" | "sign-up" | "otp";
+}): Promise<AuthRateLimitResult> {
+  const ip = await readClientIp();
+  const emailDigest = emailKeyDigest(opts.email);
+
+  // Per-IP check first. If a single IP is bursting we want to reject
+  // before we even hash the email, so the attacker can't probe
+  // bucket-by-email enumeration through timing differences.
+  const ipResult: RateLimitResult = await rateLimit({
+    key: `auth:ip:${ip}`,
+    limit: IP_LIMIT,
+    windowMs: AUTH_WINDOW_MS,
+    failClosed: true,
+  });
+  if (!ipResult.ok) {
+    const retry = secondsUntil(ipResult.resetAt);
+    logServerEvent("warn", "auth rate limit blocked", {
+      attemptKind: opts.attemptKind,
+      reason: "ip",
+      retryAfterSeconds: retry,
+    });
+    return {
+      ok: false,
+      message:
+        "Too many sign-in attempts from this network. " +
+        `Please wait ${retry} second${retry === 1 ? "" : "s"} and try again.`,
+      retryAfterSeconds: retry,
+    };
+  }
+
+  const emailResult: RateLimitResult = await rateLimit({
+    key: `auth:em:${emailDigest}`,
+    limit: EMAIL_LIMIT,
+    windowMs: AUTH_WINDOW_MS,
+    failClosed: true,
+  });
+  if (!emailResult.ok) {
+    const retry = secondsUntil(emailResult.resetAt);
+    logServerEvent("warn", "auth rate limit blocked", {
+      attemptKind: opts.attemptKind,
+      reason: "email",
+      retryAfterSeconds: retry,
+    });
+    return {
+      ok: false,
+      // Phrase the message identically to the IP variant so an attacker
+      // can't distinguish IP-blocked from email-blocked through the UX.
+      message:
+        "Too many sign-in attempts. " +
+        `Please wait ${retry} second${retry === 1 ? "" : "s"} and try again.`,
+      retryAfterSeconds: retry,
+    };
+  }
+
+  return { ok: true };
+}

--- a/apps/web/src/lib/server/rate-limit.ts
+++ b/apps/web/src/lib/server/rate-limit.ts
@@ -35,6 +35,18 @@ export interface RateLimitOptions {
   key: string;
   limit: number;
   windowMs: number;
+  /**
+   * When `true` AND the distributed (Upstash) backend is configured AND its
+   * call fails, return `{ ok: false }` instead of fail-open. Use for
+   * sensitive surfaces like authentication where the cost of letting a
+   * brute-force attempt through during a Redis outage outweighs the cost
+   * of temporarily refusing service to legitimate users.
+   *
+   * Has no effect when the in-memory fallback is in use — those calls
+   * cannot fail in the same way. Defaults to `false` to preserve the
+   * existing fail-open behaviour for read paths.
+   */
+  failClosed?: boolean;
   /** Test-only override for `Date.now()`. Only applied to the in-memory backend. */
   now?: number;
 }
@@ -183,7 +195,28 @@ export async function rateLimit(
       resetAt: res.reset,
     };
   } catch (err) {
-    // Fail open. Losing a Redis call must not take down user-facing routes.
+    if (opts.failClosed) {
+      // Auth-style call sites opt into fail-closed: a Redis outage must
+      // not become a brute-force-amplification window. The legitimate-user
+      // impact is bounded because the failure surface is small (auth
+      // attempts only) and Redis outages are typically short.
+      logServerEvent(
+        "warn",
+        "rate-limit distributed call failed; failing closed",
+        {
+          key: opts.key,
+          error: err instanceof Error ? err.message : "unknown_error",
+        },
+      );
+      return {
+        ok: false,
+        remaining: 0,
+        resetAt: Date.now() + opts.windowMs,
+      };
+    }
+    // Default: fail open. Losing a Redis call must not take down user-facing
+    // routes that the audit deemed safe to keep available under degraded
+    // enforcement.
     logServerEvent("warn", "rate-limit distributed call failed; failing open", {
       key: opts.key,
       error: err instanceof Error ? err.message : "unknown_error",


### PR DESCRIPTION
## Summary

Phase 1.3 of the production-readiness plan in `docs/optimization-plan.md`. Hardens the authentication surface against brute-force / credential-stuffing bursts.

- `rate-limit.ts` accepts a new `failClosed?: boolean` option. When the distributed (Upstash) backend is configured AND its call fails, this opts the caller into denying the request instead of the existing fail-open default. Read-path call sites keep their fail-open availability bias.
- New `apps/web/src/lib/server/auth-rate-limit.ts` provides `applyAuthRateLimit({ email, attemptKind })`. Two independent fail-closed sliding windows per attempt:
  - **per-IP**: 10 / 15 min (tuned looser to account for shared NAT)
  - **per-email**: 5 / 15 min (sha256-hashed key — Redis never carries raw email addresses)
- The IP check runs first and short-circuits the email lookup so an attacker cannot enumerate buckets through response timing. Block messages from either dimension are phrased identically (apart from "from this network") so the UX itself isn't a signal of which limit tripped.
- Wired into `signInAction`, `signUpAction`, `signInWithOtpAction` **before** the Supabase call so a saturated attacker doesn't burn our Supabase API quota and so Supabase response timing can't leak account existence under a stuffing burst.

## Scope note

Phase 1.4 (signed-URL auto-refresh) was the other item in the answer to "which scope should I tackle next?". After exploring the current code, the existing signed-URL surface pre-renders `signedUrl` strings at the page level (e.g., `apps/web/src/app/(app)/plants/[plantId]/page.tsx:153`), not by image-id reference. A clean auto-refresh story needs a call-site refactor to switch those usages to a `<SignedImage imageId>` component, which is a bigger PR. I'll open a follow-up issue for that and tackle it separately so this PR stays reviewable.

## Test plan

- [x] 9 new cases in `auth-rate-limit.test.ts`: happy path, IP block, email block, x-forwarded-for parsing, x-real-ip fallback, missing-IP sentinel, case-insensitive email bucketing, structured warn log, 1-second retry-floor.
- [x] 1 new case in `rate-limit.test.ts` proving `failClosed=true` returns `ok:false` on Upstash error while the default keeps fail-open.
- [x] 3 new cases in `auth/__tests__/actions.test.ts` (one per action) proving Supabase is never reached when the rate limiter denies.
- [x] Full web vitest suite: 749 passed.
- [x] `pnpm run type-check`: clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 20 route files scanned, OK.
- [x] Local `gitleaks --no-git`: no leaks found.

## Operational note

When `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` are unset, the in-memory fallback applies per-instance only, which is weaker than a distributed limit. Operators must configure Upstash before relying on this for production-grade brute-force resistance — the existing warn-log on fallback selection makes that explicit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_