### PR TITLE
Add GitHub Actions workflow for Next.js deployment

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -1,0 +1,93 @@
+# Sample workflow for building and deploying a Next.js site to GitHub Pages
+#
+# To get started with Next.js see: https://nextjs.org/docs/getting-started
+#
+name: Deploy Next.js site to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Detect package manager
+        id: detect-package-manager
+        run: |
+          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+            echo "manager=yarn" >> $GITHUB_OUTPUT
+            echo "command=install" >> $GITHUB_OUTPUT
+            echo "runner=yarn" >> $GITHUB_OUTPUT
+            exit 0
+          elif [ -f "${{ github.workspace }}/package.json" ]; then
+            echo "manager=npm" >> $GITHUB_OUTPUT
+            echo "command=ci" >> $GITHUB_OUTPUT
+            echo "runner=npx --no-install" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Unable to determine package manager"
+            exit 1
+          fi
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          # Automatically inject basePath in your Next.js configuration file and disable
+          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+          #
+          # You may remove this line if you want to manage the configuration yourself.
+          static_site_generator: next
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
+      - name: Install dependencies
+        run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Build with Next.js
+        run: ${{ steps.detect-package-manager.outputs.runner }} next build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
This workflow builds and deploys a Next.js site to GitHub Pages, including steps for detecting the package manager, installing dependencies, and uploading artifacts.

<!-- PhenoSage PR template. Keep PRs small and bounded. -->

## Outcome

<!-- One sentence: what user-visible or system-visible change does this make? -->

## Scope

- [ ] Single concern; no drive-by refactors
- [ ] Affected paths listed below

Affected paths:

```
<paths>
```

## Validation

Paste the output (or summary) of:

- [ ] `pnpm run validate`
- [ ] `pnpm turbo run type-check lint test`
- [ ] `pnpm turbo run build`
- [ ] `pnpm run security:routes`
- [ ] (If `apps/analysis` changed) `ruff check . && mypy app/ && pytest --cov=app`

## Test evidence

<!-- Paste test output, new test names added, coverage delta, or a link
     to a Playwright preview run. -->

## Observability impact

<!-- Does this change add/remove log lines? Introduce a new Sentry event
     category? Change an SLI? If "no impact", say so. -->

## Architecture & Forbidden Changes

Confirm none of the following were introduced (see `.github/copilot-instructions.md`):

- [ ] No browser code calls the analysis service or Supabase service-role APIs directly
- [ ] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
- [ ] No client component imports from `apps/web/src/lib/server/**`
- [ ] No `middleware.ts` added to act as a backend proxy
- [ ] No public Supabase Storage bucket for user content
- [ ] No edits to previously-committed `supabase/migrations/**` files
- [ ] No SQLite, second database, or new microservice introduced

## Affected Boundaries

Tick all that apply:

- [ ] Shared types (`packages/shared`)
- [ ] Supabase migration (`supabase/migrations/**`)
- [ ] Web Route Handler (`apps/web/src/app/api/**`)
- [ ] Server-only module (`apps/web/src/lib/server/**`)
- [ ] Analysis service contract (`apps/analysis/app/models/**`)
- [ ] Env vars / `.env.example`

If any boundary above is ticked, confirm contract symmetry across all sides
in the same PR (see `docs/playbooks/contract-safe-change-playbook.md`).

## Rollback

How do we revert this safely?

- [ ] Pure `git revert` is sufficient
- [ ] Requires migration rollback (describe below)
- [ ] Requires env var rollback (describe below)

```
<rollback notes>
```

## Follow-ups

<!-- List items that are intentionally deferred from this PR.
     The track-followups workflow will automatically open a GitHub issue
     for each bullet here when this PR is merged.
     Format: one bullet per deferred item, starting with "- ". -->

<!-- Example:
- Add X to handle edge case Y
- Write integration test for Z path
-->
