### PR TITLE
feat(security): magic-bytes image gate + Content-Length cap on JSON bodies

### DIFF
--- a/apps/analysis/app/services/image_quality.py
+++ b/apps/analysis/app/services/image_quality.py
@@ -76,16 +76,23 @@ def _looks_like_known_image(image_bytes: bytes) -> bool:
     """
     if len(image_bytes) < 12:
         return False
-    if image_bytes[:3] == b"\xff\xd8\xff":  # JPEG SOI
+    # Use `startswith(prefix, offset)` rather than slice comparison so
+    # each check avoids allocating a temporary bytes object — minor
+    # CPU win and a clearer expression of intent ("does the prefix
+    # match here?").
+    if image_bytes.startswith(b"\xff\xd8\xff"):  # JPEG SOI
         return True
-    if image_bytes[:8] == b"\x89PNG\r\n\x1a\n":  # PNG
+    if image_bytes.startswith(b"\x89PNG\r\n\x1a\n"):  # PNG
         return True
-    if image_bytes[:4] == b"RIFF" and image_bytes[8:12] == b"WEBP":
+    if image_bytes.startswith(b"RIFF") and image_bytes.startswith(b"WEBP", 8):
         return True
     # HEIC / HEIF: `ftyp` box marker followed by a 4-byte brand at
     # offset 8. We don't bother validating the box length field — a
     # malformed length would still trip Pillow's decoder downstream.
-    if image_bytes[4:8] == b"ftyp" and image_bytes[8:12] in {
+    # The set membership on the brand keeps slicing because there's
+    # no "startswith one of these prefixes" primitive — six chained
+    # startswith calls would be noisier than the slice.
+    if image_bytes.startswith(b"ftyp", 4) and image_bytes[8:12] in {
         b"heic",
         b"heix",
         b"hevc",

--- a/apps/analysis/app/services/image_quality.py
+++ b/apps/analysis/app/services/image_quality.py
@@ -6,6 +6,15 @@ low-confidence diagnosis. See `.github/copilot-instructions.md` §9.
 
 Heuristics — all computed with Pillow alone (no numpy / cv2):
 
+* **Magic bytes** — before any decode, confirm the first few bytes match a
+  known image format signature (JPEG, PNG, WebP, HEIC). Defence in depth
+  against clients that mislabel a non-image payload as an image; reason
+  ``image_decode_failed`` (same as Pillow's own UnidentifiedImageError,
+  since both mean "this isn't a usable image"). Pillow itself rejects
+  unknown formats, but checking signatures first means a crafted /
+  truncated file never reaches Pillow's decoders — and Pillow has had
+  parser CVEs in the past, so cutting it off at the boundary is cheap
+  insurance.
 * **Decode** — if Pillow can't open / verify the bytes, reason
   ``image_decode_failed``.
 * **Minimum size** — anything below :data:`MIN_DIMENSION_PX` on either side
@@ -22,11 +31,12 @@ Heuristics — all computed with Pillow alone (no numpy / cv2):
   image carries almost no spatial information (out-of-focus, motion-blur,
   uniform colour); reason ``too_blurry``.
 
-Check ordering matters: luminance is checked before blur because a black or
-white-out image is *also* technically blurry, but ``too_dark`` /
-``too_bright`` is the more actionable user-facing reason. Thresholds are
-module-level constants — easy to tune from a single place if real-world
-data shows we're rejecting good photos.
+Check ordering matters: magic bytes is first (cheapest, most defensive),
+luminance is checked before blur because a black or white-out image is
+*also* technically blurry, but ``too_dark`` / ``too_bright`` is the more
+actionable user-facing reason. Thresholds are module-level constants —
+easy to tune from a single place if real-world data shows we're rejecting
+good photos.
 """
 
 from __future__ import annotations
@@ -46,12 +56,61 @@ MAX_LUMINANCE = 235.0
 MIN_EDGE_VARIANCE = 50.0
 
 
+def _looks_like_known_image(image_bytes: bytes) -> bool:
+    """Return True iff ``image_bytes`` starts with a signature for one of
+    the formats the upload route accepts (JPEG, PNG, WebP, HEIC).
+
+    Implementation notes:
+      * JPEG starts with ``FF D8 FF`` — that 3-byte SOI marker is the
+        only stable prefix across the dozen-plus JPEG variants.
+      * PNG has an 8-byte fixed signature.
+      * WebP is a RIFF container — bytes 0..3 are ``RIFF``, then a
+        4-byte little-endian length, then bytes 8..11 are ``WEBP``.
+      * HEIC / HEIF stores the brand inside an ``ftyp`` box at offset
+        4. We accept the common HEIC brands (``heic``, ``heix``,
+        ``hevc``, ``hevx``) plus the generic HEIF brands (``mif1``,
+        ``msf1``) that Apple cameras sometimes emit.
+
+    Anything else — PDFs, ZIPs, executables, plain text mislabelled as
+    ``image/png`` — gets rejected before it reaches Pillow.
+    """
+    if len(image_bytes) < 12:
+        return False
+    if image_bytes[:3] == b"\xff\xd8\xff":  # JPEG SOI
+        return True
+    if image_bytes[:8] == b"\x89PNG\r\n\x1a\n":  # PNG
+        return True
+    if image_bytes[:4] == b"RIFF" and image_bytes[8:12] == b"WEBP":
+        return True
+    # HEIC / HEIF: `ftyp` box marker followed by a 4-byte brand at
+    # offset 8. We don't bother validating the box length field — a
+    # malformed length would still trip Pillow's decoder downstream.
+    if image_bytes[4:8] == b"ftyp" and image_bytes[8:12] in {
+        b"heic",
+        b"heix",
+        b"hevc",
+        b"hevx",
+        b"mif1",
+        b"msf1",
+    }:
+        return True
+    return False
+
+
 def assess_image_quality(image_bytes: bytes) -> None:
     """Raise :class:`ImageQualityInconclusive` if the image is unanalysable.
 
     Pure CPU work; no I/O. Intentionally *returns* nothing — successful
     completion means the caller may proceed to the vision model.
     """
+    # Magic-bytes check first. Pillow itself rejects unknown formats
+    # via UnidentifiedImageError, but we'd rather not feed bytes of
+    # unknown shape to a C-extension parser at all — Pillow / libjpeg
+    # / libwebp have all shipped parser CVEs in the past. This pre-
+    # check is a cheap "is the prefix plausibly an image?" gate.
+    if not _looks_like_known_image(image_bytes):
+        raise ImageQualityInconclusive(reason="image_decode_failed")
+
     try:
         with Image.open(io.BytesIO(image_bytes)) as opened:
             # `Image.open` is lazy; force a decode so corrupt payloads fail

--- a/apps/analysis/tests/test_image_quality.py
+++ b/apps/analysis/tests/test_image_quality.py
@@ -91,6 +91,75 @@ def test_assess_image_quality_rejects_empty_input() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Magic-bytes pre-decode guard (Phase 5.2)
+#
+# These tests pin the defence-in-depth contract: bytes whose prefix doesn't
+# match a known image format never reach Pillow's parsers. Pillow / libjpeg
+# / libwebp have shipped parser CVEs in the past — cutting off non-image
+# payloads at the boundary keeps the attack surface narrow.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        # A PDF labelled image/png in transit. Common mislabelling /
+        # attack-staging pattern: PDFs have a complex parser surface
+        # of their own and shouldn't be fed to an image decoder.
+        ("pdf", b"%PDF-1.7\n%abc\n"),
+        # ZIP archives (and the Office formats built on them).
+        ("zip", b"PK\x03\x04abcdefghijkl"),
+        # ELF binaries — would only appear in an active exploit
+        # attempt but worth proving we refuse them.
+        ("elf", b"\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00"),
+        # Plain text mislabelled as image/png.
+        ("text", b"hello world this is not an image"),
+        # 11 bytes — below the 12-byte minimum the sniffer needs.
+        ("too_short", b"\xff\xd8\xff" + b"\x00" * 8),
+    ],
+)
+def test_assess_image_quality_rejects_non_image_magic_bytes(
+    label: str, payload: bytes
+) -> None:
+    """Pre-decode magic-bytes check refuses bytes that aren't a known image."""
+    _ = label  # kept in the parametrize label for diagnostic output
+    with pytest.raises(ImageQualityInconclusive) as exc_info:
+        image_quality.assess_image_quality(payload)
+    assert exc_info.value.reason == "image_decode_failed"
+
+
+def test_magic_bytes_accepts_jpeg_signature() -> None:
+    # The full image would still need to pass the other quality
+    # heuristics (size, luminance, edge variance) to reach the
+    # vision model — we only assert that the magic-bytes layer
+    # doesn't block a real JPEG prefix here. Pillow's decoder will
+    # legitimately raise UnidentifiedImageError / OSError on the
+    # truncated payload, which collapses to the same
+    # `image_decode_failed` reason; the test below confirms the
+    # signature itself is recognised by exercising the private
+    # helper directly so we're not coupled to Pillow's behaviour.
+    assert image_quality._looks_like_known_image(b"\xff\xd8\xff" + b"\x00" * 12)
+
+
+def test_magic_bytes_accepts_each_supported_format() -> None:
+    """Pin every format the upload route declares we accept."""
+    # JPEG SOI marker.
+    assert image_quality._looks_like_known_image(b"\xff\xd8\xff\xe0" + b"\x00" * 10)
+    # PNG fixed 8-byte signature.
+    assert image_quality._looks_like_known_image(
+        b"\x89PNG\r\n\x1a\n" + b"\x00" * 8
+    )
+    # WebP: RIFF + 4-byte length + WEBP.
+    assert image_quality._looks_like_known_image(b"RIFF\x00\x00\x00\x00WEBP")
+    # HEIC ftyp brands the upload route claims to accept. The 4-byte
+    # box-size prefix is whatever — Pillow validates that downstream.
+    for brand in (b"heic", b"heix", b"hevc", b"hevx", b"mif1", b"msf1"):
+        assert image_quality._looks_like_known_image(
+            b"\x00\x00\x00\x18ftyp" + brand
+        ), brand
+
+
+# ---------------------------------------------------------------------------
 # Size guard
 # ---------------------------------------------------------------------------
 
@@ -195,7 +264,10 @@ def test_assess_image_quality_rejects_decompression_bomb(
 
     We monkeypatch Image.open to raise the error rather than constructing a
     genuine bomb-sized image, which would be slow and might hit resource limits
-    in CI.
+    in CI. The payload prefix below is a valid PNG signature so it passes
+    the magic-bytes pre-decode guard and actually reaches the monkey-patched
+    ``Image.open`` — using arbitrary bytes here would short-circuit on the
+    signature check and never exercise the decompression-bomb path.
     """
     from PIL import Image as _PILImage
 
@@ -204,7 +276,8 @@ def test_assess_image_quality_rejects_decompression_bomb(
 
     monkeypatch.setattr(image_quality.Image, "open", _raise)
 
+    payload = b"\x89PNG\r\n\x1a\n" + b"fake-bytes"
     with pytest.raises(ImageQualityInconclusive) as exc_info:
-        image_quality.assess_image_quality(b"fake-image-bytes")
+        image_quality.assess_image_quality(payload)
     assert exc_info.value.reason == "image_too_large"
     assert exc_info.value.code == "IMAGE_QUALITY_INCONCLUSIVE"

--- a/apps/web/src/lib/server/__tests__/validate.test.ts
+++ b/apps/web/src/lib/server/__tests__/validate.test.ts
@@ -1,21 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z, ZodError } from "zod";
 import type { NextRequest } from "next/server";
-import { parseJsonBody } from "../validate";
+import { DEFAULT_MAX_JSON_BYTES, parseJsonBody } from "../validate";
 
 const Schema = z.object({ foo: z.string().min(1) });
 
 function makeRequest({
   contentType,
+  contentLength,
   body,
   invalidJson,
 }: {
   contentType?: string | null;
+  contentLength?: string | null;
   body?: unknown;
   invalidJson?: boolean;
 }): NextRequest {
   const headers = new Headers();
   if (contentType != null) headers.set("content-type", contentType);
+  if (contentLength != null) headers.set("content-length", contentLength);
   return {
     headers,
     json: async () => {
@@ -109,5 +112,98 @@ describe("parseJsonBody", () => {
     );
     expect(r.ok).toBe(true);
     if (r.ok) expect(r.data).toEqual({ foo: "bar" });
+  });
+
+  // ─── Content-Length cap (Phase 5.3) ──────────────────────────────────────
+
+  it("returns 413 when declared content-length exceeds the default cap", async () => {
+    // 64 KiB default; declare 1 MB.
+    const req = makeRequest({
+      contentType: "application/json",
+      contentLength: String(1_000_000),
+      body: { foo: "bar" },
+    });
+    // Spy on the body reader to prove we short-circuited BEFORE
+    // reading. Without this assertion the test would still pass if
+    // the cap fired after json() ran — that defeats the purpose
+    // (memory pressure from parsing a huge body would already be
+    // applied).
+    const spy = vi.spyOn(req, "json");
+    const r = await parseJsonBody(req, Schema);
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(413);
+      expect(r.error).toMatch(/exceed/i);
+    }
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("respects an explicit maxBytes override (tighter than default)", async () => {
+    const req = makeRequest({
+      contentType: "application/json",
+      contentLength: "100",
+      body: { foo: "bar" },
+    });
+    const r = await parseJsonBody(req, Schema, { maxBytes: 64 });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.status).toBe(413);
+      // Error message includes the configured cap so an operator
+      // grepping for the limit value sees the truth, not the
+      // default.
+      expect(r.error).toContain("64");
+    }
+  });
+
+  it("respects an explicit maxBytes override (looser than default)", async () => {
+    const req = makeRequest({
+      contentType: "application/json",
+      contentLength: String(DEFAULT_MAX_JSON_BYTES + 1),
+      body: { foo: "bar" },
+    });
+    // The default would reject; an explicit larger cap accepts.
+    const r = await parseJsonBody(req, Schema, {
+      maxBytes: DEFAULT_MAX_JSON_BYTES * 2,
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts a body whose content-length is exactly at the cap", async () => {
+    // Off-by-one regression seal: the cap is "must be <= maxBytes",
+    // not "must be < maxBytes". A request at exactly the limit
+    // passes.
+    const req = makeRequest({
+      contentType: "application/json",
+      contentLength: String(DEFAULT_MAX_JSON_BYTES),
+      body: { foo: "bar" },
+    });
+    const r = await parseJsonBody(req, Schema);
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts a body when content-length header is absent (chunked transfer)", async () => {
+    // Under chunked transfer encoding the client may omit
+    // content-length entirely. The cap is best-effort against the
+    // common "honest big JSON" case, not a hard guarantee — we
+    // accept and let the framework's own body-size limits take over.
+    const req = makeRequest({
+      contentType: "application/json",
+      body: { foo: "bar" },
+    });
+    const r = await parseJsonBody(req, Schema);
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts a body when content-length header is malformed", async () => {
+    // A non-numeric content-length is the client's bug, not an
+    // attack signature on its own. We log nothing, accept, and let
+    // the body parser reveal the real shape.
+    const req = makeRequest({
+      contentType: "application/json",
+      contentLength: "not-a-number",
+      body: { foo: "bar" },
+    });
+    const r = await parseJsonBody(req, Schema);
+    expect(r.ok).toBe(true);
   });
 });

--- a/apps/web/src/lib/server/validate.ts
+++ b/apps/web/src/lib/server/validate.ts
@@ -6,9 +6,38 @@ export type ParseJsonBodyResult<T> =
   | { ok: true; data: T }
   | { ok: false; status: number; error: string; details?: ZodError };
 
+/**
+ * Default cap for JSON request bodies. 64 KiB is well above the largest
+ * legitimate payload we accept anywhere today (chat messages cap at 10k
+ * chars + metadata stays comfortably under) while small enough that a
+ * crafted multi-megabyte JSON payload can't tie up server resources or
+ * memory parsing it. Callers that need a different bound (e.g. an
+ * eventual avatar-upload route accepting base64) should pass an
+ * explicit `maxBytes`, NOT raise the default — the default is meant to
+ * be the "safe everywhere" value.
+ */
+const DEFAULT_MAX_JSON_BYTES = 64 * 1024;
+
+export interface ParseJsonBodyOptions {
+  /**
+   * Maximum number of bytes the request body is allowed to carry.
+   * Defaults to {@link DEFAULT_MAX_JSON_BYTES}. The check fires off
+   * the inbound `content-length` header BEFORE the body is read, so
+   * an oversize payload is rejected without ever being parsed.
+   *
+   * Note: this is the standard belt-and-braces shape — a client can
+   * lie about content-length or omit it entirely under chunked
+   * transfer encoding, in which case we fall back to letting the
+   * body parse and rely on framework limits. The cap is meaningful
+   * mainly against opportunistic abuse, not as a hard guarantee.
+   */
+  maxBytes?: number;
+}
+
 export async function parseJsonBody<T>(
   request: NextRequest,
   schema: ZodSchema<T>,
+  options: ParseJsonBodyOptions = {},
 ): Promise<ParseJsonBodyResult<T>> {
   // Use startsWith so we accept "application/json" and the standard
   // "application/json; charset=utf-8" variant but reject anything that
@@ -22,6 +51,24 @@ export async function parseJsonBody<T>(
       status: 415,
       error: "Expected application/json request body",
     };
+  }
+
+  // Reject oversized bodies before we read them. A client could still
+  // omit content-length (chunked encoding) or lie about it — neither
+  // is worth blocking entirely because Next.js itself rejects truly
+  // unbounded streams. The check is the cheap layer that catches the
+  // common "honest 50 MB JSON" abuse case.
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_JSON_BYTES;
+  const contentLengthHeader = request.headers.get("content-length");
+  if (contentLengthHeader !== null) {
+    const declared = Number.parseInt(contentLengthHeader, 10);
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      return {
+        ok: false,
+        status: 413,
+        error: `Request body exceeds the ${maxBytes}-byte limit.`,
+      };
+    }
   }
 
   let body: unknown;
@@ -46,3 +93,5 @@ export async function parseJsonBody<T>(
 
   return { ok: true, data: parsed.data };
 }
+
+export { DEFAULT_MAX_JSON_BYTES };


### PR DESCRIPTION
## Summary

Bundle A of the optimization plan — Phase **5.2** + Phase **5.3** together. Both touch the request-validation boundary and are small, defence-in-depth wins with no migration cost.

### 5.2 Magic-bytes image gate (`apps/analysis/app/services/image_quality.py`)

Pre-Pillow validation of the first 12 bytes of every uploaded image against the signature of one of the formats the upload route declares (JPEG, PNG, WebP, six HEIF brands).

Why pre-Pillow:
- Pillow / libjpeg / libwebp have shipped parser CVEs in the past. Refusing non-image prefixes at the boundary keeps the C-extension attack surface narrow.
- A client mislabelling a PDF / ZIP / ELF / plain-text payload as `image/png` (common mislabel pattern) now gets a clean `image_decode_failed` reason at the gate instead of either bubbling up as an obscure decoder error or being silently passed to the vision model.

Mismatches surface as the existing `image_decode_failed` reason — same code path callers already handle, so no contract change downstream.

### 5.3 Content-Length cap on JSON bodies (`apps/web/src/lib/server/validate.ts`)

`parseJsonBody` accepts a new optional `maxBytes` (default 64 KiB) and rejects oversize bodies with **413 before reading them**. The inbound `content-length` header is consulted up-front so a crafted multi-megabyte JSON payload never gets parsed.

- **Default 64 KiB** is well above the largest legitimate body any current route accepts (chat caps message at 10k chars + minimal metadata) and small enough that an opportunistic 50 MB JSON cannot tie up server resources.
- Callers can **override via `parseJsonBody(req, schema, { maxBytes })`** if they have a justified reason (e.g. an eventual base64 avatar route).
- **Chunked-transfer / missing `content-length` is intentionally allowed-through**; the cap is best-effort against opportunistic abuse, not a hard guarantee. Next.js framework limits cover the truly unbounded case.

## Test plan

- [x] **5 new web cases** in `validate.test.ts`: cap fires before `json()` is even called (spied), explicit maxBytes override tighter and looser than default, off-by-one regression seal (exactly at the cap accepts), absent content-length accepted (chunked), malformed content-length accepted.
- [x] **8 new analysis cases** in `test_image_quality.py`: parametrised rejection of PDF / ZIP / ELF / text / too-short payloads, explicit acceptance of every supported format signature (JPEG, PNG, WebP, six HEIF brands).
- [x] Updated existing `test_assess_image_quality_rejects_decompression_bomb` fixture to use a valid PNG signature prefix so it actually exercises the decomp-bomb path now that the magic-bytes gate runs first.
- [x] Full web vitest: **882 passed**.
- [x] Full analysis pytest: **130 passed**.
- [x] `pnpm run type-check`, `ruff`, `mypy`: all clean.
- [x] `pnpm run validate`: all 7 guardrails OK.
- [x] `pnpm run security:routes`: 21 route files scanned, OK.
- [x] Local `gitleaks --no-git`: no leaks.

## Phase 5 status after this PR

- **5.1** auth rate-limit ✅ (landed earlier as Phase 1.3)
- **5.2** magic-bytes MIME ✅ this PR
- **5.3** Content-Length cap ✅ this PR
- 5.4 nonce CSP — follow-up
- 5.5 key-rotation runbook — docs, follow-up
- 5.6 `security:routes` as required PR check — likely already enforced (job runs in `Repo — Guardrails`), confirm in follow-up


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_