### PR TITLE
perf(api): Cache-Control discipline + edge-runtime audit

### DIFF
--- a/apps/web/src/app/api/health/__tests__/route.test.ts
+++ b/apps/web/src/app/api/health/__tests__/route.test.ts
@@ -50,4 +50,17 @@ describe("GET /api/health", () => {
     const body = await GET().json();
     expect(body.commit).toBe("unknown");
   });
+
+  it("emits a public Cache-Control header with a stale-while-revalidate window", async () => {
+    // `/api/health` is a liveness signal with no per-user data, so a
+    // short shared cache is desirable — a burst of monitor hits and
+    // edge-network probes shouldn't each fan out to a fresh function
+    // invocation. The exact numbers (60s + 5min SWR) match the
+    // policy in the route's source; if you bump them there, update
+    // here too.
+    const res = GET();
+    expect(res.headers.get("cache-control")).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+  });
 });

--- a/apps/web/src/app/api/health/route.ts
+++ b/apps/web/src/app/api/health/route.ts
@@ -1,9 +1,23 @@
 import { NextResponse } from "next/server";
+import { publicCache } from "@/lib/server/response-headers";
 
 export const runtime = "edge";
 
+/**
+ * Lightweight liveness signal. Returns the build's deploy metadata
+ * with **no** dependency probes — that's `/api/ready`'s job, which
+ * the load balancer should call instead when it wants to know whether
+ * we can serve traffic.
+ *
+ * We allow a short public cache (60s with a 5-minute SWR window) so a
+ * burst of healthcheck hits — Vercel's edge + uptime monitors + the
+ * occasional curl from on-call — can be served without forcing a
+ * fresh function invocation each time. The body carries no
+ * user-specific data, only deploy metadata; safe to share at the CDN
+ * tier.
+ */
 export function GET() {
-  return NextResponse.json({
+  const response = NextResponse.json({
     status: "ok",
     service: "phenosage-web",
     env:
@@ -13,5 +27,9 @@ export function GET() {
       process.env["GIT_COMMIT_SHA"] ??
       "unknown",
     timestamp: new Date().toISOString(),
+  });
+  return publicCache(response, {
+    maxAgeSeconds: 60,
+    staleWhileRevalidateSeconds: 300,
   });
 }

--- a/apps/web/src/lib/server/__tests__/response-headers.test.ts
+++ b/apps/web/src/lib/server/__tests__/response-headers.test.ts
@@ -72,4 +72,36 @@ describe("publicCache", () => {
     publicCache(r, { maxAgeSeconds: 30 });
     expect(r.headers.get("cache-control")).toBe("public, max-age=30");
   });
+
+  it("clamps a negative max-age to 0 (RFC 9111 delta-seconds is unsigned)", () => {
+    // Without the clamp, `Math.floor(-10)` would survive into the
+    // header and emit an invalid `max-age=-10`. Cheap guard:
+    // `Math.max(0, ...)` after the floor.
+    const r = new Response(null, { status: 200 });
+    publicCache(r, { maxAgeSeconds: -10 });
+    expect(r.headers.get("cache-control")).toBe("public, max-age=0");
+  });
+
+  it("omits stale-while-revalidate when a fractional value floors to zero", () => {
+    // Regression: previously the `> 0` check on the raw input let
+    // 0.5 slip through, and then `Math.floor(0.5) === 0` produced
+    // `stale-while-revalidate=0` — contradicting the "omit when
+    // zero" contract pinned by the test above. Floor first, then
+    // check.
+    const r = new Response(null, { status: 200 });
+    publicCache(r, {
+      maxAgeSeconds: 60,
+      staleWhileRevalidateSeconds: 0.5,
+    });
+    expect(r.headers.get("cache-control")).toBe("public, max-age=60");
+  });
+
+  it("clamps a negative stale-while-revalidate to omission", () => {
+    const r = new Response(null, { status: 200 });
+    publicCache(r, {
+      maxAgeSeconds: 60,
+      staleWhileRevalidateSeconds: -5,
+    });
+    expect(r.headers.get("cache-control")).toBe("public, max-age=60");
+  });
 });

--- a/apps/web/src/lib/server/__tests__/response-headers.test.ts
+++ b/apps/web/src/lib/server/__tests__/response-headers.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { noStore, publicCache } from "../response-headers";
+
+describe("noStore", () => {
+  it("sets Cache-Control: private, no-store when the response has none", () => {
+    // The common case: an authed route returns a fresh Response and
+    // expects the wrapper to attach the baseline cache header. Same
+    // shape the legacy `attachRequestId` helper has.
+    const r = new Response(null, { status: 200 });
+    const out = noStore(r);
+    expect(out).toBe(r); // returned for chaining
+    expect(r.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("does NOT overwrite an existing Cache-Control header", () => {
+    // The streaming chat route already sets its own policy
+    // (`no-store, no-transform`) and would lose intent if the wrapper
+    // clobbered it. Pin the non-overwrite contract so a future
+    // refactor doesn't silently regress it.
+    const r = new Response(null, {
+      status: 200,
+      headers: { "cache-control": "no-store, no-transform" },
+    });
+    noStore(r);
+    expect(r.headers.get("cache-control")).toBe("no-store, no-transform");
+  });
+});
+
+describe("publicCache", () => {
+  it("sets max-age", () => {
+    const r = new Response(null, { status: 200 });
+    publicCache(r, { maxAgeSeconds: 60 });
+    expect(r.headers.get("cache-control")).toBe("public, max-age=60");
+  });
+
+  it("includes stale-while-revalidate when supplied", () => {
+    const r = new Response(null, { status: 200 });
+    publicCache(r, { maxAgeSeconds: 60, staleWhileRevalidateSeconds: 300 });
+    expect(r.headers.get("cache-control")).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+  });
+
+  it("omits stale-while-revalidate when zero or negative", () => {
+    const r = new Response(null, { status: 200 });
+    publicCache(r, { maxAgeSeconds: 60, staleWhileRevalidateSeconds: 0 });
+    expect(r.headers.get("cache-control")).toBe("public, max-age=60");
+  });
+
+  it("floors fractional seconds so the header is always an integer", () => {
+    // RFC 9111 §1.2.2: max-age is an integer count of seconds. A
+    // fractional value would technically be a parse error on some
+    // intermediaries; flooring is the safe move.
+    const r = new Response(null, { status: 200 });
+    publicCache(r, {
+      maxAgeSeconds: 60.9,
+      staleWhileRevalidateSeconds: 300.4,
+    });
+    expect(r.headers.get("cache-control")).toBe(
+      "public, max-age=60, stale-while-revalidate=300",
+    );
+  });
+
+  it("overwrites a prior Cache-Control header", () => {
+    // Unlike `noStore`, `publicCache` is a deliberate assertion that
+    // the response IS safe to share. The caller has committed to
+    // public caching, so we always take the wheel.
+    const r = new Response(null, {
+      status: 200,
+      headers: { "cache-control": "private, no-store" },
+    });
+    publicCache(r, { maxAgeSeconds: 30 });
+    expect(r.headers.get("cache-control")).toBe("public, max-age=30");
+  });
+});

--- a/apps/web/src/lib/server/__tests__/route-logging.test.ts
+++ b/apps/web/src/lib/server/__tests__/route-logging.test.ts
@@ -194,6 +194,33 @@ describe("withRouteLogging", () => {
     expect(fields).not.toHaveProperty("parentSpanId");
   });
 
+  it("applies Cache-Control: private, no-store by default", async () => {
+    // Authed routes wrapped by withRouteLogging carry session-scoped
+    // data; the wrapper supplies the baseline cache header so each
+    // route doesn't have to remember it. A regression here would let
+    // intermediate proxies hold onto per-user responses.
+    const handler = vi.fn(async () => NextResponse.json({ ok: true }));
+    const wrapped = withRouteLogging("/api/test", handler);
+    const res = await wrapped(req("GET"));
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("does not overwrite a Cache-Control header the handler already set", async () => {
+    // The streaming chat route uses `no-store, no-transform` because
+    // a transforming proxy would corrupt SSE framing. The wrapper
+    // must not clobber that more-specific policy.
+    const handler = vi.fn(
+      async () =>
+        new Response("ok", {
+          status: 200,
+          headers: { "cache-control": "no-store, no-transform" },
+        }),
+    );
+    const wrapped = withRouteLogging("/api/stream", handler);
+    const res = await wrapped(req("GET"));
+    expect(res.headers.get("cache-control")).toBe("no-store, no-transform");
+  });
+
   it("emits the same trace context on the error-log path", async () => {
     // A thrown handler should still produce a log line tagged with
     // the right trace id, otherwise a crashing request becomes an

--- a/apps/web/src/lib/server/response-headers.ts
+++ b/apps/web/src/lib/server/response-headers.ts
@@ -52,14 +52,21 @@ export function publicCache<T extends Response>(
   response: T,
   options: PublicCacheOptions,
 ): T {
-  const parts = [`public`, `max-age=${Math.floor(options.maxAgeSeconds)}`];
-  if (
-    options.staleWhileRevalidateSeconds !== undefined &&
-    options.staleWhileRevalidateSeconds > 0
-  ) {
-    parts.push(
-      `stale-while-revalidate=${Math.floor(options.staleWhileRevalidateSeconds)}`,
-    );
+  // RFC 9111 §1.2.2 requires `delta-seconds` to be a non-negative
+  // integer. Floor first, then clamp at zero so a caller that hands
+  // us a negative or fractional value can never produce an invalid
+  // header.
+  const maxAge = Math.max(0, Math.floor(options.maxAgeSeconds));
+  const parts = [`public`, `max-age=${maxAge}`];
+  if (options.staleWhileRevalidateSeconds !== undefined) {
+    // Same floor-then-clamp dance, then drop the field entirely if
+    // it rounds to zero — `stale-while-revalidate=0` is a no-op
+    // contractually, and emitting it would contradict the omit-when-
+    // zero behaviour the tests pin.
+    const swr = Math.max(0, Math.floor(options.staleWhileRevalidateSeconds));
+    if (swr > 0) {
+      parts.push(`stale-while-revalidate=${swr}`);
+    }
   }
   // Public-cache callers ARE asserting that the response is safe to
   // share, so we overwrite any prior Cache-Control header — the

--- a/apps/web/src/lib/server/response-headers.ts
+++ b/apps/web/src/lib/server/response-headers.ts
@@ -1,0 +1,69 @@
+import "server-only";
+
+/**
+ * Response-header policy helpers for API routes.
+ *
+ * The headers set here are the cache-side of the security envelope:
+ *
+ *   - `noStore(response)` — `Cache-Control: private, no-store`. The
+ *     default for any authenticated route. Intermediate proxies and
+ *     shared caches MUST NOT store the response, and even
+ *     well-behaved browser caches will only hold it for the current
+ *     session window. This is the right default for any response
+ *     that carries per-user data or that depends on a session
+ *     cookie / bearer token.
+ *
+ *   - `publicCache(response, { maxAgeSeconds, staleWhileRevalidateSeconds })`
+ *     — `Cache-Control: public, max-age=N, stale-while-revalidate=M`.
+ *     For genuinely cacheable surfaces (health JSON, marketing
+ *     fragments). Caller passes explicit values so we never ship a
+ *     default that silently caches something user-specific.
+ *
+ * Both helpers mutate the response's headers in place and return the
+ * same response so they can chain — the existing `attachRequestId`
+ * helper has the same shape.
+ */
+
+const NO_STORE = "private, no-store";
+
+export function noStore<T extends Response>(response: T): T {
+  // Use `set`, not `append`: if a downstream wrapper has already
+  // configured a Cache-Control (e.g. a streaming chat response that
+  // sets `no-store, no-transform`), we leave that alone. Only an
+  // unset header gets the default.
+  if (!response.headers.has("cache-control")) {
+    response.headers.set("cache-control", NO_STORE);
+  }
+  return response;
+}
+
+export interface PublicCacheOptions {
+  /** `max-age` in seconds. Required; no implicit default. */
+  maxAgeSeconds: number;
+  /**
+   * `stale-while-revalidate` in seconds. Optional. When set, the cache
+   * may serve a stale response while a background revalidation
+   * fetches a fresh one.
+   */
+  staleWhileRevalidateSeconds?: number;
+}
+
+export function publicCache<T extends Response>(
+  response: T,
+  options: PublicCacheOptions,
+): T {
+  const parts = [`public`, `max-age=${Math.floor(options.maxAgeSeconds)}`];
+  if (
+    options.staleWhileRevalidateSeconds !== undefined &&
+    options.staleWhileRevalidateSeconds > 0
+  ) {
+    parts.push(
+      `stale-while-revalidate=${Math.floor(options.staleWhileRevalidateSeconds)}`,
+    );
+  }
+  // Public-cache callers ARE asserting that the response is safe to
+  // share, so we overwrite any prior Cache-Control header — the
+  // helper's whole job is to set it.
+  response.headers.set("cache-control", parts.join(", "));
+  return response;
+}

--- a/apps/web/src/lib/server/route-logging.ts
+++ b/apps/web/src/lib/server/route-logging.ts
@@ -5,6 +5,7 @@ import {
   logServerEvent,
   REQUEST_ID_HEADER,
 } from "./request-id";
+import { noStore } from "./response-headers";
 import { traceContextFromRequest } from "./trace-context";
 
 /**
@@ -91,6 +92,15 @@ export function withRouteLogging<Args extends unknown[]>(
     const trace = traceContextFromRequest(req);
     try {
       const response = await handler(req, ...rest);
+      // Apply the default Cache-Control for authed API responses. The
+      // wrapped routes are all session-scoped today (analyze, upload
+      // sign, upload refresh), so `private, no-store` is the correct
+      // baseline — it prevents intermediate proxies and shared caches
+      // from holding onto per-user data. `noStore` is a no-op when
+      // the handler already set its own Cache-Control (e.g. the
+      // streaming chat route opts into `no-store, no-transform`), so
+      // routes that need a different policy keep control of it.
+      noStore(response);
       // Prefer the requestId the handler actually attached to the
       // response. When the inbound request has no `x-request-id`
       // header, both the wrapper and the handler would otherwise


### PR DESCRIPTION
## Summary

Bundle B of the optimization plan — Phase **3.5** (Cache-Control discipline) and Phase **3.8** (edge-runtime audit) together. Both touch the response layer.

### 3.5 Cache-Control discipline

New `apps/web/src/lib/server/response-headers.ts` exposes two helpers:

- `noStore(response)` → `Cache-Control: private, no-store`. The safe default for any authed surface. Critically, it **leaves an existing Cache-Control header alone** — the streaming chat route already sets `no-store, no-transform` to keep SSE framing intact, and that policy survives.
- `publicCache(response, { maxAgeSeconds, staleWhileRevalidateSeconds })` → `Cache-Control: public, max-age=N, stale-while-revalidate=M`. Caller passes explicit values so we never silently cache something user-specific. Floors fractional seconds (RFC 9111 integer-only field).

`withRouteLogging` now applies `noStore` by default. The current wrapped routes are `/api/analyze`, `/api/uploads/sign`, `/api/uploads/refresh` — all session-scoped, so `private, no-store` is the correct baseline. Any route that needs a different policy keeps control: setting a Cache-Control on the response before returning shields it from the wrapper's default.

`/api/health` switched to `publicCache(response, { 60s, 300s SWR })` because the response carries only deploy metadata (no per-user data) and the endpoint gets hit by uptime monitors + Vercel edge probes. A short shared cache + 5-minute SWR means a burst of healthcheck hits doesn't each fan out to a fresh function invocation, while a real outage still surfaces within the cache window.

### 3.8 Edge-runtime audit

**Finding**: the existing 3 edge routes (`/api/health`, `/api/ready`, `/api/healthz`) are the right set. Every other route imports from `@/lib/server/**` which uses the Supabase service-role client + Node-specific helpers — moving them would require a substantive refactor of the server-lib boundary and isn't a near-term win. Documented in the optimization plan; no code changes here.

## Test plan

- [x] **7 new cases** in `response-headers.test.ts`: noStore happy path + non-overwrite, publicCache max-age-only / with-SWR / SWR=0 omitted / fractional floor / overwrites prior header.
- [x] **2 new cases** in `route-logging.test.ts`: wrapper applies `private, no-store` by default; wrapper respects an existing Cache-Control the handler already set (streaming-route contract).
- [x] **1 new case** in `api/health/__tests__/route.test.ts`: emits the new `public, max-age=60, stale-while-revalidate=300` header.
- [x] Full web vitest: **892 passed**.
- [x] `pnpm run type-check`, `validate`, `security:routes`: all clean.
- [x] Local `gitleaks --no-git`: no leaks.

## Where Phase 3 stands after this PR

- ✅ 3.1 N+1 in compare_plants
- ⏭ 3.2 bundle analyzer setup
- ⏭ 3.3 cursor pagination on list endpoints
- ⏭ 3.4 streaming chat
- ✅ 3.5 Cache-Control discipline (this PR)
- ⏭ 3.6 EXPLAIN ANALYZE sweep
- ⏭ 3.7 pgvector HNSW (gated on >10k embeddings)
- ✅ 3.8 edge runtime audit (this PR — finding documented, no code change needed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_