### PR TITLE
feat(observability): Sentry required in prod + /api/ready dependency probes

### DIFF
--- a/apps/web/src/app/api/ready/__tests__/route.test.ts
+++ b/apps/web/src/app/api/ready/__tests__/route.test.ts
@@ -1,40 +1,178 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock probe helpers so the route test isn't an integration test of
+// the probes themselves (those are exercised by ready-probes.test.ts).
+const mocks = vi.hoisted(() => ({
+  probeSupabase: vi.fn(),
+  probeUpstash: vi.fn(),
+  probeAnalysisService: vi.fn(),
+}));
+vi.mock("@/lib/server/ready-probes", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/server/ready-probes")
+  >("@/lib/server/ready-probes");
+  return {
+    ...actual,
+    probeSupabase: mocks.probeSupabase,
+    probeUpstash: mocks.probeUpstash,
+    probeAnalysisService: mocks.probeAnalysisService,
+  };
+});
+
 import { GET } from "../route";
 
 const ORIGINAL_ENV = process.env;
 
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  mocks.probeSupabase.mockReset();
+  mocks.probeUpstash.mockReset();
+  mocks.probeAnalysisService.mockReset();
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+function envOk() {
+  process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://x.supabase.co";
+  process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "anon";
+  process.env["ANALYSIS_SERVICE_URL"] = "https://x.railway.app";
+  process.env["ANALYSIS_SERVICE_API_KEY"] = "key";
+}
+
+function probesAllOk() {
+  mocks.probeSupabase.mockResolvedValue({
+    name: "supabase",
+    ok: true,
+    latencyMs: 12,
+  });
+  mocks.probeUpstash.mockResolvedValue({
+    name: "upstash",
+    ok: true,
+    latencyMs: 8,
+  });
+  mocks.probeAnalysisService.mockResolvedValue({
+    name: "analysis-service",
+    ok: true,
+    latencyMs: 34,
+  });
+}
+
 describe("GET /api/ready", () => {
-  beforeEach(() => {
-    process.env = { ...ORIGINAL_ENV };
-  });
-  afterEach(() => {
-    process.env = ORIGINAL_ENV;
-  });
+  it("returns 200 when env is complete and every probe is ok", async () => {
+    envOk();
+    probesAllOk();
 
-  it("returns 200 when all checks pass", async () => {
-    process.env["NEXT_PUBLIC_SUPABASE_URL"] = "https://x.supabase.co";
-    process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"] = "anon";
-    process.env["ANALYSIS_SERVICE_URL"] = "https://x.railway.app";
-    process.env["ANALYSIS_SERVICE_API_KEY"] = "key";
-
-    const res = GET();
+    const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe("ok");
     expect(body.service).toBe("phenosage-web");
     expect(body.checks.every((c: { ok: boolean }) => c.ok)).toBe(true);
+    expect(body.probes).toHaveLength(3);
+    expect(body.probes.every((p: { ok: boolean }) => p.ok)).toBe(true);
   });
 
-  it("returns 503 when required env is missing", async () => {
+  it("returns 503 when required env is missing (preserves legacy behaviour)", async () => {
     delete process.env["NEXT_PUBLIC_SUPABASE_URL"];
     delete process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
     delete process.env["ANALYSIS_SERVICE_URL"];
     delete process.env["ANALYSIS_SERVICE_API_KEY"];
+    probesAllOk();
 
-    const res = GET();
+    const res = await GET();
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.status).toBe("not_ready");
     expect(body.checks.some((c: { ok: boolean }) => !c.ok)).toBe(true);
+  });
+
+  it("returns 503 when env is fine but a probe failed for a real reason", async () => {
+    // Crucial signal: a Supabase outage must mark the app unready so
+    // the load balancer takes us out of rotation. The legacy version
+    // of this endpoint missed this entirely — it would have stayed
+    // green even with Supabase down hard.
+    envOk();
+    mocks.probeSupabase.mockResolvedValue({
+      name: "supabase",
+      ok: false,
+      latencyMs: 1500,
+      detail: "timeout",
+    });
+    mocks.probeUpstash.mockResolvedValue({
+      name: "upstash",
+      ok: true,
+      latencyMs: 8,
+    });
+    mocks.probeAnalysisService.mockResolvedValue({
+      name: "analysis-service",
+      ok: true,
+      latencyMs: 34,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.status).toBe("not_ready");
+    // The failing probe is still surfaced so on-call can see WHY.
+    const failed = body.probes.find(
+      (p: { name: string }) => p.name === "supabase",
+    );
+    expect(failed.ok).toBe(false);
+    expect(failed.detail).toBe("timeout");
+  });
+
+  it("stays ready when only an OPTIONAL probe (not-configured) is missing", async () => {
+    // Pins the dev-mode contract: a preview deploy without Upstash
+    // configured uses the in-memory rate-limit fallback and must
+    // still report ready.
+    envOk();
+    mocks.probeSupabase.mockResolvedValue({
+      name: "supabase",
+      ok: true,
+      latencyMs: 12,
+    });
+    mocks.probeUpstash.mockResolvedValue({
+      name: "upstash",
+      ok: false,
+      latencyMs: 0,
+      detail: "not-configured",
+    });
+    mocks.probeAnalysisService.mockResolvedValue({
+      name: "analysis-service",
+      ok: true,
+      latencyMs: 34,
+    });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("ok");
+  });
+
+  it("runs the three probes in parallel (not sequentially)", async () => {
+    // The route must not stack probe latencies — if each takes 500ms
+    // serial would make the readiness call >1500ms. Parallel keeps
+    // it ~500ms. We assert this by spying on the call timestamps.
+    envOk();
+    const startTimes: number[] = [];
+    const slowProbe = (name: string) => async () => {
+      startTimes.push(performance.now());
+      await new Promise((r) => setTimeout(r, 50));
+      return { name, ok: true, latencyMs: 50 };
+    };
+    mocks.probeSupabase.mockImplementation(slowProbe("supabase"));
+    mocks.probeUpstash.mockImplementation(slowProbe("upstash"));
+    mocks.probeAnalysisService.mockImplementation(
+      slowProbe("analysis-service"),
+    );
+
+    await GET();
+    expect(startTimes).toHaveLength(3);
+    // All three should start within a few ms of each other — much
+    // less than the 50ms each probe sleeps.
+    const spread = Math.max(...startTimes) - Math.min(...startTimes);
+    expect(spread).toBeLessThan(20);
   });
 });

--- a/apps/web/src/app/api/ready/route.ts
+++ b/apps/web/src/app/api/ready/route.ts
@@ -1,40 +1,78 @@
 import { NextResponse } from "next/server";
+import {
+  probeAnalysisService,
+  probeBlocksReadiness,
+  probeSupabase,
+  probeUpstash,
+  type ProbeResult,
+} from "@/lib/server/ready-probes";
 
 export const runtime = "edge";
 
-type Check = { name: string; ok: boolean; detail?: string };
+type EnvCheck = { name: string; ok: boolean; detail?: string };
 
-function check(name: string, ok: boolean, detail?: string): Check {
-  const result: Check = { name, ok };
+function envCheck(name: string, ok: boolean, detail?: string): EnvCheck {
+  const result: EnvCheck = { name, ok };
   if (detail !== undefined) result.detail = detail;
   return result;
 }
 
-export function GET() {
-  const checks: Check[] = [
-    check(
+/**
+ * Readiness endpoint for load balancers / uptime monitors.
+ *
+ * Returns 200 when:
+ *   - every required env var is present (existing behaviour, kept
+ *     for backward compatibility with any monitor that parses
+ *     `checks`)
+ *   - every CONFIGURED dependency probe (supabase / upstash /
+ *     analysis-service) responded successfully within its timeout
+ *
+ * A `not-configured` probe (e.g. Upstash absent in a preview deploy
+ * using the in-memory rate-limit fallback) is REPORTED in the
+ * `probes` array but does NOT fail the readiness verdict. See
+ * `probeBlocksReadiness` in `ready-probes.ts`.
+ *
+ * Probes run in parallel via `Promise.all`; the overall route latency
+ * is therefore bounded by the slowest single probe (each capped at
+ * ~1.5s internally). Connection-level failures land in `detail` as
+ * opaque codes only — never raw upstream error text — because this
+ * endpoint is unauthenticated and any field we emit is effectively
+ * public.
+ */
+export async function GET() {
+  const checks: EnvCheck[] = [
+    envCheck(
       "supabase_url",
       Boolean(process.env["NEXT_PUBLIC_SUPABASE_URL"]),
       "NEXT_PUBLIC_SUPABASE_URL",
     ),
-    check(
+    envCheck(
       "supabase_anon_key",
       Boolean(process.env["NEXT_PUBLIC_SUPABASE_ANON_KEY"]),
       "NEXT_PUBLIC_SUPABASE_ANON_KEY",
     ),
-    check(
+    envCheck(
       "analysis_service_url",
       Boolean(process.env["ANALYSIS_SERVICE_URL"]),
       "ANALYSIS_SERVICE_URL",
     ),
-    check(
+    envCheck(
       "analysis_service_api_key",
       Boolean(process.env["ANALYSIS_SERVICE_API_KEY"]),
       "ANALYSIS_SERVICE_API_KEY",
     ),
   ];
 
-  const ok = checks.every((c) => c.ok);
+  const probes: ProbeResult[] = await Promise.all([
+    probeSupabase(),
+    probeUpstash(),
+    probeAnalysisService(),
+  ]);
+
+  const envOk = checks.every((c) => c.ok);
+  const probesOk = probes.every((p) => !probeBlocksReadiness(p));
+  const ok = envOk && probesOk;
+
   const body = {
     status: ok ? "ok" : "not_ready",
     service: "phenosage-web",
@@ -45,6 +83,7 @@ export function GET() {
     env:
       process.env["NEXT_PUBLIC_APP_ENV"] ?? process.env.NODE_ENV ?? "unknown",
     checks,
+    probes,
     timestamp: new Date().toISOString(),
   };
   return NextResponse.json(body, { status: ok ? 200 : 503 });

--- a/apps/web/src/lib/server/__tests__/env.test.ts
+++ b/apps/web/src/lib/server/__tests__/env.test.ts
@@ -57,4 +57,49 @@ describe("env validation", () => {
       expect((err as EnvValidationError).violations).toHaveLength(2);
     }
   });
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Conditional production rules (Phase 2.1)
+  // ───────────────────────────────────────────────────────────────────────
+
+  it("does NOT require SENTRY_DSN outside production", () => {
+    // Dev / preview deploys (or the empty default) should be unaffected
+    // so contributors don't need to mint a Sentry project to run the
+    // app locally.
+    const env = baseValidEnv();
+    delete env["SENTRY_DSN"];
+    delete env["NEXT_PUBLIC_APP_ENV"];
+    expect(getServerEnvErrors(env)).toEqual([]);
+
+    env["NEXT_PUBLIC_APP_ENV"] = "preview";
+    expect(getServerEnvErrors(env)).toEqual([]);
+  });
+
+  it("requires SENTRY_DSN when NEXT_PUBLIC_APP_ENV=production", () => {
+    // The cost of letting prod go dark (no error tracking, no perf
+    // traces) is much higher than the cost of failing the deploy. This
+    // test pins that "fail-the-deploy-fast" contract so a future
+    // refactor doesn't quietly relax it.
+    const env = baseValidEnv();
+    delete env["SENTRY_DSN"];
+    env["NEXT_PUBLIC_APP_ENV"] = "production";
+    const errs = getServerEnvErrors(env);
+    expect(errs.some((e) => e.includes("SENTRY_DSN"))).toBe(true);
+  });
+
+  it("validates SENTRY_DSN shape when supplied (any environment)", () => {
+    // A typo'd or pasted-wrong DSN must surface immediately rather
+    // than fail silently inside Sentry's SDK init.
+    const env = baseValidEnv();
+    env["SENTRY_DSN"] = "definitely-not-a-dsn";
+    const errs = getServerEnvErrors(env);
+    expect(errs.some((e) => e.includes("SENTRY_DSN"))).toBe(true);
+  });
+
+  it("accepts a well-formed SENTRY_DSN in production", () => {
+    const env = baseValidEnv();
+    env["NEXT_PUBLIC_APP_ENV"] = "production";
+    env["SENTRY_DSN"] = "https://abc123@o4504.ingest.sentry.io/12345";
+    expect(getServerEnvErrors(env)).toEqual([]);
+  });
 });

--- a/apps/web/src/lib/server/__tests__/ready-probes.test.ts
+++ b/apps/web/src/lib/server/__tests__/ready-probes.test.ts
@@ -1,0 +1,188 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+import {
+  probeAnalysisService,
+  probeBlocksReadiness,
+  probeSupabase,
+  probeUpstash,
+} from "../ready-probes";
+
+function envWith(
+  overrides: Record<string, string | undefined>,
+): NodeJS.ProcessEnv {
+  const base: Record<string, string | undefined> = {
+    NEXT_PUBLIC_SUPABASE_URL: "https://x.supabase.co",
+    NEXT_PUBLIC_SUPABASE_ANON_KEY: "anon-key",
+    ANALYSIS_SERVICE_URL: "https://x.railway.app",
+    ANALYSIS_SERVICE_API_KEY: "service-key",
+    UPSTASH_REDIS_REST_URL: "https://x.upstash.io",
+    UPSTASH_REDIS_REST_TOKEN: "rest-token",
+  };
+  return { ...base, ...overrides } as NodeJS.ProcessEnv;
+}
+
+let fetchSpy: MockInstance;
+
+beforeEach(() => {
+  // `vi.spyOn(globalThis, "fetch")` returns the EXISTING spy on a
+  // re-spy, so call history accumulates across tests within a file.
+  // Restoring + re-spying every test gives each case a clean
+  // `mock.calls[0]` to assert against.
+  fetchSpy = vi.spyOn(globalThis, "fetch");
+  fetchSpy.mockReset();
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+describe("probeSupabase", () => {
+  it("returns ok when /auth/v1/health responds 200", async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 200 }));
+    const result = await probeSupabase(envWith({}));
+    expect(result.ok).toBe(true);
+    expect(result.name).toBe("supabase");
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    // Verify we hit the correct URL with the apikey header so a probe
+    // doesn't quietly stop validating the project's own identity.
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://x.supabase.co/auth/v1/health");
+    expect(new Headers(init.headers).get("apikey")).toBe("anon-key");
+  });
+
+  it("returns bad-status when /auth/v1/health responds non-200", async () => {
+    // A 503 from Supabase means the project is paused or experiencing
+    // an outage — readiness must reflect that, otherwise traffic gets
+    // routed to a degraded backend.
+    fetchSpy.mockResolvedValue(new Response(null, { status: 503 }));
+    const result = await probeSupabase(envWith({}));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("bad-status");
+  });
+
+  it("returns unreachable on transport error", async () => {
+    fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+    const result = await probeSupabase(envWith({}));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("unreachable");
+  });
+
+  it("returns timeout when the fetch is aborted by the internal deadline", async () => {
+    // Synthesize the same error the abort path produces. Verifying the
+    // discrimination matters because on-call distinguishes "supabase
+    // is slow" from "supabase is down" through this field.
+    const abortErr = new Error("aborted");
+    (abortErr as Error & { name?: string }).name = "AbortError";
+    fetchSpy.mockRejectedValue(abortErr);
+    const result = await probeSupabase(envWith({}));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("timeout");
+  });
+
+  it("returns not-configured when the URL or key is absent", async () => {
+    // Probes that aren't configured must NOT leak through as failures
+    // — `probeBlocksReadiness` returns false for this case so the
+    // overall readiness verdict isn't tainted.
+    const result = await probeSupabase(
+      envWith({
+        NEXT_PUBLIC_SUPABASE_URL: undefined,
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: undefined,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("not-configured");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("probeUpstash", () => {
+  it("returns ok when /ping responds 200", async () => {
+    fetchSpy.mockResolvedValue(new Response("PONG", { status: 200 }));
+    const result = await probeUpstash(envWith({}));
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://x.upstash.io/ping");
+    expect(new Headers(init.headers).get("Authorization")).toBe(
+      "Bearer rest-token",
+    );
+  });
+
+  it("returns not-configured when Upstash isn't wired up", async () => {
+    // Dev / preview deploys use the in-memory rate-limit fallback by
+    // design. Not configuring Upstash is a normal state, not a
+    // readiness failure.
+    const result = await probeUpstash(
+      envWith({
+        UPSTASH_REDIS_REST_URL: undefined,
+        UPSTASH_REDIS_REST_TOKEN: undefined,
+      }),
+    );
+    expect(result.detail).toBe("not-configured");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("probeAnalysisService", () => {
+  it("hits /health with the bearer key", async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 200 }));
+    const result = await probeAnalysisService(envWith({}));
+    expect(result.ok).toBe(true);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://x.railway.app/health");
+    expect(new Headers(init.headers).get("Authorization")).toBe(
+      "Bearer service-key",
+    );
+  });
+
+  it("returns bad-status when /health responds non-200", async () => {
+    // A 401 here means our API key was rotated and we forgot to sync
+    // it — readiness must reflect that, otherwise the proxy will fail
+    // every analyze call with no warning at the platform layer.
+    fetchSpy.mockResolvedValue(new Response(null, { status: 401 }));
+    const result = await probeAnalysisService(envWith({}));
+    expect(result.ok).toBe(false);
+    expect(result.detail).toBe("bad-status");
+  });
+});
+
+describe("probeBlocksReadiness", () => {
+  it("does not block when the probe is ok", () => {
+    expect(probeBlocksReadiness({ name: "x", ok: true, latencyMs: 12 })).toBe(
+      false,
+    );
+  });
+
+  it("does not block when the probe is not-configured", () => {
+    // Critical invariant: a dev box without Upstash configured must
+    // still report ready. Reversing this would make every preview
+    // deploy mark itself unready and refuse traffic.
+    expect(
+      probeBlocksReadiness({
+        name: "upstash",
+        ok: false,
+        latencyMs: 0,
+        detail: "not-configured",
+      }),
+    ).toBe(false);
+  });
+
+  it("blocks when the probe failed for any other reason", () => {
+    for (const detail of ["timeout", "unreachable", "bad-status"]) {
+      expect(
+        probeBlocksReadiness({
+          name: "supabase",
+          ok: false,
+          latencyMs: 1500,
+          detail,
+        }),
+      ).toBe(true);
+    }
+  });
+});

--- a/apps/web/src/lib/server/env.ts
+++ b/apps/web/src/lib/server/env.ts
@@ -13,6 +13,14 @@
 type Rule = {
   name: string;
   required: boolean;
+  /**
+   * When set, this rule is also treated as `required` whenever
+   * `NEXT_PUBLIC_APP_ENV === "production"`. Used for variables that
+   * are optional in dev/preview (so contributors don't have to set
+   * them) but mandatory in prod (so the deploy fails fast on the
+   * platform health check rather than silently in user traffic).
+   */
+  requiredInProduction?: boolean;
   pattern?: RegExp;
   hint?: string;
 };
@@ -40,6 +48,19 @@ const SERVER_RULES: Rule[] = [
     hint: "AIza...  (from https://aistudio.google.com/app/apikey)",
   },
   { name: "NEXT_PUBLIC_APP_URL", required: true, pattern: /^https?:\/\// },
+  {
+    // Optional in dev/preview, REQUIRED in production. Without a DSN the
+    // app would deploy successfully but operate blind — no crash reports,
+    // no perf traces, no error-rate dashboards. The cost of letting
+    // production go dark is much higher than the cost of failing the
+    // deploy. Hint matches the public DSN shape Sentry issues
+    // (`https://<key>@<orgId>.ingest.sentry.io/<projectId>`).
+    name: "SENTRY_DSN",
+    required: false,
+    requiredInProduction: true,
+    pattern: /^https:\/\/[^@/]+@[^/]+\/[0-9]+$/,
+    hint: "https://<publicKey>@<orgId>.ingest.sentry.io/<projectId>",
+  },
 ];
 
 const PUBLIC_RULES: Rule[] = SERVER_RULES.filter((r) =>
@@ -54,11 +75,18 @@ export class EnvValidationError extends Error {
 }
 
 function validate(rules: Rule[], env: NodeJS.ProcessEnv): string[] {
+  // "production" gating is opt-in via the public APP_ENV var so that
+  // VERCEL_ENV / NODE_ENV quirks (Vercel preview deploys both have
+  // NODE_ENV=production at build time) can't accidentally trigger
+  // strict checks where they aren't intended.
+  const isProduction = env["NEXT_PUBLIC_APP_ENV"] === "production";
   const errors: string[] = [];
   for (const rule of rules) {
     const value = env[rule.name];
+    const effectivelyRequired =
+      rule.required || (isProduction && rule.requiredInProduction === true);
     if (!value) {
-      if (rule.required) {
+      if (effectivelyRequired) {
         errors.push(
           `${rule.name} is required${rule.hint ? ` (e.g. ${rule.hint})` : ""}`,
         );

--- a/apps/web/src/lib/server/ready-probes.ts
+++ b/apps/web/src/lib/server/ready-probes.ts
@@ -1,0 +1,168 @@
+import "server-only";
+
+/**
+ * Connectivity probes used by the readiness endpoint.
+ *
+ * Each probe is bounded by an internal timeout so a single slow
+ * dependency cannot stretch the whole readiness response. Probes run
+ * in parallel from the route handler — order here doesn't imply order
+ * of execution.
+ *
+ * Error messages from upstream are intentionally NOT surfaced — the
+ * readiness endpoint is unauthenticated by design (load balancers
+ * call it without credentials), so any field we put in `detail` is
+ * effectively public. Only opaque codes like "timeout" / "unreachable"
+ * / "bad-status" are emitted.
+ */
+
+export type ProbeResult = {
+  name: string;
+  ok: boolean;
+  latencyMs: number;
+  /**
+   * Opaque short code when `ok=false` (e.g. "timeout", "unreachable",
+   * "bad-status", "not-configured"). Never includes raw error text
+   * from the upstream because this surface is unauthenticated.
+   */
+  detail?: string;
+};
+
+/**
+ * Wrap a fetch in an `AbortController` so the probe can't outlive the
+ * configured timeout. Returns a discriminated `{ ok, response }` /
+ * `{ ok, reason }` so callers don't have to re-classify the failure.
+ */
+async function probeFetch(
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<
+  | { ok: true; status: number }
+  | { ok: false; reason: "timeout" | "unreachable" }
+> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    return { ok: true, status: res.status };
+  } catch (err) {
+    // AbortError surfaces as DOMException on edge; check name to
+    // distinguish from a real transport error so on-call gets the
+    // useful signal.
+    const name = (err as Error & { name?: string })?.name ?? "";
+    if (name === "AbortError" || name === "TimeoutError") {
+      return { ok: false, reason: "timeout" };
+    }
+    return { ok: false, reason: "unreachable" };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function notConfigured(name: string): ProbeResult {
+  return { name, ok: false, latencyMs: 0, detail: "not-configured" };
+}
+
+function timed(
+  name: string,
+  started: number,
+  status: "ok" | "bad-status",
+): ProbeResult {
+  const latencyMs = Math.max(0, Math.round(performance.now() - started));
+  if (status === "ok") return { name, ok: true, latencyMs };
+  return { name, ok: false, latencyMs, detail: "bad-status" };
+}
+
+function failed(name: string, started: number, reason: string): ProbeResult {
+  const latencyMs = Math.max(0, Math.round(performance.now() - started));
+  return { name, ok: false, latencyMs, detail: reason };
+}
+
+/**
+ * Supabase: hit the public `/auth/v1/health` endpoint with the anon
+ * key. 200 = the project is reachable and not paused. We deliberately
+ * don't issue a privileged query (e.g. `select 1` via PostgREST) so
+ * the readiness endpoint can stay unauthenticated and so a brief RLS
+ * misconfiguration can't mark the whole app as unready.
+ */
+export async function probeSupabase(
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 1500,
+): Promise<ProbeResult> {
+  const url = env["NEXT_PUBLIC_SUPABASE_URL"];
+  const anon = env["NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+  if (!url || !anon) return notConfigured("supabase");
+  const started = performance.now();
+  const result = await probeFetch(
+    `${url.replace(/\/$/, "")}/auth/v1/health`,
+    { headers: { apikey: anon } },
+    timeoutMs,
+  );
+  if (!result.ok) return failed("supabase", started, result.reason);
+  return timed(
+    "supabase",
+    started,
+    result.status === 200 ? "ok" : "bad-status",
+  );
+}
+
+/**
+ * Upstash Redis: REST `/ping` returns `PONG`. We skip the probe when
+ * Upstash isn't configured (dev / preview environments use the
+ * in-memory rate-limit fallback by design) rather than reporting it
+ * as failed — the route's `ok` calculation excludes probes whose
+ * detail is `not-configured`.
+ */
+export async function probeUpstash(
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 1500,
+): Promise<ProbeResult> {
+  const url = env["UPSTASH_REDIS_REST_URL"];
+  const token = env["UPSTASH_REDIS_REST_TOKEN"];
+  if (!url || !token) return notConfigured("upstash");
+  const started = performance.now();
+  const result = await probeFetch(
+    `${url.replace(/\/$/, "")}/ping`,
+    { headers: { Authorization: `Bearer ${token}` } },
+    timeoutMs,
+  );
+  if (!result.ok) return failed("upstash", started, result.reason);
+  return timed("upstash", started, result.status === 200 ? "ok" : "bad-status");
+}
+
+/**
+ * Analysis service: hit its `/health` endpoint with the shared bearer
+ * token so a forgotten / rotated key fails the readiness check too,
+ * not just a network outage.
+ */
+export async function probeAnalysisService(
+  env: NodeJS.ProcessEnv = process.env,
+  timeoutMs = 1500,
+): Promise<ProbeResult> {
+  const url = env["ANALYSIS_SERVICE_URL"];
+  const apiKey = env["ANALYSIS_SERVICE_API_KEY"];
+  if (!url || !apiKey) return notConfigured("analysis-service");
+  const started = performance.now();
+  const result = await probeFetch(
+    `${url.replace(/\/$/, "")}/health`,
+    { headers: { Authorization: `Bearer ${apiKey}` } },
+    timeoutMs,
+  );
+  if (!result.ok) return failed("analysis-service", started, result.reason);
+  return timed(
+    "analysis-service",
+    started,
+    result.status === 200 ? "ok" : "bad-status",
+  );
+}
+
+/**
+ * Decide whether a single probe counts toward the overall readiness
+ * verdict. `not-configured` probes are reported but excluded — a dev
+ * machine without Upstash configured should still be "ready" because
+ * the rate limiter has an in-memory fallback.
+ */
+export function probeBlocksReadiness(probe: ProbeResult): boolean {
+  if (probe.ok) return false;
+  return probe.detail !== "not-configured";
+}


### PR DESCRIPTION
## Summary

Phase 2 of the production-readiness plan, items 2.1 and 2.3. Foundational observability work — the rest of Phase 2 (per-route timing middleware, W3C `traceparent`, Sentry alert rules) will follow in separate PRs to keep this reviewable.

### 2.1 SENTRY_DSN required in production

- `Rule` in `apps/web/src/lib/server/env.ts` now accepts `requiredInProduction?: boolean`. The validator treats such rules as required whenever `NEXT_PUBLIC_APP_ENV === "production"` — deliberately not `NODE_ENV` or `VERCEL_ENV` because Vercel preview builds have `NODE_ENV=production` at build time, which would falsely trigger strict checks.
- Applied to `SENTRY_DSN`: optional in dev/preview, required in prod. A deploy without a DSN would run blind (no error tracking, no perf traces). Failing the deploy fast is much better than discovering the gap from user reports.
- Pattern check fires whenever a DSN is supplied (any env), so a typo'd DSN surfaces at boot instead of failing silently inside the Sentry SDK init.

### 2.3 `/api/ready` dependency probes

The previous readiness route only checked env-var **presence** — a paused Supabase project or a revoked analysis-service API key would not mark the app unready, and the load balancer would keep routing user traffic to a degraded backend.

New `apps/web/src/lib/server/ready-probes.ts` runs three real connectivity probes:

| Probe | Method | Signal |
|-------|--------|--------|
| **Supabase** | `GET /auth/v1/health` with anon key | 200 = project reachable and not paused |
| **Upstash** | `GET /ping` with bearer token | Skipped (`not-configured`) when absent — dev/preview uses in-memory rate-limit fallback |
| **Analysis service** | `GET /health` with bearer token | Auth-protected, so a forgotten/rotated key also fails readiness |

- Each probe is bounded by a 1500ms `AbortController` timeout.
- Probes run in parallel via `Promise.all` — overall latency is ~slowest probe, not the sum.
- Error messages from upstream are intentionally **not** surfaced in `detail` — the endpoint is unauthenticated and any field we emit is effectively public. Only opaque codes (`timeout`, `unreachable`, `bad-status`, `not-configured`).
- Response shape is additive: the legacy `checks` array (env presence) is preserved unchanged so existing monitors keep parsing; the new `probes` array sits alongside it.
- Overall `status` is `not_ready` iff any required env is missing **OR** any non-`not-configured` probe failed.

## Test plan

- [x] **4 new env cases**: conditional production requirement off outside prod, on in prod, shape-check applies in both, valid DSN accepted.
- [x] **11 new probe cases**: Supabase ok/bad-status/unreachable/timeout/not-configured; Upstash ok/not-configured; analysis-service ok/bad-status; `probeBlocksReadiness` decision matrix.
- [x] **5 new route cases**: full green, env-missing 503 (legacy path preserved), probe-failure 503 with `detail` surfaced, not-configured stays ready, parallel-execution assertion via start-timestamp spread.
- [x] Full web vitest: **795 passed** (20 new).
- [x] `pnpm run type-check`: clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 21 route files scanned, OK.
- [x] Local `gitleaks --no-git`: no leaks found.
- [x] `eslint --max-warnings=0`: clean.

## Follow-ups (tracked in `docs/optimization-plan.md`)

- **2.2** per-route timing log middleware (`{requestId, userId, route, durationMs, status}`)
- **2.4** W3C `traceparent` propagation: browser → Next route → FastAPI → OpenAI
- **2.5** Sentry alert rules (p95 / error-rate thresholds, on-call docs)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_