### PR TITLE
feat(observability): W3C traceparent propagation web → analysis

### DIFF
--- a/apps/analysis/app/middleware.py
+++ b/apps/analysis/app/middleware.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import logging
+import re
+import secrets
 import time
 from contextvars import ContextVar
 from uuid import uuid4
@@ -11,31 +13,124 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.responses import Response
 
 REQUEST_ID_HEADER = "x-request-id"
+TRACEPARENT_HEADER = "traceparent"
+
+# Anchored W3C Trace Context regex. Mirrors apps/web/src/lib/server/trace-context.ts
+# so the two services agree on which inbound values are trustworthy.
+# Spec: https://www.w3.org/TR/trace-context/
+_TRACEPARENT_PATTERN = re.compile(
+    r"^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$"
+)
+_ALL_ZERO_TRACE = re.compile(r"^0+$")
+
 _request_id_ctx: ContextVar[str] = ContextVar("request_id", default="-")
+# Trace-context fields are stored alongside the request id so log_event
+# can attach them automatically to every line emitted during this
+# request without each call-site having to thread them through.
+_trace_id_ctx: ContextVar[str] = ContextVar("trace_id", default="-")
+_span_id_ctx: ContextVar[str] = ContextVar("span_id", default="-")
+_parent_span_id_ctx: ContextVar[str] = ContextVar("parent_span_id", default="-")
 
 
 def get_request_id() -> str:
     return _request_id_ctx.get()
 
 
+def get_trace_id() -> str:
+    return _trace_id_ctx.get()
+
+
+def get_span_id() -> str:
+    return _span_id_ctx.get()
+
+
+def _random_hex(byte_count: int) -> str:
+    return secrets.token_hex(byte_count)
+
+
+def _parse_traceparent(value: str | None) -> tuple[str, str, str] | None:
+    """Return ``(trace_id, parent_span_id, flags)`` when ``value`` is a
+    well-formed W3C ``traceparent``.  Reject the all-zero degenerate
+    forms which the spec forbids — they're a common shape from
+    misconfigured emitters and would otherwise pollute our trace ids.
+    """
+    if not value:
+        return None
+    match = _TRACEPARENT_PATTERN.match(value.strip())
+    if not match:
+        return None
+    trace_id, parent_span_id, flags = match.groups()
+    if _ALL_ZERO_TRACE.match(trace_id) or _ALL_ZERO_TRACE.match(parent_span_id):
+        return None
+    return trace_id, parent_span_id, flags
+
+
+def _build_trace_context(inbound: str | None) -> tuple[str, str, str | None, str]:
+    """Return ``(trace_id, span_id, parent_span_id, flags)``.
+
+    Continues an inbound trace when one was supplied, otherwise mints
+    a fresh one and marks this hop as the trace originator
+    (``parent_span_id is None``).
+    """
+    parsed = _parse_traceparent(inbound)
+    if parsed is not None:
+        trace_id, parent_span_id, flags = parsed
+        return trace_id, _random_hex(8), parent_span_id, flags
+    return _random_hex(16), _random_hex(8), None, "00"
+
+
 def log_event(level: int, message: str, **fields: object) -> None:
-    payload = {
+    """Emit a structured JSON log line with request + trace fields.
+
+    ``trace_id`` / ``span_id`` are always populated. ``parent_span_id``
+    is omitted on trace-originator hops so on-call doesn't waste time
+    grepping for ``"-"`` as a parent id.
+    """
+    payload: dict[str, object] = {
         "level": logging.getLevelName(level).lower(),
         "message": message,
         "request_id": get_request_id(),
+        "trace_id": get_trace_id(),
+        "span_id": get_span_id(),
         "service": "phenosage-analysis",
         **fields,
     }
+    parent = _parent_span_id_ctx.get()
+    if parent != "-":
+        payload["parent_span_id"] = parent
     logging.getLogger("phenosage.analysis").log(level, json.dumps(payload, default=str))
 
 
 class RequestContextMiddleware(BaseHTTPMiddleware):
+    """Resolve request id + W3C trace context for every incoming request.
+
+    The context variables set here are picked up by ``log_event``
+    anywhere in the request lifecycle — there's no need to thread the
+    trace fields through each call site explicitly.
+    """
+
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint
     ) -> Response:
         request_id = request.headers.get(REQUEST_ID_HEADER, "").strip() or str(uuid4())
-        token = _request_id_ctx.set(request_id)
+        inbound_traceparent = request.headers.get(TRACEPARENT_HEADER)
+        trace_id, span_id, parent_span_id, flags = _build_trace_context(
+            inbound_traceparent
+        )
+
+        rid_token = _request_id_ctx.set(request_id)
+        trace_token = _trace_id_ctx.set(trace_id)
+        span_token = _span_id_ctx.set(span_id)
+        parent_token = _parent_span_id_ctx.set(parent_span_id or "-")
+
         request.state.request_id = request_id
+        request.state.trace_id = trace_id
+        request.state.span_id = span_id
+        # `outbound_traceparent` is the wire value any code inside the
+        # request handler should send on its own outbound calls (the
+        # value identifies THIS span as the parent on the next hop).
+        request.state.outbound_traceparent = f"00-{trace_id}-{span_id}-{flags}"
+
         start = time.perf_counter()
 
         try:
@@ -48,10 +143,18 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
                 path=request.url.path,
                 duration_ms=round((time.perf_counter() - start) * 1000, 2),
             )
-            _request_id_ctx.reset(token)
+            _request_id_ctx.reset(rid_token)
+            _trace_id_ctx.reset(trace_token)
+            _span_id_ctx.reset(span_token)
+            _parent_span_id_ctx.reset(parent_token)
             raise
 
         response.headers[REQUEST_ID_HEADER] = request_id
+        # Echo the inbound trace fields back on the response so the
+        # caller (apps/web) can correlate the response with its own
+        # span without having to keep the request-side state.
+        response.headers[TRACEPARENT_HEADER] = request.state.outbound_traceparent
+
         log_event(
             logging.INFO,
             "request completed",
@@ -60,5 +163,8 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
             status_code=response.status_code,
             duration_ms=round((time.perf_counter() - start) * 1000, 2),
         )
-        _request_id_ctx.reset(token)
+        _request_id_ctx.reset(rid_token)
+        _trace_id_ctx.reset(trace_token)
+        _span_id_ctx.reset(span_token)
+        _parent_span_id_ctx.reset(parent_token)
         return response

--- a/apps/analysis/tests/test_middleware_traceparent.py
+++ b/apps/analysis/tests/test_middleware_traceparent.py
@@ -1,0 +1,197 @@
+"""End-to-end tests for W3C `traceparent` propagation in
+RequestContextMiddleware.
+
+The middleware is the join point between apps/web and apps/analysis
+in our trace pipeline: it must accept a well-formed inbound
+traceparent and reject malformed values defensively (otherwise a
+typo / crafted value pollutes our trace correlation), continue the
+trace by minting a fresh span id, and echo the new traceparent back
+on the response so callers can see what this hop spanned.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import middleware
+
+SPAN_ID_RE = re.compile(r"^[0-9a-f]{16}$")
+TRACE_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+TRACEPARENT_RE = re.compile(r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$")
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """A minimal FastAPI app wired with the request-context middleware
+    so the tests exercise the real production code path, not a
+    re-implementation of the middleware's behaviour.
+    """
+    app = FastAPI()
+    app.add_middleware(middleware.RequestContextMiddleware)
+
+    @app.get("/ping")
+    def ping() -> dict[str, object]:
+        # Expose the middleware-resolved fields so tests can assert on
+        # the in-handler view as well as the outbound headers.
+        return {
+            "request_id": middleware.get_request_id(),
+            "trace_id": middleware.get_trace_id(),
+            "span_id": middleware.get_span_id(),
+        }
+
+    return app
+
+
+def _completion_log_payload(caplog: Any) -> dict[str, object] | None:
+    """Find the `request completed` payload emitted by the middleware,
+    parse the JSON, and return it. The middleware logs structured
+    JSON so on-call can grep by `trace_id`; the test mirrors that
+    parsing instead of asserting on free-form text.
+    """
+    for record in caplog.records:
+        try:
+            payload = json.loads(record.getMessage())
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if payload.get("message") == "request completed":
+            return payload
+    return None
+
+
+def test_originates_a_fresh_trace_when_no_traceparent_inbound(
+    app: FastAPI, caplog: pytest.LogCaptureFixture
+) -> None:
+    client = TestClient(app)
+    with caplog.at_level("INFO", logger="phenosage.analysis"):
+        response = client.get("/ping")
+    assert response.status_code == 200
+
+    # In-handler view: trace fields are populated, not the "-" default.
+    body = response.json()
+    assert TRACE_ID_RE.match(body["trace_id"]), body["trace_id"]
+    assert SPAN_ID_RE.match(body["span_id"]), body["span_id"]
+
+    # Outbound header echoes the SAME trace/span the handler saw, so
+    # the caller can correlate the response with its own next hop.
+    outbound = response.headers["traceparent"]
+    assert TRACEPARENT_RE.match(outbound), outbound
+    assert body["trace_id"] in outbound
+    assert body["span_id"] in outbound
+
+    # Log line: no parent_span_id because this hop is the originator.
+    log = _completion_log_payload(caplog)
+    assert log is not None
+    assert log["trace_id"] == body["trace_id"]
+    assert log["span_id"] == body["span_id"]
+    assert "parent_span_id" not in log
+
+
+def test_continues_an_inbound_trace_and_emits_fresh_span(
+    app: FastAPI, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The trace_id is the join key — it must survive verbatim across
+    services. The span_id is per-hop, so it must change. The inbound
+    span becomes our parent.
+    """
+    inbound_trace = "0af7651916cd43dd8448eb211c80319c"
+    inbound_span = "b7ad6b7169203331"
+    inbound_traceparent = f"00-{inbound_trace}-{inbound_span}-01"
+    client = TestClient(app)
+    with caplog.at_level("INFO", logger="phenosage.analysis"):
+        response = client.get("/ping", headers={"traceparent": inbound_traceparent})
+    assert response.status_code == 200
+
+    body = response.json()
+    assert body["trace_id"] == inbound_trace
+    assert body["span_id"] != inbound_span
+    assert SPAN_ID_RE.match(body["span_id"])
+
+    # Outbound traceparent preserves trace + flags, swaps in new span.
+    outbound = response.headers["traceparent"]
+    assert outbound == f"00-{inbound_trace}-{body['span_id']}-01"
+
+    log = _completion_log_payload(caplog)
+    assert log is not None
+    assert log["trace_id"] == inbound_trace
+    assert log["parent_span_id"] == inbound_span
+    assert log["span_id"] == body["span_id"]
+
+
+@pytest.mark.parametrize(
+    "bad_traceparent",
+    [
+        "not-a-real-traceparent",
+        # Wrong version field
+        "01-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        # All-zero trace id (spec forbids; common emitter bug)
+        "00-" + "0" * 32 + "-b7ad6b7169203331-01",
+        # All-zero span id (same)
+        "00-0af7651916cd43dd8448eb211c80319c-" + "0" * 16 + "-01",
+        # Uppercase hex (spec forbids)
+        "00-0AF7651916CD43DD8448EB211C80319C-b7ad6b7169203331-01",
+        # Truncated
+        "00-0af7-b7ad-01",
+        # Empty
+        "",
+    ],
+)
+def test_rejects_malformed_traceparent_and_originates_a_fresh_trace(
+    app: FastAPI, bad_traceparent: str
+) -> None:
+    """A malformed inbound value must NOT leak partial garbage into
+    our trace_id. Better to start a fresh trace than to propagate
+    corrupted state — once a bogus trace id is in our logs, it's the
+    join key and ops can't grep around it.
+    """
+    client = TestClient(app)
+    response = client.get("/ping", headers={"traceparent": bad_traceparent})
+    assert response.status_code == 200
+
+    body = response.json()
+    # New trace; nothing of the bad input survives.
+    assert TRACE_ID_RE.match(body["trace_id"]), body["trace_id"]
+    if bad_traceparent and "0af7651916cd43dd8448eb211c80319c" in bad_traceparent:
+        assert body["trace_id"] != "0af7651916cd43dd8448eb211c80319c"
+
+
+def test_log_event_attaches_trace_fields_inside_request_scope(
+    app: FastAPI, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Code that emits its own structured logs inside the request
+    handler should pick up the trace context automatically via the
+    contextvars, without each call site having to thread it through.
+    """
+    import logging
+
+    @app.get("/log-once")
+    def log_once() -> dict[str, str]:
+        middleware.log_event(logging.INFO, "handler log line", custom_field="x")
+        return {"trace_id": middleware.get_trace_id()}
+
+    inbound_trace = "0af7651916cd43dd8448eb211c80319c"
+    inbound_traceparent = f"00-{inbound_trace}-b7ad6b7169203331-01"
+    client = TestClient(app)
+    with caplog.at_level("INFO", logger="phenosage.analysis"):
+        response = client.get("/log-once", headers={"traceparent": inbound_traceparent})
+    assert response.status_code == 200
+
+    # The handler-emitted log line should carry the same trace_id as
+    # the middleware-emitted completion log — that's the entire point
+    # of using contextvars.
+    handler_payloads = []
+    for record in caplog.records:
+        try:
+            payload = json.loads(record.getMessage())
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if payload.get("message") == "handler log line":
+            handler_payloads.append(payload)
+    assert handler_payloads
+    assert handler_payloads[0]["trace_id"] == inbound_trace
+    assert handler_payloads[0]["custom_field"] == "x"

--- a/apps/web/src/lib/server/__tests__/analysis-proxy.test.ts
+++ b/apps/web/src/lib/server/__tests__/analysis-proxy.test.ts
@@ -48,6 +48,24 @@ describe("analysis-proxy", () => {
     expect(new Headers(init.headers).get("Authorization")).toBe(
       "Bearer test-key",
     );
+    // Default call without explicit traceparent: don't smuggle one
+    // onto the wire — the downstream service will start a fresh
+    // trace. Forwarding a blank or generated traceparent here would
+    // collapse traceless calls into a single phantom trace id.
+    expect(new Headers(init.headers).get("traceparent")).toBeNull();
+  });
+
+  it("forwards an explicit traceparent on outbound calls", async () => {
+    // The route handler builds the trace context once (the wrapper)
+    // and threads its `traceparent` through to the proxy so the
+    // analysis service shares the same trace id in its logs. This
+    // is the join key for end-to-end correlation across the two
+    // services.
+    mockOk({ ok: true });
+    const trace = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    await callAnalysisService({ endpoint: "/status", traceparent: trace });
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(new Headers(init.headers).get("traceparent")).toBe(trace);
   });
 
   it("serializes the body on POST", async () => {

--- a/apps/web/src/lib/server/__tests__/route-logging.test.ts
+++ b/apps/web/src/lib/server/__tests__/route-logging.test.ts
@@ -163,4 +163,51 @@ describe("withRouteLogging", () => {
     expect(handler).toHaveBeenCalledWith(expect.any(NextRequest), ctx);
     expect(await res.json()).toEqual({ id: "abc" });
   });
+
+  it("continues an inbound W3C trace: preserves traceId, fresh spanId, parentSpanId = inbound", async () => {
+    // End-to-end trace correlation depends on the wrapper carrying
+    // the inbound trace id through into its log lines so a single
+    // trace grep returns both apps/web and apps/analysis output.
+    const handler = vi.fn(async () => NextResponse.json({ ok: true }));
+    const wrapped = withRouteLogging("/api/test", handler);
+    const inbound = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    await wrapped(req("GET", { traceparent: inbound }));
+    const fields = logServerEvent.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(fields["traceId"]).toBe("0af7651916cd43dd8448eb211c80319c");
+    expect(fields["parentSpanId"]).toBe("b7ad6b7169203331");
+    // The spanId is NEWLY minted; it must not equal the inbound
+    // parent span — that would collapse the trace tree.
+    expect(fields["spanId"]).not.toBe("b7ad6b7169203331");
+    expect(fields["spanId"]).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("originates a fresh trace and omits parentSpanId when no traceparent inbound", async () => {
+    // Trace-originator hops shouldn't emit a parentSpanId field at
+    // all — including a placeholder would mislead on-call into
+    // grepping for a non-existent upstream span.
+    const handler = vi.fn(async () => NextResponse.json({ ok: true }));
+    const wrapped = withRouteLogging("/api/test", handler);
+    await wrapped(req("GET"));
+    const fields = logServerEvent.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(fields["traceId"]).toMatch(/^[0-9a-f]{32}$/);
+    expect(fields["spanId"]).toMatch(/^[0-9a-f]{16}$/);
+    expect(fields).not.toHaveProperty("parentSpanId");
+  });
+
+  it("emits the same trace context on the error-log path", async () => {
+    // A thrown handler should still produce a log line tagged with
+    // the right trace id, otherwise a crashing request becomes an
+    // orphan in the trace tree.
+    const handler = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const wrapped = withRouteLogging("/api/test", handler);
+    const inbound = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01";
+    await expect(
+      wrapped(req("POST", { traceparent: inbound })),
+    ).rejects.toBeTruthy();
+    const fields = logServerEvent.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(fields["traceId"]).toBe("0af7651916cd43dd8448eb211c80319c");
+    expect(fields["parentSpanId"]).toBe("b7ad6b7169203331");
+  });
 });

--- a/apps/web/src/lib/server/__tests__/trace-context.test.ts
+++ b/apps/web/src/lib/server/__tests__/trace-context.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildTraceContext,
+  generateSpanId,
+  generateTraceId,
+  parseTraceparent,
+  traceContextFromRequest,
+  TRACEPARENT_HEADER,
+} from "../trace-context";
+
+const VALID_TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+const VALID_SPAN_ID = "b7ad6b7169203331";
+const VALID_TRACEPARENT = `00-${VALID_TRACE_ID}-${VALID_SPAN_ID}-01`;
+
+describe("parseTraceparent", () => {
+  it("accepts a well-formed value", () => {
+    expect(parseTraceparent(VALID_TRACEPARENT)).toEqual({
+      traceId: VALID_TRACE_ID,
+      parentSpanId: VALID_SPAN_ID,
+      flags: "01",
+    });
+  });
+
+  it.each([
+    ["null", null],
+    ["empty string", ""],
+    ["wrong version", "01-" + VALID_TRACE_ID + "-" + VALID_SPAN_ID + "-01"],
+    ["short trace id", "00-abc-" + VALID_SPAN_ID + "-01"],
+    [
+      "uppercase hex",
+      "00-" + VALID_TRACE_ID.toUpperCase() + "-" + VALID_SPAN_ID + "-01",
+    ],
+    ["short span id", "00-" + VALID_TRACE_ID + "-abc-01"],
+    ["short flags", "00-" + VALID_TRACE_ID + "-" + VALID_SPAN_ID + "-1"],
+    // The spec forbids all-zero trace/span ids — they're a common
+    // shape from misconfigured emitters and would otherwise pollute
+    // our trace correlation.
+    ["all-zero trace id", "00-" + "0".repeat(32) + "-" + VALID_SPAN_ID + "-01"],
+    ["all-zero span id", "00-" + VALID_TRACE_ID + "-" + "0".repeat(16) + "-01"],
+  ])("rejects %s", (_label, value) => {
+    expect(parseTraceparent(value)).toBeNull();
+  });
+
+  it("trims surrounding whitespace before parsing", async () => {
+    expect(parseTraceparent(`  ${VALID_TRACEPARENT}  `)).toEqual({
+      traceId: VALID_TRACE_ID,
+      parentSpanId: VALID_SPAN_ID,
+      flags: "01",
+    });
+  });
+});
+
+describe("generateTraceId / generateSpanId", () => {
+  it("emits lowercase hex of the expected width", () => {
+    for (let i = 0; i < 20; i++) {
+      const traceId = generateTraceId();
+      const spanId = generateSpanId();
+      expect(traceId).toMatch(/^[0-9a-f]{32}$/);
+      expect(spanId).toMatch(/^[0-9a-f]{16}$/);
+    }
+  });
+
+  it("produces different values across calls (sanity check on RNG)", () => {
+    // Not a cryptographic-randomness assertion, just a smoke test
+    // that we're calling getRandomValues each time rather than
+    // returning a memoised constant.
+    const a = generateTraceId();
+    const b = generateTraceId();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("buildTraceContext", () => {
+  it("continues an inbound trace: preserves traceId, mints a fresh spanId, parent = inbound span", () => {
+    const ctx = buildTraceContext(VALID_TRACEPARENT);
+    expect(ctx.traceId).toBe(VALID_TRACE_ID);
+    expect(ctx.parentSpanId).toBe(VALID_SPAN_ID);
+    expect(ctx.spanId).not.toBe(VALID_SPAN_ID);
+    expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(ctx.flags).toBe("01");
+    // The wire value MUST reflect this hop's new spanId, not the
+    // inbound one. Forwarding the inbound verbatim would make
+    // downstream services see THIS hop's parent as their parent,
+    // collapsing the trace tree.
+    expect(ctx.traceparent).toBe(`00-${VALID_TRACE_ID}-${ctx.spanId}-01`);
+  });
+
+  it("originates a fresh trace when no inbound header is present", () => {
+    const ctx = buildTraceContext(null);
+    expect(ctx.parentSpanId).toBeNull();
+    expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(ctx.spanId).toMatch(/^[0-9a-f]{16}$/);
+    expect(ctx.flags).toBe("00");
+    expect(ctx.traceparent).toBe(`00-${ctx.traceId}-${ctx.spanId}-00`);
+  });
+
+  it("treats malformed inbound as 'no inbound' and originates a fresh trace", () => {
+    // Defensive: a malformed inbound value must not leak partial
+    // garbage into our outbound trace id. Better to start a fresh
+    // trace than to propagate corrupted state.
+    const ctx = buildTraceContext("not-a-real-traceparent");
+    expect(ctx.parentSpanId).toBeNull();
+    expect(ctx.traceId).toMatch(/^[0-9a-f]{32}$/);
+  });
+});
+
+describe("traceContextFromRequest", () => {
+  it("reads the traceparent header from a Request", () => {
+    const req = new Request("http://localhost/", {
+      headers: { [TRACEPARENT_HEADER]: VALID_TRACEPARENT },
+    });
+    const ctx = traceContextFromRequest(req);
+    expect(ctx.traceId).toBe(VALID_TRACE_ID);
+    expect(ctx.parentSpanId).toBe(VALID_SPAN_ID);
+  });
+
+  it("mints a fresh trace when the header is absent", () => {
+    const req = new Request("http://localhost/");
+    const ctx = traceContextFromRequest(req);
+    expect(ctx.parentSpanId).toBeNull();
+  });
+});

--- a/apps/web/src/lib/server/analysis-proxy.ts
+++ b/apps/web/src/lib/server/analysis-proxy.ts
@@ -8,12 +8,22 @@ import {
   withResilience,
   type ResilienceOptions,
 } from "./resilience";
+import { TRACEPARENT_HEADER } from "./trace-context";
 
 interface ProxyOptions {
   endpoint: string;
   method?: "GET" | "POST";
   body?: unknown;
   requestId?: string;
+  /**
+   * W3C `traceparent` value to forward to the analysis service so a
+   * single trace id grep-correlates web logs with analysis logs
+   * end-to-end. When omitted the call still works — the analysis
+   * service will start a fresh trace on its side — but the two
+   * sides won't share a trace id. Route handlers obtain this from
+   * `withRouteLogging`'s trace context (or `traceContextFromRequest`).
+   */
+  traceparent?: string;
   /**
    * Override the default 30s upstream timeout. The browser-facing route
    * handler shouldn't be left hanging on a stuck Railway service —
@@ -99,6 +109,7 @@ export async function callAnalysisService<T = unknown>(
     method = "GET",
     body,
     requestId,
+    traceparent,
     timeoutMs = configuredTimeoutMs || DEFAULT_TIMEOUT_MS,
     resilience,
   } = options;
@@ -117,15 +128,23 @@ export async function callAnalysisService<T = unknown>(
     return await breaker.run(() =>
       withResilience<T>(
         async (_attempt, signal) => {
+          const headers = withRequestIdHeader(
+            {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${apiKey}`,
+            },
+            effectiveRequestId,
+          );
+          // Forward W3C `traceparent` so the analysis service can
+          // continue the trace on its side. We pass the value
+          // through verbatim — the route handler is the span owner
+          // and built the header; we're just on the wire here.
+          if (traceparent) {
+            headers.set(TRACEPARENT_HEADER, traceparent);
+          }
           const init: RequestInit = {
             method,
-            headers: withRequestIdHeader(
-              {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${apiKey}`,
-              },
-              effectiveRequestId,
-            ),
+            headers,
             signal,
           };
           if (body !== undefined) {
@@ -341,6 +360,12 @@ export async function analyzeImage(params: {
   previousImageId?: string;
   previousStoragePath?: string;
   requestId?: string;
+  /**
+   * W3C `traceparent` for the analysis-service hop. Pass the value
+   * the calling route built via `traceContextFromRequest(request)`
+   * so the two services share a trace id in their logs.
+   */
+  traceparent?: string;
 }): Promise<AnalysisResponse> {
   const growContext: Record<string, unknown> = {
     grow_id: params.growContext.growId,
@@ -382,6 +407,7 @@ export async function analyzeImage(params: {
     method: "POST",
     body,
     ...(params.requestId ? { requestId: params.requestId } : {}),
+    ...(params.traceparent ? { traceparent: params.traceparent } : {}),
     // POST /analyze is safe to retry: the persistence layer in
     // `runAndPersistPlantAnalysis` upserts on `image_id` (uniqueness
     // enforced by `plant_analyses.image_id UNIQUE` in migration 004) and

--- a/apps/web/src/lib/server/analysis-proxy.ts
+++ b/apps/web/src/lib/server/analysis-proxy.ts
@@ -128,13 +128,13 @@ export async function callAnalysisService<T = unknown>(
     return await breaker.run(() =>
       withResilience<T>(
         async (_attempt, signal) => {
-          const headers = withRequestIdHeader(
+          const headers = new Headers(withRequestIdHeader(
             {
               "Content-Type": "application/json",
               Authorization: `Bearer ${apiKey}`,
             },
             effectiveRequestId,
-          );
+          ));
           // Forward W3C `traceparent` so the analysis service can
           // continue the trace on its side. We pass the value
           // through verbatim — the route handler is the span owner

--- a/apps/web/src/lib/server/route-logging.ts
+++ b/apps/web/src/lib/server/route-logging.ts
@@ -5,6 +5,7 @@ import {
   logServerEvent,
   REQUEST_ID_HEADER,
 } from "./request-id";
+import { traceContextFromRequest } from "./trace-context";
 
 /**
  * Higher-order wrapper that emits a structured `request completed` log
@@ -81,6 +82,13 @@ export function withRouteLogging<Args extends unknown[]>(
     // backwards and yield a negative durationMs.
     const started = performance.now();
     const method = req.method;
+    // Build the trace context once at the route boundary. The same
+    // (traceId, spanId, parentSpanId) is then emitted in both the
+    // completion log and the failure log, so a single request always
+    // grep-matches the same trace identifier across every line we
+    // produce. parentSpanId is null when this route is the trace
+    // originator (no upstream traceparent header).
+    const trace = traceContextFromRequest(req);
     try {
       const response = await handler(req, ...rest);
       // Prefer the requestId the handler actually attached to the
@@ -96,6 +104,9 @@ export function withRouteLogging<Args extends unknown[]>(
         method,
         status: response.status,
         requestId,
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        ...(trace.parentSpanId ? { parentSpanId: trace.parentSpanId } : {}),
         durationMs: Math.round(performance.now() - started),
       });
       return response;
@@ -114,6 +125,9 @@ export function withRouteLogging<Args extends unknown[]>(
         method,
         status: 500,
         requestId,
+        traceId: trace.traceId,
+        spanId: trace.spanId,
+        ...(trace.parentSpanId ? { parentSpanId: trace.parentSpanId } : {}),
         durationMs: Math.round(performance.now() - started),
         error: err instanceof Error ? err.message : "unknown_error",
       });

--- a/apps/web/src/lib/server/trace-context.ts
+++ b/apps/web/src/lib/server/trace-context.ts
@@ -1,0 +1,146 @@
+import "server-only";
+
+/**
+ * W3C Trace Context propagation helpers.
+ *
+ * Spec: https://www.w3.org/TR/trace-context/
+ *
+ * The `traceparent` header carries four positional fields separated
+ * by `-`:
+ *
+ *   version-traceId-parentSpanId-traceFlags
+ *
+ * For example:
+ *
+ *   00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+ *
+ *   - **version** is `00` (the only one currently defined).
+ *   - **traceId** is 32 lowercase hex chars (128 bits). Stays the
+ *     SAME across every hop of a single trace.
+ *   - **parentSpanId** is 16 lowercase hex chars (64 bits). The id
+ *     of the span the caller just created — i.e. the parent of the
+ *     span the receiver is about to create.
+ *   - **traceFlags** is 2 hex chars; `00` = unsampled, `01` =
+ *     sampled. We propagate whatever the upstream sent without
+ *     making a sampling decision ourselves — that's a Sentry / OTel
+ *     concern.
+ *
+ * What this module deliberately does NOT do:
+ *
+ *   - No `tracestate` parsing. We propagate `tracestate` opaquely
+ *     when implemented later; for now we only handle the basic
+ *     `traceparent` field which is enough to correlate web →
+ *     analysis logs end-to-end.
+ *   - No actual OpenTelemetry SDK integration. That's a follow-up.
+ *     The data we emit is structured-log-friendly so future OTel
+ *     wiring can backfill spans from these fields.
+ */
+
+export const TRACEPARENT_HEADER = "traceparent";
+
+/**
+ * Anchored regex covering the only currently-defined `version=00`
+ * shape. Reject malformed inbound traceparent values defensively
+ * because a typo'd or attacker-crafted value could otherwise pollute
+ * our trace ids and make grep-by-trace useless.
+ */
+const TRACEPARENT_PATTERN = /^00-([0-9a-f]{32})-([0-9a-f]{16})-([0-9a-f]{2})$/;
+
+export interface ParsedTraceparent {
+  traceId: string;
+  parentSpanId: string;
+  flags: string;
+}
+
+export function parseTraceparent(
+  value: string | null | undefined,
+): ParsedTraceparent | null {
+  if (!value) return null;
+  const match = TRACEPARENT_PATTERN.exec(value.trim());
+  if (!match) return null;
+  // Non-null assertion is safe because the regex requires all four
+  // groups; the spec also forbids the all-zero variants (traceId
+  // `0`*32 or parentSpanId `0`*16). Defending against those keeps
+  // bogus values out of our logs.
+  const [, traceId, parentSpanId, flags] = match as unknown as [
+    string,
+    string,
+    string,
+    string,
+  ];
+  if (/^0+$/.test(traceId) || /^0+$/.test(parentSpanId)) return null;
+  return { traceId, parentSpanId, flags };
+}
+
+/**
+ * `crypto.getRandomValues` works in both Node and Edge runtimes. We
+ * use it directly because `crypto.randomUUID()` produces a UUID with
+ * dashes and version/variant bits set, which is the wrong shape for
+ * a W3C trace id.
+ */
+function randomHex(byteCount: number): string {
+  const bytes = new Uint8Array(byteCount);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (const b of bytes) {
+    out += b.toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+export function generateTraceId(): string {
+  return randomHex(16);
+}
+
+export function generateSpanId(): string {
+  return randomHex(8);
+}
+
+export interface TraceContext {
+  /** Header value the current span should emit on outbound calls and in its own log lines. */
+  traceparent: string;
+  /** Stable across all hops of the same trace; the join key for grep / correlation. */
+  traceId: string;
+  /** The id of the current span — the one this hop is producing. */
+  spanId: string;
+  /** The id of the upstream span if there was one. Null if this hop is the trace originator. */
+  parentSpanId: string | null;
+  /** Two-hex-char flags, propagated as-is. */
+  flags: string;
+}
+
+/**
+ * Build the trace context the current route should log and forward.
+ *
+ *   - If a valid inbound `traceparent` is present, continue the
+ *     trace: keep its `traceId`, mint a fresh `spanId`, treat the
+ *     inbound `parentSpanId` as our parent, preserve flags.
+ *   - If no header (or malformed), this hop is the originator:
+ *     mint a fresh `traceId` and `spanId`, parent is null, flags
+ *     default to `00` (unsampled — Sentry will upgrade later).
+ *
+ * The returned `traceparent` is the wire value the current span
+ * should emit (header on outbound, field in logs). NOT the inbound
+ * value, which is now historical.
+ */
+export function buildTraceContext(
+  inboundTraceparent: string | null | undefined,
+): TraceContext {
+  const parsed = parseTraceparent(inboundTraceparent);
+  const traceId = parsed?.traceId ?? generateTraceId();
+  const spanId = generateSpanId();
+  const parentSpanId = parsed?.parentSpanId ?? null;
+  const flags = parsed?.flags ?? "00";
+  return {
+    traceparent: `00-${traceId}-${spanId}-${flags}`,
+    traceId,
+    spanId,
+    parentSpanId,
+    flags,
+  };
+}
+
+/** Convenience: read the inbound header from a `Request` and build the context. */
+export function traceContextFromRequest(request: Request): TraceContext {
+  return buildTraceContext(request.headers.get(TRACEPARENT_HEADER));
+}


### PR DESCRIPTION
## Summary

Phase 2.4 of the production-readiness plan. Adds **W3C `traceparent` propagation** end-to-end between `apps/web` and `apps/analysis` so a single trace id grep returns matching log lines from both halves of the system.

### Web side

- New `apps/web/src/lib/server/trace-context.ts`:
  - Anchored W3C parser rejecting malformed and spec-forbidden all-zero variants (common emitter bug — would otherwise pollute our trace ids).
  - `generateTraceId()` / `generateSpanId()` via `crypto.getRandomValues` (Node + Edge compatible).
  - `buildTraceContext(inbound)` returns `{ traceparent, traceId, spanId, parentSpanId, flags }` — continues an inbound trace by preserving its `traceId` and minting a fresh `spanId`, or originates a fresh trace when no header.
  - `traceContextFromRequest(request)` shortcut for route handlers.
- `route-logging.ts` builds the trace context once at the route boundary and emits `{traceId, spanId, parentSpanId?}` on **both** success and failure log lines. `parentSpanId` is omitted on trace-originator hops.
- `analysis-proxy.ts` accepts optional `traceparent` on `callAnalysisService` / `analyzeImage`; when supplied it's forwarded as the outbound header so the analysis service shares the trace id.

### Analysis side

`apps/analysis/app/middleware.py`:
- Reads `traceparent` alongside `x-request-id`, validates the W3C shape, rejects malformed / all-zero defensively.
- Continues inbound trace OR originates fresh. Stores `trace_id` / `span_id` / `parent_span_id` in **contextvars** so `log_event` picks them up automatically — handler code emitting structured logs gets the trace fields for free.
- Attaches THIS hop's outbound `traceparent` to the response so callers can correlate the response with their next-hop span.

### Scope decisions

- No `tracestate` parsing yet — `traceparent` alone is enough for log correlation; `tracestate` follows when actual OTel SDKs land.
- No instrumentation of Supabase / OpenAI outbound calls inside the analysis service — those are third parties and forwarding to them adds no value. Confined to our own service boundary.

## Test plan

- [x] **10 new trace-context cases** (parser happy/sad, hex helpers, `buildTraceContext` continue/originate/malformed paths, `traceContextFromRequest` with and without header).
- [x] **3 new route-logging cases** (continues inbound, originates fresh + omits parentSpanId, error-log path tagged with the same trace).
- [x] **1 new analysis-proxy case** (outbound `traceparent` forwarded only when supplied).
- [x] **10 new Python middleware cases** (originator path, continuator path, 7 parametrised rejection cases for malformed inbound, contextvar-based `log_event` integration).
- [x] Full web vitest: **825 passed**.
- [x] Full analysis pytest: **123 passed**.
- [x] `pnpm run type-check`, `ruff`, `mypy`: all clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 21 route files scanned, OK.
- [x] Local `gitleaks --no-git`: no leaks.

## Follow-ups (tracked in `docs/optimization-plan.md`)

- **2.5** Sentry alert rules (p95 / error-rate thresholds, on-call docs).
- Threading `traceparent` from route handlers into `analyzeImage` call sites (currently the option exists but no handler passes it yet; this PR is the plumbing, the next is the wiring).
- Full OpenTelemetry SDK integration so trace data lands in a real backend, not just structured logs.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_