### PR TITLE
feat(uploads): signed-URL auto-refresh endpoint + &lt;SignedImage&gt;

### DIFF
--- a/apps/web/src/app/api/uploads/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/uploads/refresh/__tests__/route.test.ts
@@ -84,6 +84,31 @@ describe("POST /api/uploads/refresh", () => {
   });
 
   it.each([
+    ["null", "null"],
+    ["a top-level number", "42"],
+    ["a top-level string", '"hi"'],
+    ["a top-level array", "[1,2,3]"],
+  ])(
+    "returns 400 (not a TypeError 500) when the body is %s",
+    async (_label, raw) => {
+      // request.json() succeeds for any valid JSON value — primitives
+      // and arrays included — but only an object can carry our named
+      // fields. Without the shape guard, body.plantId would throw on
+      // null and the route would return an unhandled 500.
+      getServerSession.mockResolvedValue(SESSION_OK);
+      const req = new NextRequest("http://localhost/api/uploads/refresh", {
+        method: "POST",
+        body: raw,
+        headers: { "content-type": "application/json" },
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(400);
+      expect((await res.json()).error).toMatch(/JSON object/);
+      expect(signPlantImageUrl).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
     ["plantId", { imageId: "i1" }],
     ["imageId", { plantId: "p1" }],
   ])("returns 400 when %s is missing", async (_field, body) => {

--- a/apps/web/src/app/api/uploads/refresh/__tests__/route.test.ts
+++ b/apps/web/src/app/api/uploads/refresh/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+const getServerSession = vi.fn();
+const getServerUser = vi.fn();
+const signPlantImageUrl = vi.fn();
+const rateLimit = vi.fn();
+const rateLimitKeyFromRequest = vi.fn();
+const logServerEvent = vi.fn();
+
+vi.mock("@/lib/server/auth", () => ({
+  getServerSession: (...args: unknown[]) => getServerSession(...args),
+  getServerUser: (...args: unknown[]) => getServerUser(...args),
+}));
+vi.mock("@/lib/server/plants", () => ({
+  signPlantImageUrl: (...args: unknown[]) => signPlantImageUrl(...args),
+}));
+vi.mock("@/lib/server/rate-limit", () => ({
+  rateLimit: (...args: unknown[]) => rateLimit(...args),
+  rateLimitKeyFromRequest: (...args: unknown[]) =>
+    rateLimitKeyFromRequest(...args),
+}));
+vi.mock("@/lib/server/request-id", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/server/request-id")
+  >("@/lib/server/request-id");
+  return {
+    ...actual,
+    logServerEvent: (...args: unknown[]) => logServerEvent(...args),
+  };
+});
+
+import { POST } from "../route";
+
+function jsonRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/uploads/refresh", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const SESSION_OK = { user: { id: "u1" } } as const;
+
+describe("POST /api/uploads/refresh", () => {
+  beforeEach(() => {
+    (getServerSession as Mock).mockReset();
+    (getServerUser as Mock).mockReset();
+    (signPlantImageUrl as Mock).mockReset();
+    (rateLimit as Mock).mockReset();
+    (rateLimitKeyFromRequest as Mock).mockReset();
+    (logServerEvent as Mock).mockReset();
+    rateLimit.mockResolvedValue({ ok: true });
+    rateLimitKeyFromRequest.mockReturnValue("k");
+    getServerUser.mockResolvedValue({ id: "u1" });
+  });
+
+  it("returns 401 when no session is present", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = await POST(jsonRequest({ plantId: "p1", imageId: "i1" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("Unauthorized");
+    expect(signPlantImageUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when the per-user rate limit denies the request", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    rateLimit.mockResolvedValueOnce({ ok: false, remaining: 0, resetAt: 0 });
+    const res = await POST(jsonRequest({ plantId: "p1", imageId: "i1" }));
+    expect(res.status).toBe(429);
+    expect(signPlantImageUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    const req = new NextRequest("http://localhost/api/uploads/refresh", {
+      method: "POST",
+      body: "{not-json",
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/valid JSON/);
+  });
+
+  it.each([
+    ["plantId", { imageId: "i1" }],
+    ["imageId", { plantId: "p1" }],
+  ])("returns 400 when %s is missing", async (_field, body) => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    const res = await POST(jsonRequest(body));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/required/);
+    expect(signPlantImageUrl).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the helper denies access (auth or missing image collapse together)", async () => {
+    // The helper returns null both when the caller isn't authorized
+    // for the plant AND when the imageId doesn't belong to the plant.
+    // The route must NOT distinguish them in the response so an
+    // attacker cannot probe imageId existence.
+    getServerSession.mockResolvedValue(SESSION_OK);
+    signPlantImageUrl.mockResolvedValueOnce(null);
+    const res = await POST(jsonRequest({ plantId: "p1", imageId: "i1" }));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/not found or access denied/i);
+  });
+
+  it("returns a fresh signed URL on success", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    signPlantImageUrl.mockResolvedValueOnce({
+      signedUrl: "https://example.com/refreshed.png?token=new",
+      expiresAt: "2026-05-18T01:00:00.000Z",
+    });
+    const res = await POST(
+      jsonRequest({ plantId: "p1", imageId: "i1", expiresInSeconds: 600 }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.signedUrl).toBe("https://example.com/refreshed.png?token=new");
+    expect(body.expiresAt).toBe("2026-05-18T01:00:00.000Z");
+    expect(signPlantImageUrl).toHaveBeenCalledWith({
+      plantId: "p1",
+      imageId: "i1",
+      expiresInSeconds: 600,
+    });
+  });
+
+  it("omits expiresInSeconds from the helper call when the client sends a non-numeric value", async () => {
+    // Bad-shape input shouldn't reach the helper as something
+    // surprising. We strip it so the helper picks its default.
+    getServerSession.mockResolvedValue(SESSION_OK);
+    signPlantImageUrl.mockResolvedValueOnce({
+      signedUrl: "https://example.com/x",
+      expiresAt: "2026-05-18T01:00:00.000Z",
+    });
+    await POST(
+      jsonRequest({
+        plantId: "p1",
+        imageId: "i1",
+        expiresInSeconds: "ten minutes",
+      }),
+    );
+    const call = (signPlantImageUrl as Mock).mock.calls[0]?.[0];
+    expect(call).not.toHaveProperty("expiresInSeconds");
+  });
+
+  it("returns 500 and logs structured error when the helper throws", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    signPlantImageUrl.mockRejectedValueOnce(new Error("boom"));
+    const res = await POST(jsonRequest({ plantId: "p1", imageId: "i1" }));
+    expect(res.status).toBe(500);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "signed url refresh failed",
+      expect.objectContaining({
+        plantId: "p1",
+        imageId: "i1",
+        error: "boom",
+      }),
+    );
+  });
+});

--- a/apps/web/src/app/api/uploads/refresh/route.ts
+++ b/apps/web/src/app/api/uploads/refresh/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession, getServerUser } from "@/lib/server/auth";
+import { signPlantImageUrl } from "@/lib/server/plants";
+import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
+import {
+  attachRequestId,
+  getOrCreateRequestId,
+  logServerEvent,
+} from "@/lib/server/request-id";
+
+/**
+ * POST /api/uploads/refresh
+ *
+ * Re-sign a Supabase Storage download URL for a previously-uploaded
+ * plant image. Used by `<SignedImage>` on the client when the original
+ * signed URL (rendered into the page at SSR time) expires before the
+ * user finishes interacting with the page.
+ *
+ * Body: `{ plantId: string, imageId: string, expiresInSeconds?: number }`
+ * Returns: `{ signedUrl, expiresAt, requestId }` on success.
+ *
+ * Auth: requires a session, and `signPlantImageUrl` re-verifies the
+ * caller actually owns the plant *and* the image belongs to that plant
+ * — passing an image id for a plant the caller doesn't own returns 404,
+ * never a fresh URL.
+ *
+ * Rate limit: same per-user budget as `/api/uploads/sign` because the
+ * cost profile (one Supabase signing round-trip) is identical.
+ */
+export async function POST(request: NextRequest) {
+  const requestId = getOrCreateRequestId(request);
+  const session = await getServerSession();
+  if (!session) {
+    return attachRequestId(
+      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
+      requestId,
+    );
+  }
+
+  const user = await getServerUser();
+  const rate = await rateLimit({
+    key: rateLimitKeyFromRequest(request, user?.id ?? null),
+    limit: 30,
+    windowMs: 60_000,
+  });
+  if (!rate.ok) {
+    return attachRequestId(
+      NextResponse.json(
+        {
+          error: "Too many image refresh requests. Try again shortly.",
+          requestId,
+        },
+        { status: 429 },
+      ),
+      requestId,
+    );
+  }
+
+  let body: {
+    plantId?: unknown;
+    imageId?: unknown;
+    expiresInSeconds?: unknown;
+  };
+  try {
+    body = (await request.json()) as typeof body;
+  } catch {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Request body must be valid JSON.", requestId },
+        { status: 400 },
+      ),
+      requestId,
+    );
+  }
+
+  // Narrow validation here (instead of zod) keeps the route handler
+  // self-contained and matches the style of the sibling /sign route.
+  // Both ids are UUIDs in our schema; we don't enforce the full UUID
+  // shape because Postgres will reject malformed ids on the lookup
+  // anyway and the auth check will short-circuit to null/404.
+  if (typeof body.plantId !== "string" || body.plantId.length === 0) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "plantId is required.", requestId },
+        { status: 400 },
+      ),
+      requestId,
+    );
+  }
+  if (typeof body.imageId !== "string" || body.imageId.length === 0) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "imageId is required.", requestId },
+        { status: 400 },
+      ),
+      requestId,
+    );
+  }
+  // The TTL is optional; the helper clamps to [60, 3600] so a bad value
+  // here is harmless. Anything non-numeric just falls through to the
+  // helper's default.
+  const expiresInSeconds =
+    typeof body.expiresInSeconds === "number" &&
+    Number.isFinite(body.expiresInSeconds)
+      ? body.expiresInSeconds
+      : undefined;
+
+  try {
+    const signed = await signPlantImageUrl({
+      plantId: body.plantId,
+      imageId: body.imageId,
+      ...(expiresInSeconds !== undefined ? { expiresInSeconds } : {}),
+    });
+    if (!signed) {
+      // Auth failure and missing image collapse into one 404 so an
+      // unauthorised caller cannot probe image-id existence.
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Image not found or access denied.", requestId },
+          { status: 404 },
+        ),
+        requestId,
+      );
+    }
+    return attachRequestId(
+      NextResponse.json({
+        signedUrl: signed.signedUrl,
+        expiresAt: signed.expiresAt,
+        requestId,
+      }),
+      requestId,
+    );
+  } catch (error) {
+    logServerEvent("error", "signed url refresh failed", {
+      requestId,
+      plantId: body.plantId,
+      imageId: body.imageId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Failed to refresh image URL.", requestId },
+        { status: 500 },
+      ),
+      requestId,
+    );
+  }
+}

--- a/apps/web/src/app/api/uploads/refresh/route.ts
+++ b/apps/web/src/app/api/uploads/refresh/route.ts
@@ -72,6 +72,19 @@ export async function POST(request: NextRequest) {
       requestId,
     );
   }
+  // `request.json()` succeeds for primitives (`null`, numbers, strings)
+  // and arrays — none of which carry the named fields we expect. Reject
+  // them here so the field-access checks below can rely on `body` being
+  // an actual object, instead of throwing a TypeError → unhandled 500.
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return attachRequestId(
+      NextResponse.json(
+        { error: "Request body must be a JSON object.", requestId },
+        { status: 400 },
+      ),
+      requestId,
+    );
+  }
 
   // Narrow validation here (instead of zod) keeps the route handler
   // self-contained and matches the style of the sibling /sign route.

--- a/apps/web/src/components/__tests__/signed-image.test.tsx
+++ b/apps/web/src/components/__tests__/signed-image.test.tsx
@@ -69,6 +69,35 @@ describe("SignedImage", () => {
     });
   });
 
+  it("treats a throwing refreshFn as a refresh failure (no unhandled rejection)", async () => {
+    // `handleError` is async and wired to an event handler, so an
+    // unhandled rejection from `refreshFn` would bubble to the
+    // browser's window.onunhandledrejection (and Sentry, etc).
+    // Wrapping with `.catch(() => null)` funnels the throw through
+    // the same fallback path as a null return.
+    const refreshFn = vi.fn().mockRejectedValue(new Error("network down"));
+    const onPermanentFailure = vi.fn();
+    render(
+      <SignedImage
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=expired"
+        alt="leaf"
+        refreshFn={refreshFn}
+        fallback={<span data-testid="placeholder">image unavailable</span>}
+        onPermanentFailure={onPermanentFailure}
+      />,
+    );
+
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    fireEvent.error(img);
+
+    await screen.findByTestId("placeholder");
+    expect(onPermanentFailure).toHaveBeenCalledWith(
+      "initial-and-refresh-failed",
+    );
+  });
+
   it("renders the fallback when both the initial URL and the refresh fail", async () => {
     const refreshFn = vi.fn().mockResolvedValue(null);
     const onPermanentFailure = vi.fn();

--- a/apps/web/src/components/__tests__/signed-image.test.tsx
+++ b/apps/web/src/components/__tests__/signed-image.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SignedImage } from "../signed-image";
+
+describe("SignedImage", () => {
+  it("renders the initial signed URL as the img src", () => {
+    render(
+      <SignedImage
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=initial"
+        alt="leaf"
+      />,
+    );
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    expect(img.src).toBe("https://example.com/a.png?token=initial");
+  });
+
+  it("fetches a refreshed URL once when the initial img fires error", async () => {
+    const refreshFn = vi.fn().mockResolvedValue({
+      signedUrl: "https://example.com/a.png?token=refreshed",
+    });
+    render(
+      <SignedImage
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=expired"
+        alt="leaf"
+        refreshFn={refreshFn}
+      />,
+    );
+
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    // Simulate Supabase returning 403 for the expired URL.
+    fireEvent.error(img);
+
+    await waitFor(() => {
+      expect(img.src).toBe("https://example.com/a.png?token=refreshed");
+    });
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(refreshFn).toHaveBeenCalledWith({ plantId: "p1", imageId: "i1" });
+  });
+
+  it("never refreshes more than once per mount even on a hot error loop", async () => {
+    // A perpetually-broken URL would otherwise let the browser fire
+    // onError repeatedly while we're waiting on refresh. The ref-based
+    // guard inside the component is what prevents that.
+    const refreshFn = vi.fn().mockResolvedValue({
+      signedUrl: "https://example.com/a.png?token=also-bad",
+    });
+    render(
+      <SignedImage
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=expired"
+        alt="leaf"
+        refreshFn={refreshFn}
+      />,
+    );
+
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    fireEvent.error(img);
+    fireEvent.error(img);
+    fireEvent.error(img);
+
+    await waitFor(() => {
+      expect(refreshFn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("renders the fallback when both the initial URL and the refresh fail", async () => {
+    const refreshFn = vi.fn().mockResolvedValue(null);
+    const onPermanentFailure = vi.fn();
+    render(
+      <SignedImage
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=expired"
+        alt="leaf"
+        refreshFn={refreshFn}
+        fallback={<span data-testid="placeholder">image unavailable</span>}
+        onPermanentFailure={onPermanentFailure}
+      />,
+    );
+
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    fireEvent.error(img);
+
+    await screen.findByTestId("placeholder");
+    expect(screen.queryByAltText("leaf")).toBeNull();
+    expect(onPermanentFailure).toHaveBeenCalledWith(
+      "initial-and-refresh-failed",
+    );
+  });
+
+  it("renders fallback on the second failure even if the refresh succeeded once", async () => {
+    // The refresh URL itself can expire in the rare case the user
+    // leaves the page for >1 hour after the first refresh. After two
+    // failed loads we stop and show fallback rather than loop.
+    const refreshFn = vi.fn().mockResolvedValue({
+      signedUrl: "https://example.com/a.png?token=second-but-also-bad",
+    });
+    const onPermanentFailure = vi.fn();
+    render(
+      <SignedImage
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=expired"
+        alt="leaf"
+        refreshFn={refreshFn}
+        fallback={<span data-testid="placeholder">image unavailable</span>}
+        onPermanentFailure={onPermanentFailure}
+      />,
+    );
+
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    fireEvent.error(img); // triggers refresh
+    await waitFor(() =>
+      expect(img.src).toBe(
+        "https://example.com/a.png?token=second-but-also-bad",
+      ),
+    );
+    fireEvent.error(img); // second failure → fallback
+
+    await screen.findByTestId("placeholder");
+    expect(refreshFn).toHaveBeenCalledTimes(1);
+    expect(onPermanentFailure).toHaveBeenCalledTimes(1);
+  });
+
+  it("callers get a fresh retry budget by changing key (React idiom)", async () => {
+    // This component intentionally does NOT watch `initialSrc` for
+    // changes — see the JSDoc. The blessed React pattern for
+    // resetting per-mount state is to change `key`, which unmounts
+    // and remounts. This test pins that contract so a future
+    // refactor doesn't quietly add an effect-based reset (which
+    // would re-introduce the cascading-render hazard).
+    const refreshFn = vi.fn().mockResolvedValue({
+      signedUrl: "https://example.com/refreshed.png",
+    });
+    const { rerender } = render(
+      <SignedImage
+        key="i1"
+        plantId="p1"
+        imageId="i1"
+        initialSrc="https://example.com/a.png?token=expired"
+        alt="leaf"
+        refreshFn={refreshFn}
+      />,
+    );
+
+    const img = screen.getByAltText("leaf") as HTMLImageElement;
+    fireEvent.error(img);
+    await waitFor(() => expect(refreshFn).toHaveBeenCalledTimes(1));
+
+    // Changing key forces a fresh mount with its own state. The new
+    // initialSrc is honoured because there's no stale "src" left
+    // from the previous mount.
+    rerender(
+      <SignedImage
+        key="i2"
+        plantId="p1"
+        imageId="i2"
+        initialSrc="https://example.com/b.png?token=new"
+        alt="leaf"
+        refreshFn={refreshFn}
+      />,
+    );
+
+    const updated = screen.getByAltText("leaf") as HTMLImageElement;
+    expect(updated.src).toBe("https://example.com/b.png?token=new");
+    fireEvent.error(updated);
+    await waitFor(() => expect(refreshFn).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/web/src/components/signed-image.tsx
+++ b/apps/web/src/components/signed-image.tsx
@@ -108,7 +108,12 @@ export function SignedImage({
       return;
     }
     refreshedRef.current = true;
-    const result = await refreshFn({ plantId, imageId });
+    // `.catch(() => null)` guarantees a refreshFn that throws — a
+    // test seam that synchronously rejects, a network error not
+    // already caught by `defaultRefresh` — never escapes this async
+    // event handler as an unhandled rejection. A thrown error and a
+    // null return funnel through the same fallback path.
+    const result = await refreshFn({ plantId, imageId }).catch(() => null);
     if (!result) {
       setFailed(true);
       onPermanentFailure?.("initial-and-refresh-failed");

--- a/apps/web/src/components/signed-image.tsx
+++ b/apps/web/src/components/signed-image.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+/**
+ * Image wrapper that auto-refreshes a Supabase signed URL on expiry.
+ *
+ * Pages render an initial signed URL into `initialSrc` at SSR time
+ * (typically with a 10-60 minute TTL). If the user leaves the page
+ * open past that window, Supabase returns 403 for the next fetch and
+ * the `<img>` fires an `error` event. This component catches that
+ * event exactly once and asks `/api/uploads/refresh` for a fresh URL
+ * bound to `(plantId, imageId)`. If the refresh also fails — network
+ * error, true 404, ownership revoked — the component renders the
+ * supplied `fallback` (or nothing) instead of looping.
+ *
+ * Why a one-shot retry rather than unlimited:
+ *   - A broken image whose URL can't be refreshed (deleted, RLS
+ *     revoked, network down) would otherwise loop forever, hammering
+ *     the refresh endpoint and the rate limiter.
+ *   - Legitimate expiry is a single event per render — one retry
+ *     covers it; anything beyond is the failure mode above.
+ *
+ * Resetting state when a different image is shown: this component
+ * does NOT watch `initialSrc` for changes. If a caller wants the
+ * one-shot retry budget reset (e.g. because the visible image
+ * changed), they should pass `key={imageId}` so React unmounts and
+ * remounts. That's the standard "reset state by changing key" pattern
+ * and it keeps this component free of the cascading-render hazard
+ * that a useEffect-driven reset would introduce.
+ */
+
+type SignedImageProps = {
+  plantId: string;
+  imageId: string;
+  /** The initial server-rendered signed URL. */
+  initialSrc: string;
+  /** Required for accessibility. */
+  alt: string;
+  /** Optional class for the underlying `<img>`. */
+  className?: string;
+  /** Element to render when both the initial URL and a refresh fail. */
+  fallback?: React.ReactNode;
+  /**
+   * Test seam: override the refresh fetcher. Production callers should
+   * not pass this — the default hits `/api/uploads/refresh` with the
+   * standard envelope.
+   */
+  refreshFn?: (_params: {
+    plantId: string;
+    imageId: string;
+  }) => Promise<{ signedUrl: string } | null>;
+  /**
+   * Optional callback so wider error logging / Sentry breadcrumbs can
+   * be wired without depending on a global logger from a client
+   * component. Called once when the second URL also fails.
+   */
+  onPermanentFailure?: (_reason: "initial-and-refresh-failed") => void;
+};
+
+async function defaultRefresh(params: {
+  plantId: string;
+  imageId: string;
+}): Promise<{ signedUrl: string } | null> {
+  try {
+    const res = await fetch("/api/uploads/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as { signedUrl?: string };
+    return data.signedUrl ? { signedUrl: data.signedUrl } : null;
+  } catch {
+    // Network errors collapse to "couldn't refresh" — the caller's
+    // fallback UI is the right place to surface that to the user.
+    return null;
+  }
+}
+
+export function SignedImage({
+  plantId,
+  imageId,
+  initialSrc,
+  alt,
+  className,
+  fallback = null,
+  refreshFn = defaultRefresh,
+  onPermanentFailure,
+}: SignedImageProps) {
+  const [src, setSrc] = useState(initialSrc);
+  const [failed, setFailed] = useState(false);
+  // `refreshedRef` tracks whether we've already issued a refresh for
+  // *this mount*. Using a ref rather than state means the value
+  // updates synchronously inside `handleError`, so a rapid double
+  // `onError` (browser quirks, devtools throttling) can't fire two
+  // refresh calls.
+  const refreshedRef = useRef(false);
+
+  const handleError = useCallback(async () => {
+    if (refreshedRef.current) {
+      // Second failure: the refresh URL didn't work either. Surface
+      // the failure to the caller (for logging) and render the
+      // fallback. No more network calls — we don't want to feed a
+      // hot-loop into the rate limiter.
+      setFailed(true);
+      onPermanentFailure?.("initial-and-refresh-failed");
+      return;
+    }
+    refreshedRef.current = true;
+    const result = await refreshFn({ plantId, imageId });
+    if (!result) {
+      setFailed(true);
+      onPermanentFailure?.("initial-and-refresh-failed");
+      return;
+    }
+    setSrc(result.signedUrl);
+  }, [refreshFn, plantId, imageId, onPermanentFailure]);
+
+  if (failed) {
+    return <>{fallback}</>;
+  }
+
+  // next/image is unsuitable here: it requires the dynamic signed-URL
+  // host to be whitelisted at build time, and it doesn't expose an
+  // `onError` hook compatible with our refresh-on-403 swap. Plain
+  // `<img>` is the right primitive for this use case.
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} className={className} onError={handleError} />
+  );
+}

--- a/apps/web/src/lib/server/__tests__/plants.test.ts
+++ b/apps/web/src/lib/server/__tests__/plants.test.ts
@@ -273,12 +273,10 @@ describe("plants server helpers", () => {
 
   it("signPlantImageUrl returns a fresh URL with an iso expiresAt on success", async () => {
     vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
-    const maybeSingle = vi
-      .fn()
-      .mockResolvedValue({
-        data: { storage_path: "plant-1/x.jpg" },
-        error: null,
-      });
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: { storage_path: "plant-1/x.jpg" },
+      error: null,
+    });
     const eqPlant = vi.fn(() => ({ maybeSingle }));
     const eqId = vi.fn(() => ({ eq: eqPlant }));
     const select = vi.fn(() => ({ eq: eqId }));
@@ -333,6 +331,39 @@ describe("plants server helpers", () => {
       expiresInSeconds: 999_999, // above ceiling
     });
     expect(createSignedUrl).toHaveBeenLastCalledWith("p/x", 3600);
+  });
+
+  it("signPlantImageUrl falls back to default TTL when expiresInSeconds is NaN", async () => {
+    // Defense-in-depth: if a caller upstream of the route handler
+    // (e.g. a future internal cron) hands the helper a NaN, the
+    // clamp must NOT propagate it into `new Date(Date.now() + NaN)`,
+    // which would throw `RangeError: Invalid time value`.
+    const maybeSingle = vi
+      .fn()
+      .mockResolvedValue({ data: { storage_path: "p/x" }, error: null });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle })) })),
+    }));
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ select })) });
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://example.com/x" },
+      error: null,
+    });
+    getStorageClient.mockReturnValue({
+      from: vi.fn(() => ({ createSignedUrl })),
+    });
+
+    const result = await signPlantImageUrl({
+      plantId: "plant-1",
+      imageId: "image-1",
+      expiresInSeconds: Number.NaN,
+    });
+    // Default of 600s lands inside the [60, 3600] clamp, so that's
+    // the TTL we should see — and crucially, `expiresAt` parses as a
+    // real Date, not "Invalid Date".
+    expect(createSignedUrl).toHaveBeenLastCalledWith("p/x", 600);
+    expect(result).not.toBeNull();
+    expect(Number.isNaN(Date.parse(result!.expiresAt))).toBe(false);
   });
 
   it("signPlantImageUrl throws when Supabase returns a sign error", async () => {

--- a/apps/web/src/lib/server/__tests__/plants.test.ts
+++ b/apps/web/src/lib/server/__tests__/plants.test.ts
@@ -39,6 +39,7 @@ import {
   persistPlantImageUpload,
   preparePlantImageUpload,
   runAndPersistPlantAnalysis,
+  signPlantImageUrl,
 } from "../plants";
 
 const PLANT_CONTEXT = {
@@ -233,6 +234,126 @@ describe("plants server helpers", () => {
         requestId: "req-1",
       }),
     ).rejects.toThrow("Failed to create signed upload URL: bucket unavailable");
+  });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // signPlantImageUrl — Phase 1.4 (signed-URL auto-refresh)
+  // ───────────────────────────────────────────────────────────────────────
+
+  it("signPlantImageUrl returns null when the caller isn't authorized for the plant", async () => {
+    getAuthorizedPlantContext.mockResolvedValue(null);
+    await expect(
+      signPlantImageUrl({ plantId: "plant-1", imageId: "image-1" }),
+    ).resolves.toBeNull();
+    expect(getDbClient).not.toHaveBeenCalled();
+    expect(getStorageClient).not.toHaveBeenCalled();
+  });
+
+  it("signPlantImageUrl returns null when the imageId doesn't belong to the plant", async () => {
+    // Critical defense: the auth check covers the plant, but a caller
+    // who owns plant A must not be able to refresh an image belonging
+    // to plant B by passing B's id. Bounding the SELECT by plant_id
+    // is the seal.
+    const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+    const eqPlant = vi.fn(() => ({ maybeSingle }));
+    const eqId = vi.fn(() => ({ eq: eqPlant }));
+    const select = vi.fn(() => ({ eq: eqId }));
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ select })) });
+
+    await expect(
+      signPlantImageUrl({
+        plantId: "plant-1",
+        imageId: "image-from-other-plant",
+      }),
+    ).resolves.toBeNull();
+    expect(eqId).toHaveBeenCalledWith("id", "image-from-other-plant");
+    expect(eqPlant).toHaveBeenCalledWith("plant_id", "plant-1");
+    expect(getStorageClient).not.toHaveBeenCalled();
+  });
+
+  it("signPlantImageUrl returns a fresh URL with an iso expiresAt on success", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_800_000_000_000);
+    const maybeSingle = vi
+      .fn()
+      .mockResolvedValue({
+        data: { storage_path: "plant-1/x.jpg" },
+        error: null,
+      });
+    const eqPlant = vi.fn(() => ({ maybeSingle }));
+    const eqId = vi.fn(() => ({ eq: eqPlant }));
+    const select = vi.fn(() => ({ eq: eqId }));
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ select })) });
+
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://example.com/x.jpg?token=fresh" },
+      error: null,
+    });
+    getStorageClient.mockReturnValue({
+      from: vi.fn(() => ({ createSignedUrl })),
+    });
+
+    const result = await signPlantImageUrl({
+      plantId: "plant-1",
+      imageId: "image-1",
+      expiresInSeconds: 600,
+    });
+    expect(result).toEqual({
+      signedUrl: "https://example.com/x.jpg?token=fresh",
+      expiresAt: new Date(1_800_000_000_000 + 600_000).toISOString(),
+    });
+    expect(createSignedUrl).toHaveBeenCalledWith("plant-1/x.jpg", 600);
+  });
+
+  it("signPlantImageUrl clamps expiresInSeconds to [60, 3600]", async () => {
+    const maybeSingle = vi
+      .fn()
+      .mockResolvedValue({ data: { storage_path: "p/x" }, error: null });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle })) })),
+    }));
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ select })) });
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: { signedUrl: "https://example.com/x" },
+      error: null,
+    });
+    getStorageClient.mockReturnValue({
+      from: vi.fn(() => ({ createSignedUrl })),
+    });
+
+    await signPlantImageUrl({
+      plantId: "plant-1",
+      imageId: "image-1",
+      expiresInSeconds: 1, // below floor
+    });
+    expect(createSignedUrl).toHaveBeenLastCalledWith("p/x", 60);
+
+    await signPlantImageUrl({
+      plantId: "plant-1",
+      imageId: "image-1",
+      expiresInSeconds: 999_999, // above ceiling
+    });
+    expect(createSignedUrl).toHaveBeenLastCalledWith("p/x", 3600);
+  });
+
+  it("signPlantImageUrl throws when Supabase returns a sign error", async () => {
+    const maybeSingle = vi
+      .fn()
+      .mockResolvedValue({ data: { storage_path: "p/x" }, error: null });
+    const select = vi.fn(() => ({
+      eq: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle })) })),
+    }));
+    getDbClient.mockReturnValue({ from: vi.fn(() => ({ select })) });
+    const createSignedUrl = vi.fn().mockResolvedValue({
+      data: null,
+      error: { message: "bucket unavailable" },
+    });
+    getStorageClient.mockReturnValue({
+      from: vi.fn(() => ({ createSignedUrl })),
+    });
+
+    await expect(
+      signPlantImageUrl({ plantId: "plant-1", imageId: "image-1" }),
+    ).rejects.toThrow("Failed to sign plant image URL: bucket unavailable");
   });
 
   it("returns null for finalized image persistence when the plant is not authorized", async () => {

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -205,6 +205,72 @@ export async function persistPlantImageUpload(params: {
   };
 }
 
+/**
+ * Mint a fresh signed download URL for a single plant image.
+ *
+ * Used by the `<SignedImage>` client component's refresh path: when a
+ * previously-rendered signed URL expires (Supabase 403), the component
+ * calls `/api/uploads/refresh`, which calls this. Ownership is
+ * enforced two ways:
+ *
+ *   1. `getAuthorizedPlantContext` checks the caller actually owns /
+ *      is a member of the grow that contains the plant.
+ *   2. The `plant_images` lookup is bounded by `plant_id = context.plantId`
+ *      so a caller who owns plant A cannot pass image B (belonging to
+ *      plant B) and harvest a fresh URL.
+ *
+ * Returns `null` whenever auth or lookup fails. The caller maps that
+ * to a 404 so the existence (or non-existence) of an image id is not
+ * disclosed to unauthorised parties.
+ */
+export async function signPlantImageUrl(params: {
+  plantId: string;
+  imageId: string;
+  /** TTL for the new signed URL, in seconds. Capped at 1 hour. */
+  expiresInSeconds?: number;
+}): Promise<{ signedUrl: string; expiresAt: string } | null> {
+  const context = await getAuthorizedPlantContext(params.plantId);
+  if (!context) {
+    return null;
+  }
+
+  const db = getDbClient();
+  const { data: image, error: imageError } = await db
+    .from("plant_images")
+    .select("storage_path")
+    .eq("id", params.imageId)
+    .eq("plant_id", context.plantId)
+    .maybeSingle();
+  if (imageError) {
+    throw new Error(`Failed to load image for signing: ${imageError.message}`);
+  }
+  if (!image) {
+    return null;
+  }
+
+  // Clamp the TTL so a misbehaving client can't request a year-long
+  // signed URL. 60s minimum prevents thrashing if a client retries on
+  // every error.
+  const requested = params.expiresInSeconds ?? 600;
+  const expiresIn = Math.max(60, Math.min(3600, Math.floor(requested)));
+
+  const storage = getStorageClient().from("plant-images");
+  const { data, error } = await storage.createSignedUrl(
+    (image as { storage_path: string }).storage_path,
+    expiresIn,
+  );
+  if (error || !data?.signedUrl) {
+    throw new Error(
+      `Failed to sign plant image URL: ${error?.message ?? "no url"}`,
+    );
+  }
+
+  return {
+    signedUrl: data.signedUrl,
+    expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
+  };
+}
+
 export async function getLatestPlantAnalysis(
   plantId: string,
 ): Promise<AnalysisResponse | null> {

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -251,8 +251,17 @@ export async function signPlantImageUrl(params: {
   // Clamp the TTL so a misbehaving client can't request a year-long
   // signed URL. 60s minimum prevents thrashing if a client retries on
   // every error.
+  //
+  // Defense-in-depth: the route handler already filters non-finite
+  // input, but the helper guards itself against `NaN` / `Infinity`
+  // anyway. A NaN here would propagate through the clamp and then
+  // explode at `new Date(Date.now() + NaN).toISOString()` with
+  // `RangeError: Invalid time value`, taking down the whole request.
   const requested = params.expiresInSeconds ?? 600;
-  const expiresIn = Math.max(60, Math.min(3600, Math.floor(requested)));
+  const safeRequested = Number.isFinite(requested)
+    ? Math.floor(requested)
+    : 600;
+  const expiresIn = Math.max(60, Math.min(3600, safeRequested));
 
   const storage = getStorageClient().from("plant-images");
   const { data, error } = await storage.createSignedUrl(


### PR DESCRIPTION
## Summary

Phase 1.4 of the production-readiness plan in `docs/optimization-plan.md`. Closes out Phase 1 of the optimization arc. Gives the client a way to recover when a server-rendered Supabase signed URL expires while the user is still on the page.

### Three new pieces

**1. `signPlantImageUrl(plantId, imageId, expiresInSeconds?)`** in `apps/web/src/lib/server/plants.ts`
- Two layers of authorization. `getAuthorizedPlantContext` enforces grow membership; the `plant_images` SELECT is bounded by `plant_id = context.plantId` so a caller who owns plant A cannot smuggle image B's id and harvest a fresh URL.
- TTL clamped to `[60, 3600]` seconds.

**2. `POST /api/uploads/refresh`** at `apps/web/src/app/api/uploads/refresh/route.ts`
- Returns `{ signedUrl, expiresAt, requestId }`.
- Auth failure and missing image collapse into one 404 so image-id existence isn't disclosed to unauthenticated probers.
- Per-user rate limited (30/min, same cost profile as `/api/uploads/sign`).

**3. `<SignedImage plantId imageId initialSrc alt fallback?>`** at `apps/web/src/components/signed-image.tsx`
- Renders the SSR-rendered initial signed URL.
- On `<img>` error, fetches `/api/uploads/refresh` exactly once (ref-guarded so rapid double-error events from devtools throttling can't double-fire).
- On second failure, renders the caller's `fallback` (or null) — refuses to loop so a permanently-broken URL doesn't hammer the refresh endpoint and the rate limiter.
- Callers that need a fresh retry budget for a different image pass `key={imageId}` (the React-idiomatic "reset state by changing key" pattern). Kept out of the component so we don't drag in the cascading-render hazard a `useEffect`-driven reset would introduce.

### Scope decision: no call-site adoption yet

The existing comparison panel at `apps/web/src/app/(app)/plants/[plantId]/page.tsx:153-164` is the most at-risk site (10-minute TTL). Adopting `<SignedImage>` there requires switching from pre-resolved `signedUrl` strings to passing `imageId` down through the panel component, which is a larger UI refactor that deserves its own review. Tracked as a follow-up so this PR stays reviewable.

## Test plan

- [x] **6 component cases**: initial render, refresh on error, never more than one refresh per mount, fallback on double-failure, fallback on refresh-then-still-bad, `key` change yields fresh retry budget.
- [x] **8 route-handler cases**: 401, 429, 400 for invalid JSON, 400 for each missing id, 404 collapses auth+missing (no enumeration), 200 happy path, `expiresInSeconds` passthrough, non-numeric TTL ignored, 500 logs structured error.
- [x] **5 helper cases**: unauthorized → null, image-from-other-plant → null, success returns iso `expiresAt`, TTL clamp to `[60, 3600]`, storage error propagates.
- [x] Full web vitest: **770 passed**.
- [x] `pnpm run type-check`: clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 21 route files scanned (+1 for `/api/uploads/refresh`), OK.
- [x] Local `gitleaks --no-git`: no leaks found.
- [x] `eslint --max-warnings=0`: clean.

## Follow-ups

- Migrate `apps/web/src/app/(app)/plants/[plantId]/page.tsx` comparison panel to `<SignedImage>`.
- Audit other render sites for signed-URL expiry exposure as part of the broader Phase 4 (Error UX) work.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_