### PR TITLE
feat(observability): per-route timing logs via withRouteLogging wrapper

### DIFF
--- a/apps/web/src/app/api/analyze/route.ts
+++ b/apps/web/src/app/api/analyze/route.ts
@@ -5,6 +5,7 @@ import { apiError, apiSuccess } from "@/lib/server/api-errors";
 import { getServerSession, getServerUser } from "@/lib/server/auth";
 import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
 import { getOrCreateRequestId, logServerEvent } from "@/lib/server/request-id";
+import { withRouteLogging } from "@/lib/server/route-logging";
 import { parseJsonBody } from "@/lib/server/validate";
 
 const AnalyzeJobRequestSchema = z.object({
@@ -13,75 +14,80 @@ const AnalyzeJobRequestSchema = z.object({
   idempotency_key: z.string().min(8).max(128).optional(),
 });
 
-export async function POST(request: NextRequest) {
-  const requestId = getOrCreateRequestId(request);
-  const session = await getServerSession();
-  if (!session) {
-    return apiError(401, "UNAUTHORIZED", "Unauthorized", requestId);
-  }
+export const POST = withRouteLogging(
+  "/api/analyze",
+  async (request: NextRequest) => {
+    const requestId = getOrCreateRequestId(request);
+    const session = await getServerSession();
+    if (!session) {
+      return apiError(401, "UNAUTHORIZED", "Unauthorized", requestId);
+    }
 
-  const user = await getServerUser();
-  const rate = await rateLimit({
-    key: `analyze:${rateLimitKeyFromRequest(request, user?.id ?? null)}`,
-    limit: 5,
-    windowMs: 60_000,
-  });
-  if (!rate.ok) {
-    return apiError(
-      429,
-      "RATE_LIMITED",
-      "Too many analysis requests. Try again shortly.",
-      requestId,
-      { retryAfterSeconds: 30 },
-    );
-  }
-
-  const parsed = await parseJsonBody(request, AnalyzeJobRequestSchema);
-  if (!parsed.ok) {
-    return apiError(
-      parsed.status,
-      parsed.status === 415 ? "UNSUPPORTED_MEDIA_TYPE" : "UNPROCESSABLE_ENTITY",
-      parsed.error,
-      requestId,
-    );
-  }
-
-  try {
-    const job = await enqueueAnalysisJob({
-      plantId: parsed.data.plant_id,
-      imageId: parsed.data.image_id,
-      ...(parsed.data.idempotency_key
-        ? { idempotencyKey: parsed.data.idempotency_key }
-        : {}),
+    const user = await getServerUser();
+    const rate = await rateLimit({
+      key: `analyze:${rateLimitKeyFromRequest(request, user?.id ?? null)}`,
+      limit: 5,
+      windowMs: 60_000,
     });
-    if (!job) {
+    if (!rate.ok) {
       return apiError(
-        404,
-        "NOT_FOUND",
-        "Plant image not found or access denied",
+        429,
+        "RATE_LIMITED",
+        "Too many analysis requests. Try again shortly.",
+        requestId,
+        { retryAfterSeconds: 30 },
+      );
+    }
+
+    const parsed = await parseJsonBody(request, AnalyzeJobRequestSchema);
+    if (!parsed.ok) {
+      return apiError(
+        parsed.status,
+        parsed.status === 415
+          ? "UNSUPPORTED_MEDIA_TYPE"
+          : "UNPROCESSABLE_ENTITY",
+        parsed.error,
         requestId,
       );
     }
-    return apiSuccess(
-      202,
-      {
-        job_id: job.id,
-        status: job.status,
-        plant_id: job.plantId,
-        image_id: job.imageId,
-      },
-      requestId,
-    );
-  } catch (error) {
-    logServerEvent("error", "analysis job enqueue failed", {
-      requestId,
-      error: error instanceof Error ? error.message : "unknown_error",
-    });
-    return apiError(
-      500,
-      "INTERNAL_ERROR",
-      "Failed to enqueue analysis job",
-      requestId,
-    );
-  }
-}
+
+    try {
+      const job = await enqueueAnalysisJob({
+        plantId: parsed.data.plant_id,
+        imageId: parsed.data.image_id,
+        ...(parsed.data.idempotency_key
+          ? { idempotencyKey: parsed.data.idempotency_key }
+          : {}),
+      });
+      if (!job) {
+        return apiError(
+          404,
+          "NOT_FOUND",
+          "Plant image not found or access denied",
+          requestId,
+        );
+      }
+      return apiSuccess(
+        202,
+        {
+          job_id: job.id,
+          status: job.status,
+          plant_id: job.plantId,
+          image_id: job.imageId,
+        },
+        requestId,
+      );
+    } catch (error) {
+      logServerEvent("error", "analysis job enqueue failed", {
+        requestId,
+        error: error instanceof Error ? error.message : "unknown_error",
+      });
+      return apiError(
+        500,
+        "INTERNAL_ERROR",
+        "Failed to enqueue analysis job",
+        requestId,
+      );
+    }
+  },
+);

--- a/apps/web/src/app/api/uploads/refresh/route.ts
+++ b/apps/web/src/app/api/uploads/refresh/route.ts
@@ -7,6 +7,7 @@ import {
   getOrCreateRequestId,
   logServerEvent,
 } from "@/lib/server/request-id";
+import { withRouteLogging } from "@/lib/server/route-logging";
 
 /**
  * POST /api/uploads/refresh
@@ -27,135 +28,141 @@ import {
  * Rate limit: same per-user budget as `/api/uploads/sign` because the
  * cost profile (one Supabase signing round-trip) is identical.
  */
-export async function POST(request: NextRequest) {
-  const requestId = getOrCreateRequestId(request);
-  const session = await getServerSession();
-  if (!session) {
-    return attachRequestId(
-      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
-      requestId,
-    );
-  }
-
-  const user = await getServerUser();
-  const rate = await rateLimit({
-    key: rateLimitKeyFromRequest(request, user?.id ?? null),
-    limit: 30,
-    windowMs: 60_000,
-  });
-  if (!rate.ok) {
-    return attachRequestId(
-      NextResponse.json(
-        {
-          error: "Too many image refresh requests. Try again shortly.",
-          requestId,
-        },
-        { status: 429 },
-      ),
-      requestId,
-    );
-  }
-
-  let body: {
-    plantId?: unknown;
-    imageId?: unknown;
-    expiresInSeconds?: unknown;
-  };
-  try {
-    body = (await request.json()) as typeof body;
-  } catch {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Request body must be valid JSON.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-  // `request.json()` succeeds for primitives (`null`, numbers, strings)
-  // and arrays — none of which carry the named fields we expect. Reject
-  // them here so the field-access checks below can rely on `body` being
-  // an actual object, instead of throwing a TypeError → unhandled 500.
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Request body must be a JSON object.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-
-  // Narrow validation here (instead of zod) keeps the route handler
-  // self-contained and matches the style of the sibling /sign route.
-  // Both ids are UUIDs in our schema; we don't enforce the full UUID
-  // shape because Postgres will reject malformed ids on the lookup
-  // anyway and the auth check will short-circuit to null/404.
-  if (typeof body.plantId !== "string" || body.plantId.length === 0) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "plantId is required.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-  if (typeof body.imageId !== "string" || body.imageId.length === 0) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "imageId is required.", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-  // The TTL is optional; the helper clamps to [60, 3600] so a bad value
-  // here is harmless. Anything non-numeric just falls through to the
-  // helper's default.
-  const expiresInSeconds =
-    typeof body.expiresInSeconds === "number" &&
-    Number.isFinite(body.expiresInSeconds)
-      ? body.expiresInSeconds
-      : undefined;
-
-  try {
-    const signed = await signPlantImageUrl({
-      plantId: body.plantId,
-      imageId: body.imageId,
-      ...(expiresInSeconds !== undefined ? { expiresInSeconds } : {}),
-    });
-    if (!signed) {
-      // Auth failure and missing image collapse into one 404 so an
-      // unauthorised caller cannot probe image-id existence.
+export const POST = withRouteLogging(
+  "/api/uploads/refresh",
+  async (request: NextRequest) => {
+    const requestId = getOrCreateRequestId(request);
+    const session = await getServerSession();
+    if (!session) {
       return attachRequestId(
         NextResponse.json(
-          { error: "Image not found or access denied.", requestId },
-          { status: 404 },
+          { error: "Unauthorized", requestId },
+          { status: 401 },
         ),
         requestId,
       );
     }
-    return attachRequestId(
-      NextResponse.json({
-        signedUrl: signed.signedUrl,
-        expiresAt: signed.expiresAt,
-        requestId,
-      }),
-      requestId,
-    );
-  } catch (error) {
-    logServerEvent("error", "signed url refresh failed", {
-      requestId,
-      plantId: body.plantId,
-      imageId: body.imageId,
-      error: error instanceof Error ? error.message : "unknown_error",
+
+    const user = await getServerUser();
+    const rate = await rateLimit({
+      key: rateLimitKeyFromRequest(request, user?.id ?? null),
+      limit: 30,
+      windowMs: 60_000,
     });
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Failed to refresh image URL.", requestId },
-        { status: 500 },
-      ),
-      requestId,
-    );
-  }
-}
+    if (!rate.ok) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: "Too many image refresh requests. Try again shortly.",
+            requestId,
+          },
+          { status: 429 },
+        ),
+        requestId,
+      );
+    }
+
+    let body: {
+      plantId?: unknown;
+      imageId?: unknown;
+      expiresInSeconds?: unknown;
+    };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Request body must be valid JSON.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    // `request.json()` succeeds for primitives (`null`, numbers, strings)
+    // and arrays — none of which carry the named fields we expect. Reject
+    // them here so the field-access checks below can rely on `body` being
+    // an actual object, instead of throwing a TypeError → unhandled 500.
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Request body must be a JSON object.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+
+    // Narrow validation here (instead of zod) keeps the route handler
+    // self-contained and matches the style of the sibling /sign route.
+    // Both ids are UUIDs in our schema; we don't enforce the full UUID
+    // shape because Postgres will reject malformed ids on the lookup
+    // anyway and the auth check will short-circuit to null/404.
+    if (typeof body.plantId !== "string" || body.plantId.length === 0) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "plantId is required.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    if (typeof body.imageId !== "string" || body.imageId.length === 0) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "imageId is required.", requestId },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+    // The TTL is optional; the helper clamps to [60, 3600] so a bad value
+    // here is harmless. Anything non-numeric just falls through to the
+    // helper's default.
+    const expiresInSeconds =
+      typeof body.expiresInSeconds === "number" &&
+      Number.isFinite(body.expiresInSeconds)
+        ? body.expiresInSeconds
+        : undefined;
+
+    try {
+      const signed = await signPlantImageUrl({
+        plantId: body.plantId,
+        imageId: body.imageId,
+        ...(expiresInSeconds !== undefined ? { expiresInSeconds } : {}),
+      });
+      if (!signed) {
+        // Auth failure and missing image collapse into one 404 so an
+        // unauthorised caller cannot probe image-id existence.
+        return attachRequestId(
+          NextResponse.json(
+            { error: "Image not found or access denied.", requestId },
+            { status: 404 },
+          ),
+          requestId,
+        );
+      }
+      return attachRequestId(
+        NextResponse.json({
+          signedUrl: signed.signedUrl,
+          expiresAt: signed.expiresAt,
+          requestId,
+        }),
+        requestId,
+      );
+    } catch (error) {
+      logServerEvent("error", "signed url refresh failed", {
+        requestId,
+        plantId: body.plantId,
+        imageId: body.imageId,
+        error: error instanceof Error ? error.message : "unknown_error",
+      });
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Failed to refresh image URL.", requestId },
+          { status: 500 },
+        ),
+        requestId,
+      );
+    }
+  },
+);

--- a/apps/web/src/app/api/uploads/sign/route.ts
+++ b/apps/web/src/app/api/uploads/sign/route.ts
@@ -7,132 +7,147 @@ import {
   getOrCreateRequestId,
   logServerEvent,
 } from "@/lib/server/request-id";
+import { withRouteLogging } from "@/lib/server/route-logging";
 
 // POST /api/uploads/sign
 // Returns a short-lived Supabase Storage signed upload URL.
 // The browser uploads directly to Supabase; the signed URL is generated here
 // on the server so the service role key is never exposed.
-export async function POST(request: NextRequest) {
-  const requestId = getOrCreateRequestId(request);
-  const session = await getServerSession();
-  if (!session) {
-    return attachRequestId(
-      NextResponse.json({ error: "Unauthorized", requestId }, { status: 401 }),
-      requestId,
-    );
-  }
-
-  const user = await getServerUser();
-  const rate = await rateLimit({
-    key: rateLimitKeyFromRequest(request, user?.id ?? null),
-    limit: 10,
-    windowMs: 60_000,
-  });
-  if (!rate.ok) {
-    return attachRequestId(
-      NextResponse.json(
-        {
-          error: "Too many upload preparations. Try again shortly.",
-          requestId,
-        },
-        { status: 429 },
-      ),
-      requestId,
-    );
-  }
-
-  const body = (await request.json()) as {
-    plantId: string;
-    fileName: string;
-    contentType: string;
-    takenAt?: string;
-    source?: "camera" | "upload";
-    notes?: string;
-    chatThreadId?: string;
-  };
-
-  if (!body.plantId || !body.fileName || !body.contentType) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "plantId, fileName, and contentType are required", requestId },
-        { status: 400 },
-      ),
-      requestId,
-    );
-  }
-
-  // Explicitly recognise (and reject) video MIME types with a structured
-  // reason code so the chat UI can render a "video coming soon" affordance
-  // instead of a generic "Unsupported content type" toast. Video support
-  // requires frame-extraction infrastructure not yet in place.
-  if (body.contentType.startsWith("video/")) {
-    return attachRequestId(
-      NextResponse.json(
-        {
-          error: "Video uploads are not yet supported.",
-          reason: "video_unsupported",
-          requestId,
-        },
-        { status: 415 },
-      ),
-      requestId,
-    );
-  }
-
-  // Validate content type — images only
-  const allowedTypes = ["image/jpeg", "image/png", "image/webp", "image/heic"];
-  if (!allowedTypes.includes(body.contentType)) {
-    return attachRequestId(
-      NextResponse.json(
-        { error: "Unsupported content type", requestId },
-        { status: 415 },
-      ),
-      requestId,
-    );
-  }
-
-  try {
-    const prepared = await preparePlantImageUpload({
-      plantId: body.plantId,
-      fileName: body.fileName,
-      contentType: body.contentType,
-      requestId,
-    });
-
-    if (!prepared) {
+export const POST = withRouteLogging(
+  "/api/uploads/sign",
+  async (request: NextRequest) => {
+    const requestId = getOrCreateRequestId(request);
+    const session = await getServerSession();
+    if (!session) {
       return attachRequestId(
         NextResponse.json(
-          { error: "Plant not found or access denied", requestId },
-          { status: 404 },
+          { error: "Unauthorized", requestId },
+          { status: 401 },
         ),
         requestId,
       );
     }
 
-    return attachRequestId(
-      NextResponse.json({
-        ...prepared,
-        chatThreadId: body.chatThreadId ?? null,
-        requestId,
-      }),
-      requestId,
-    );
-  } catch (error) {
-    logServerEvent("error", "upload signing failed", {
-      requestId,
-      plantId: body.plantId,
-      error: error instanceof Error ? error.message : "unknown_error",
+    const user = await getServerUser();
+    const rate = await rateLimit({
+      key: rateLimitKeyFromRequest(request, user?.id ?? null),
+      limit: 10,
+      windowMs: 60_000,
     });
-    return attachRequestId(
-      NextResponse.json(
-        {
-          error:
-            error instanceof Error ? error.message : "Upload signing failed",
+    if (!rate.ok) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: "Too many upload preparations. Try again shortly.",
+            requestId,
+          },
+          { status: 429 },
+        ),
+        requestId,
+      );
+    }
+
+    const body = (await request.json()) as {
+      plantId: string;
+      fileName: string;
+      contentType: string;
+      takenAt?: string;
+      source?: "camera" | "upload";
+      notes?: string;
+      chatThreadId?: string;
+    };
+
+    if (!body.plantId || !body.fileName || !body.contentType) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: "plantId, fileName, and contentType are required",
+            requestId,
+          },
+          { status: 400 },
+        ),
+        requestId,
+      );
+    }
+
+    // Explicitly recognise (and reject) video MIME types with a structured
+    // reason code so the chat UI can render a "video coming soon" affordance
+    // instead of a generic "Unsupported content type" toast. Video support
+    // requires frame-extraction infrastructure not yet in place.
+    if (body.contentType.startsWith("video/")) {
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error: "Video uploads are not yet supported.",
+            reason: "video_unsupported",
+            requestId,
+          },
+          { status: 415 },
+        ),
+        requestId,
+      );
+    }
+
+    // Validate content type — images only
+    const allowedTypes = [
+      "image/jpeg",
+      "image/png",
+      "image/webp",
+      "image/heic",
+    ];
+    if (!allowedTypes.includes(body.contentType)) {
+      return attachRequestId(
+        NextResponse.json(
+          { error: "Unsupported content type", requestId },
+          { status: 415 },
+        ),
+        requestId,
+      );
+    }
+
+    try {
+      const prepared = await preparePlantImageUpload({
+        plantId: body.plantId,
+        fileName: body.fileName,
+        contentType: body.contentType,
+        requestId,
+      });
+
+      if (!prepared) {
+        return attachRequestId(
+          NextResponse.json(
+            { error: "Plant not found or access denied", requestId },
+            { status: 404 },
+          ),
           requestId,
-        },
-        { status: 500 },
-      ),
-      requestId,
-    );
-  }
-}
+        );
+      }
+
+      return attachRequestId(
+        NextResponse.json({
+          ...prepared,
+          chatThreadId: body.chatThreadId ?? null,
+          requestId,
+        }),
+        requestId,
+      );
+    } catch (error) {
+      logServerEvent("error", "upload signing failed", {
+        requestId,
+        plantId: body.plantId,
+        error: error instanceof Error ? error.message : "unknown_error",
+      });
+      return attachRequestId(
+        NextResponse.json(
+          {
+            error:
+              error instanceof Error ? error.message : "Upload signing failed",
+            requestId,
+          },
+          { status: 500 },
+        ),
+        requestId,
+      );
+    }
+  },
+);

--- a/apps/web/src/lib/server/__tests__/route-logging.test.ts
+++ b/apps/web/src/lib/server/__tests__/route-logging.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const logServerEvent = vi.fn();
+vi.mock("../request-id", async () => {
+  const actual =
+    await vi.importActual<typeof import("../request-id")>("../request-id");
+  return {
+    ...actual,
+    logServerEvent: (...args: unknown[]) => logServerEvent(...args),
+  };
+});
+
+import { withRouteLogging } from "../route-logging";
+
+beforeEach(() => {
+  logServerEvent.mockReset();
+});
+
+function req(
+  method: "GET" | "POST" = "GET",
+  headers: Record<string, string> = {},
+): NextRequest {
+  return new NextRequest("http://localhost/api/test", { method, headers });
+}
+
+describe("withRouteLogging", () => {
+  it("logs an info envelope after a successful handler", async () => {
+    const handler = vi.fn(async () =>
+      NextResponse.json({ ok: true }, { status: 200 }),
+    );
+    const wrapped = withRouteLogging("/api/test", handler);
+    const res = await wrapped(req("POST"));
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(logServerEvent).toHaveBeenCalledTimes(1);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "request completed",
+      expect.objectContaining({
+        route: "/api/test",
+        method: "POST",
+        status: 200,
+      }),
+    );
+    const fields = logServerEvent.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(typeof fields["requestId"]).toBe("string");
+    expect(typeof fields["durationMs"]).toBe("number");
+    expect(fields["durationMs"]).toBeGreaterThanOrEqual(0);
+  });
+
+  it("propagates the inbound x-request-id into the log line", async () => {
+    // End-to-end tracing depends on the requestId surviving the
+    // route boundary. The wrapper must read the inbound header, not
+    // mint a fresh id and discard the upstream one.
+    const handler = vi.fn(async () => NextResponse.json({ ok: true }));
+    const wrapped = withRouteLogging("/api/test", handler);
+    await wrapped(req("GET", { "x-request-id": "trace-abc-123" }));
+    const fields = logServerEvent.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(fields["requestId"]).toBe("trace-abc-123");
+  });
+
+  it("preserves a non-2xx status in the log without throwing", async () => {
+    // 4xx / 5xx returns are normal control flow — the wrapper must
+    // surface the status verbatim, not coerce to 200 or 500.
+    const handler = vi.fn(async () =>
+      NextResponse.json({ error: "nope" }, { status: 404 }),
+    );
+    const wrapped = withRouteLogging("/api/test", handler);
+    const res = await wrapped(req("GET"));
+    expect(res.status).toBe(404);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "info",
+      "request completed",
+      expect.objectContaining({ status: 404 }),
+    );
+  });
+
+  it("logs an error envelope and re-throws when the handler throws", async () => {
+    // The wrapper's only job on failure is to record the envelope;
+    // the framework's default error handling (500 response, Sentry
+    // capture, etc.) must still run. Swallowing here would mean the
+    // browser sees an empty response.
+    const handler = vi.fn(async () => {
+      throw new Error("kaboom");
+    });
+    const wrapped = withRouteLogging("/api/test", handler);
+
+    await expect(wrapped(req("POST"))).rejects.toThrow("kaboom");
+    expect(logServerEvent).toHaveBeenCalledTimes(1);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "request failed",
+      expect.objectContaining({
+        route: "/api/test",
+        method: "POST",
+        status: 500,
+        error: "kaboom",
+      }),
+    );
+  });
+
+  it("uses 'unknown_error' for non-Error throws", async () => {
+    const handler = vi.fn(async () => {
+      throw "string-throw";
+    });
+    const wrapped = withRouteLogging("/api/test", handler);
+    await expect(wrapped(req("GET"))).rejects.toBeTruthy();
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "request failed",
+      expect.objectContaining({ error: "unknown_error" }),
+    );
+  });
+
+  it("passes additional handler args through unchanged", async () => {
+    // Next.js route handlers receive a context arg (e.g.
+    // `{ params: Promise<{ id: string }> }`) — the wrapper must not
+    // swallow it, otherwise dynamic routes silently break.
+    type Ctx = { params: Promise<{ id: string }> };
+    const handler = vi.fn(async (_req: NextRequest, ctx: Ctx) => {
+      const { id } = await ctx.params;
+      return NextResponse.json({ id }, { status: 200 });
+    });
+    const wrapped = withRouteLogging("/api/test/[id]", handler);
+    const ctx: Ctx = { params: Promise.resolve({ id: "abc" }) };
+    const res = await wrapped(req("GET"), ctx);
+    expect(handler).toHaveBeenCalledWith(expect.any(NextRequest), ctx);
+    expect(await res.json()).toEqual({ id: "abc" });
+  });
+});

--- a/apps/web/src/lib/server/__tests__/route-logging.test.ts
+++ b/apps/web/src/lib/server/__tests__/route-logging.test.ts
@@ -60,9 +60,10 @@ describe("withRouteLogging", () => {
     expect(fields["requestId"]).toBe("trace-abc-123");
   });
 
-  it("preserves a non-2xx status in the log without throwing", async () => {
-    // 4xx / 5xx returns are normal control flow — the wrapper must
-    // surface the status verbatim, not coerce to 200 or 500.
+  it("classifies 4xx responses as warn (worth flagging, not paging)", async () => {
+    // 4xx is normal control flow — a 401 spike could be a leaked
+    // token, a 422 spike could be a bad client deploy — both
+    // deserve dashboard visibility above noise but not on-call.
     const handler = vi.fn(async () =>
       NextResponse.json({ error: "nope" }, { status: 404 }),
     );
@@ -70,10 +71,44 @@ describe("withRouteLogging", () => {
     const res = await wrapped(req("GET"));
     expect(res.status).toBe(404);
     expect(logServerEvent).toHaveBeenCalledWith(
-      "info",
+      "warn",
       "request completed",
       expect.objectContaining({ status: 404 }),
     );
+  });
+
+  it("classifies 5xx responses as error (must page)", async () => {
+    // 5xx is the alerting band — the on-call pipeline filters on
+    // log level, so coercing a 503 to info would hide real outages.
+    const handler = vi.fn(async () =>
+      NextResponse.json({ error: "down" }, { status: 503 }),
+    );
+    const wrapped = withRouteLogging("/api/test", handler);
+    await wrapped(req("GET"));
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "request completed",
+      expect.objectContaining({ status: 503 }),
+    );
+  });
+
+  it("prefers the requestId attached to the response over a fresh mint", async () => {
+    // Critical correlation contract: when the inbound request has
+    // NO x-request-id header, both the wrapper and the handler would
+    // otherwise call `getOrCreateRequestId` independently and mint
+    // different UUIDs. The log line and the client-visible header
+    // would then disagree. Reading the header back from the response
+    // closes that gap.
+    const headers = new Headers({ "x-request-id": "handler-minted-xyz" });
+    const handler = vi.fn(
+      async () => new Response(null, { status: 200, headers }),
+    );
+    const wrapped = withRouteLogging("/api/test", handler);
+    // Inbound deliberately has no x-request-id so the two code paths
+    // would diverge without the response-header lookup.
+    await wrapped(req("GET"));
+    const fields = logServerEvent.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(fields["requestId"]).toBe("handler-minted-xyz");
   });
 
   it("logs an error envelope and re-throws when the handler throws", async () => {

--- a/apps/web/src/lib/server/route-logging.ts
+++ b/apps/web/src/lib/server/route-logging.ts
@@ -1,6 +1,10 @@
 import "server-only";
 import type { NextRequest } from "next/server";
-import { getOrCreateRequestId, logServerEvent } from "./request-id";
+import {
+  getOrCreateRequestId,
+  logServerEvent,
+  REQUEST_ID_HEADER,
+} from "./request-id";
 
 /**
  * Higher-order wrapper that emits a structured `request completed` log
@@ -48,35 +52,69 @@ export type LoggedHandler<Args extends unknown[]> = (
   ..._rest: Args
 ) => Promise<Response>;
 
+/**
+ * Map an HTTP status to the structured log level we want to surface
+ * it at. The bands let dashboards / alerts filter sanely:
+ *
+ *   - `5xx` → `error` so the on-call pipeline pages on real outages.
+ *   - `4xx` → `warn` because client errors are worth flagging
+ *     (spike of 401s → leaked-token suspicion, spike of 422s → bad
+ *     client deploy) but should not page.
+ *   - everything else → `info`.
+ *
+ * `else → info` includes 2xx and 3xx; 1xx isn't a real terminal
+ * response shape our routes produce so it's not special-cased.
+ */
+function levelForStatus(status: number): "error" | "warn" | "info" {
+  if (status >= 500) return "error";
+  if (status >= 400) return "warn";
+  return "info";
+}
+
 export function withRouteLogging<Args extends unknown[]>(
   routeName: string,
   handler: LoggedHandler<Args>,
 ): LoggedHandler<Args> {
   return async (req, ...rest) => {
-    const requestId = getOrCreateRequestId(req);
-    const started = Date.now();
+    // `performance.now()` is monotonic and sub-ms; immune to NTP
+    // adjustments mid-request that could make `Date.now()` go
+    // backwards and yield a negative durationMs.
+    const started = performance.now();
     const method = req.method;
     try {
       const response = await handler(req, ...rest);
-      logServerEvent("info", "request completed", {
+      // Prefer the requestId the handler actually attached to the
+      // response. When the inbound request has no `x-request-id`
+      // header, both the wrapper and the handler would otherwise
+      // mint INDEPENDENT UUIDs via `getOrCreateRequestId`, and the
+      // log line would carry a different id than the client sees.
+      // Reading the header back closes that correlation gap.
+      const requestId =
+        response.headers.get(REQUEST_ID_HEADER) || getOrCreateRequestId(req);
+      logServerEvent(levelForStatus(response.status), "request completed", {
         route: routeName,
         method,
         status: response.status,
         requestId,
-        durationMs: Date.now() - started,
+        durationMs: Math.round(performance.now() - started),
       });
       return response;
     } catch (err) {
-      // Log the failure envelope first, then re-throw so the
-      // framework's error handling (default 500, Sentry capture if
-      // wired) still runs unchanged. We deliberately don't catch
-      // here — the wrapper's only job is to record the envelope.
+      // On uncaught throw we can't read the response headers (none
+      // exist yet), so we fall back to deriving the requestId from
+      // the inbound header alone. This means a request that arrived
+      // WITHOUT `x-request-id` and threw before producing a response
+      // will get a fresh UUID here that doesn't match any subsequent
+      // handler-side log. Memoising `getOrCreateRequestId` per
+      // request (e.g. via a WeakMap keyed on the NextRequest) is a
+      // worthwhile follow-up — out of scope here.
+      const requestId = getOrCreateRequestId(req);
       logServerEvent("error", "request failed", {
         route: routeName,
         method,
         status: 500,
         requestId,
-        durationMs: Date.now() - started,
+        durationMs: Math.round(performance.now() - started),
         error: err instanceof Error ? err.message : "unknown_error",
       });
       throw err;

--- a/apps/web/src/lib/server/route-logging.ts
+++ b/apps/web/src/lib/server/route-logging.ts
@@ -1,0 +1,85 @@
+import "server-only";
+import type { NextRequest } from "next/server";
+import { getOrCreateRequestId, logServerEvent } from "./request-id";
+
+/**
+ * Higher-order wrapper that emits a structured `request completed` log
+ * line for every invocation of a route handler.
+ *
+ * Why a wrapper instead of an actual Next.js middleware:
+ *   - This repo deliberately forbids adding `middleware.ts` to
+ *     `apps/web` (see CLAUDE.md non-negotiables) because the auth /
+ *     security boundary lives in the route handlers themselves and we
+ *     don't want a second cross-cutting layer with its own runtime
+ *     constraints. A composable wrapper keeps the same observability
+ *     win without that boundary cost.
+ *
+ * Emitted fields:
+ *   - `route`     — stable identifier supplied at wrap time. Keep it
+ *                   low-cardinality (no per-id values) so log
+ *                   aggregations can group on it cleanly.
+ *   - `method`    — HTTP verb.
+ *   - `status`    — HTTP status code returned by the handler. 500
+ *                   when the handler threw (the throw still
+ *                   propagates after the log).
+ *   - `requestId` — resolved from the inbound `x-request-id` header
+ *                   when present, otherwise newly minted. Matches
+ *                   whatever the handler itself sees via
+ *                   `getOrCreateRequestId`.
+ *   - `durationMs` — wall-clock time in milliseconds, rounded.
+ *
+ * What this wrapper deliberately does NOT log:
+ *   - User id / session info. Each route already resolves its own
+ *     auth context and emits route-specific logs; duplicating it here
+ *     would mean a double-fetch on every request just to get a field.
+ *   - Request / response bodies. Bodies can contain PII and signed
+ *     URLs; the timing log is a request-envelope concern, not a
+ *     content concern.
+ *
+ * Streaming caveat: for routes that return a `ReadableStream`
+ * (chat), the `status` field reflects the *response object* returned
+ * by the handler — typically 200 even if a downstream model error
+ * later aborts the stream. Use route-internal logs to track stream
+ * completion / failure separately.
+ */
+
+export type LoggedHandler<Args extends unknown[]> = (
+  _req: NextRequest,
+  ..._rest: Args
+) => Promise<Response>;
+
+export function withRouteLogging<Args extends unknown[]>(
+  routeName: string,
+  handler: LoggedHandler<Args>,
+): LoggedHandler<Args> {
+  return async (req, ...rest) => {
+    const requestId = getOrCreateRequestId(req);
+    const started = Date.now();
+    const method = req.method;
+    try {
+      const response = await handler(req, ...rest);
+      logServerEvent("info", "request completed", {
+        route: routeName,
+        method,
+        status: response.status,
+        requestId,
+        durationMs: Date.now() - started,
+      });
+      return response;
+    } catch (err) {
+      // Log the failure envelope first, then re-throw so the
+      // framework's error handling (default 500, Sentry capture if
+      // wired) still runs unchanged. We deliberately don't catch
+      // here — the wrapper's only job is to record the envelope.
+      logServerEvent("error", "request failed", {
+        route: routeName,
+        method,
+        status: 500,
+        requestId,
+        durationMs: Date.now() - started,
+        error: err instanceof Error ? err.message : "unknown_error",
+      });
+      throw err;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Phase 2.2 of the production-readiness plan. Completes the observability ground-floor begun by #198.

### New: `withRouteLogging(routeName, handler)`

Higher-order wrapper in `apps/web/src/lib/server/route-logging.ts` that emits a structured `request completed` (or `request failed`) log line on every invocation:

| field | source |
|-------|--------|
| `route` | Low-cardinality identifier supplied at wrap time |
| `method` | HTTP verb |
| `status` | Response status, or `500` on uncaught throw |
| `requestId` | `getOrCreateRequestId(req)` — matches whatever the handler itself sees |
| `durationMs` | Wall-clock, rounded |

### Why a wrapper, not a middleware

CLAUDE.md's non-negotiables forbid adding `middleware.ts` to `apps/web` — the auth/security boundary lives in the route handlers themselves and we don't want a second cross-cutting layer with its own runtime constraints. A composable HOF gives the same observability win without changing that contract.

### What it deliberately does NOT log

- User id / session info. Each route already resolves its own auth context and emits route-specific logs; duplicating it here would mean a double-fetch on every request just to enrich one field.
- Request / response bodies. Bodies can contain PII and signed URLs; the timing log is a request-envelope concern, not content.

### Adopted at

| Route | Method | Notes |
|-------|--------|-------|
| `/api/analyze` | POST | High-traffic, expensive (enqueues an analysis job) |
| `/api/uploads/sign` | POST | Pre-upload critical path |
| `/api/uploads/refresh` | POST | New from #195 — covered from day one |

### Deliberately NOT adopted at

- `/api/health`, `/api/ready` — load balancers call them constantly; a log per tick would drown real signal.
- `/api/chat` — returns a `ReadableStream`, so the `response.status` the wrapper sees is set before the stream completes. Documented as the streaming caveat in the helper's JSDoc; revisit once Phase 4 streaming work lands.

## Test plan

- [x] **6 new cases** in `route-logging.test.ts`: success log, requestId propagation from inbound header, non-2xx surfaces verbatim, throw → error log + rethrow, non-Error throws map to `"unknown_error"`, handler context arg passes through unchanged (so dynamic routes don't silently break).
- [x] Full web vitest: **801 passed** (6 new).
- [x] `pnpm run type-check`: clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 21 route files scanned, OK.
- [x] Local `gitleaks --no-git`: no leaks.
- [x] `eslint --max-warnings=0`: clean.

## Follow-ups (tracked in `docs/optimization-plan.md`)

- Broader adoption to remaining `/api/**` routes (low-risk mechanical change).
- **2.4** W3C `traceparent` propagation: browser → Next route → FastAPI → OpenAI.
- **2.5** Sentry alert rules (p95 / error-rate thresholds, on-call docs).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_