### PR TITLE
feat: "What Changed?" two-image AI diff on plant detail page

### DIFF
--- a/apps/analysis/app/models/analysis.py
+++ b/apps/analysis/app/models/analysis.py
@@ -116,3 +116,65 @@ class AnalyzeResponse(BaseModel):
     is_fallback: bool = False
     fallback_reason: str | None = None
     request_id: str | None = None
+
+
+class CompareRequest(BaseModel):
+    """Request body for POST /compare.
+
+    The web proxy sends the two most recent images for a plant. The
+    "current" image is the freshest capture; "previous" is the prior one.
+    Order matters: the model is told to describe how the plant changed
+    *from previous to current*.
+    """
+
+    plant_id: str
+    image_id_current: str
+    storage_path_current: str
+    image_id_previous: str
+    storage_path_previous: str
+    grow_context: GrowContext
+
+    @field_validator("storage_path_current")
+    @classmethod
+    def _check_current(cls, value: str) -> str:
+        return _validate_storage_path(value)
+
+    @field_validator("storage_path_previous")
+    @classmethod
+    def _check_previous(cls, value: str) -> str:
+        return _validate_storage_path(value)
+
+
+class UniformityDelta(StrEnum):
+    """Coarse direction of canopy uniformity / overall health between the two
+    images. Mirrors the ``trend`` vocabulary in the executive-summary spec
+    so the UI can colour-code consistently with the health score."""
+
+    improved = "improved"
+    unchanged = "unchanged"
+    declined = "declined"
+    unknown = "unknown"
+
+
+class CompareResponse(BaseModel):
+    """Structured "what changed" between two plant images.
+
+    The UI's "What Changed?" button renders ``summary`` as a one-liner and
+    ``bullets`` as a list. ``uniformity_delta`` drives the colour token.
+    """
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    plant_id: str
+    image_id_current: str
+    image_id_previous: str
+    summary: str
+    bullets: list[str]
+    uniformity_delta: UniformityDelta = UniformityDelta.unknown
+    confidence: float = Field(default=0.0, ge=0, le=1)
+    analyzed_at: datetime
+    model_version: str
+    analysis_mode: str = "fallback"
+    is_fallback: bool = False
+    fallback_reason: str | None = None
+    request_id: str | None = None

--- a/apps/analysis/app/routers/analyze.py
+++ b/apps/analysis/app/routers/analyze.py
@@ -2,8 +2,14 @@ from fastapi import APIRouter, Depends, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.config import settings
-from app.models.analysis import AnalyzeRequest, AnalyzeResponse
+from app.models.analysis import (
+    AnalyzeRequest,
+    AnalyzeResponse,
+    CompareRequest,
+    CompareResponse,
+)
 from app.services.image_analysis import run_analysis
+from app.services.image_comparison import compare_images
 
 router = APIRouter()
 bearer = HTTPBearer()
@@ -33,3 +39,21 @@ async def analyze_plant(
     _: None = Depends(verify_api_key),
 ) -> AnalyzeResponse:
     return await run_analysis(request)
+
+
+@router.post(
+    "/compare",
+    response_model=CompareResponse,
+    summary='Compare two plant images and return a "what changed" payload',
+    description=(
+        "Accepts the storage paths for the two most recent images of a plant "
+        "(current and previous) plus grow context, downloads both, and runs a "
+        "single multimodal vision call describing how the plant changed. "
+        "Called only by the Next.js proxy — never directly by the browser."
+    ),
+)
+async def compare_plant_images(
+    request: CompareRequest,
+    _: None = Depends(verify_api_key),
+) -> CompareResponse:
+    return await compare_images(request)

--- a/apps/analysis/app/services/__init__.py
+++ b/apps/analysis/app/services/__init__.py
@@ -1,6 +1,11 @@
 from app.services.image_analysis import run_analysis
 from app.services.image_comparison import compare_images
-from app.services.prompts import SYSTEM_PROMPT, build_analysis_prompt
+from app.services.prompts import (
+    COMPARISON_SYSTEM_PROMPT,
+    SYSTEM_PROMPT,
+    build_analysis_prompt,
+    build_comparison_prompt,
+)
 from app.services.scoring import compute_health_score
 
 __all__ = [
@@ -8,5 +13,7 @@ __all__ = [
     "compare_images",
     "compute_health_score",
     "build_analysis_prompt",
+    "build_comparison_prompt",
     "SYSTEM_PROMPT",
+    "COMPARISON_SYSTEM_PROMPT",
 ]

--- a/apps/analysis/app/services/image_analysis.py
+++ b/apps/analysis/app/services/image_analysis.py
@@ -3,21 +3,16 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import re
 from datetime import UTC, datetime
-from urllib.parse import quote
-
-import httpx
 
 from app.config import settings
 from app.errors import (
     AnalysisError,
     ConfigurationError,
-    InvalidStoragePath,
     ModelBadResponse,
     ModelRateLimited,
     ModelUnavailable,
-    StorageUnavailable,
+    StorageUnavailable,  # noqa: F401 - re-exported for tests that reference image_analysis.StorageUnavailable
 )
 from app.middleware import get_request_id, log_event
 from app.models.analysis import (
@@ -31,6 +26,7 @@ from app.services.image_quality import assess_image_quality
 from app.services.prompts import SYSTEM_PROMPT, build_analysis_prompt
 from app.services.retry import with_retry
 from app.services.scoring import compute_health_score
+from app.services.storage import fetch_image as _fetch_storage_image
 
 # Bounded retries for transient upstream failures. Storage gets one extra
 # attempt over the model because it is dramatically cheaper to re-run and
@@ -44,62 +40,6 @@ _MODEL_CALL_MAX_ATTEMPTS = 2
 
 MODEL_VERSION = "gpt-4o-mini-vision"
 logger = logging.getLogger(__name__)
-_STORAGE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
-
-
-def _sanitize_storage_path(storage_path: str) -> str:
-    path = storage_path.strip()
-    if (
-        not path
-        or path.startswith("/")
-        or path.startswith(".")
-        or ".." in path
-        or "\\" in path
-        or "?" in path
-        or "#" in path
-        or not _STORAGE_PATH_PATTERN.fullmatch(path)
-    ):
-        raise InvalidStoragePath()
-    return quote(path, safe="/-._~")
-
-
-async def _fetch_storage_image(storage_path: str) -> tuple[bytes, str]:
-    if not settings.supabase_url or not settings.supabase_service_role_key:
-        # Missing creds is a deploy-time misconfiguration, not a transient
-        # failure — never retry.
-        raise ConfigurationError("Supabase storage credentials are not configured")
-
-    safe_storage_path = _sanitize_storage_path(storage_path)
-    base_url = settings.supabase_url.rstrip("/")
-    url = (
-        f"{base_url}/storage/v1/object/authenticated/plant-images/"
-        f"{safe_storage_path}"
-    )
-    headers = {
-        "Authorization": f"Bearer {settings.supabase_service_role_key}",
-        "x-request-id": get_request_id(),
-    }
-
-    try:
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            response = await client.get(url, headers=headers)
-            response.raise_for_status()
-            content_type = response.headers.get("content-type", "image/jpeg")
-            return response.content, content_type
-    except httpx.HTTPStatusError as exc:
-        # 401/403 here means the service-role key is wrong / revoked — that's
-        # a configuration problem, not a transient outage.
-        if exc.response.status_code in (401, 403):
-            raise ConfigurationError(
-                "Supabase rejected the service-role credential."
-            ) from exc
-        raise StorageUnavailable(
-            f"Supabase storage returned HTTP {exc.response.status_code}."
-        ) from exc
-    except (httpx.TimeoutException, httpx.TransportError, ConnectionError) as exc:
-        raise StorageUnavailable(
-            "Supabase storage is unreachable or timed out."
-        ) from exc
 
 
 def _build_fallback_response(

--- a/apps/analysis/app/services/image_comparison.py
+++ b/apps/analysis/app/services/image_comparison.py
@@ -1,35 +1,257 @@
-"""Image-comparison stub (Milestone 2).
+"""Two-image "what changed?" comparison.
 
-Intentionally unimplemented. The active analysis path in
-``image_analysis.run_analysis`` hardcodes ``comparison_summary=None`` and
-the web client only renders a comparison block when that field is truthy
-(see ``apps/web/src/app/(app)/plants/[plantId]/page.tsx``), so users
-never see a placeholder string. The defensive sentinel below ensures
-this function cannot be wired into a production path by accident — a
-future PR that ships real comparison logic must replace the body
-wholesale, not extend it.
+The Next.js proxy calls ``POST /compare`` with the two most recent
+``plant_images`` for a plant. We download both, send them in a single
+multimodal vision call, and return a structured ``CompareResponse`` whose
+bullets become the UI's "What changed?" list.
+
+Failure model mirrors ``image_analysis.run_analysis``: only expected
+dependency failures (``AnalysisError`` subclasses) degrade to an
+inconclusive envelope. Programmer defects propagate so they surface in
+monitoring rather than masquerading as a low-confidence diagnosis.
 """
 
 from __future__ import annotations
 
+import base64
+import json
+import logging
+from datetime import UTC, datetime
 
-async def compare_images(
-    image_id_a: str,
-    storage_path_a: str,
-    image_id_b: str,
-    storage_path_b: str,
-) -> str:
-    """Compare two plant images and return a descriptive summary of changes.
+from app.config import settings
+from app.errors import (
+    AnalysisError,
+    ConfigurationError,
+    ModelBadResponse,
+    ModelRateLimited,
+    ModelUnavailable,
+)
+from app.middleware import get_request_id, log_event
+from app.models.analysis import CompareRequest, CompareResponse, UniformityDelta
+from app.services.image_quality import assess_image_quality
+from app.services.prompts import (
+    COMPARISON_SYSTEM_PROMPT,
+    build_comparison_prompt,
+)
+from app.services.retry import with_retry
+from app.services.storage import fetch_image
 
-    Raises
-    ------
-    NotImplementedError
-        Always. Until Milestone 2 implements real comparison, calling this
-        from a production path is a bug — surface it loudly instead of
-        returning a misleading placeholder string.
-    """
-    _ = (image_id_a, storage_path_a, image_id_b, storage_path_b)
-    raise NotImplementedError(
-        "Image comparison is not yet implemented (Milestone 2). "
-        "The active analysis path must not call this function."
+logger = logging.getLogger(__name__)
+
+MODEL_VERSION = "gpt-4o-mini-vision"
+_STORAGE_FETCH_MAX_ATTEMPTS = 3
+_MODEL_CALL_MAX_ATTEMPTS = 2
+_MAX_BULLETS = 5
+
+
+def _build_fallback_response(
+    request: CompareRequest,
+    *,
+    reason: str,
+) -> CompareResponse:
+    return CompareResponse(
+        plant_id=request.plant_id,
+        image_id_current=request.image_id_current,
+        image_id_previous=request.image_id_previous,
+        summary=(
+            "Inconclusive comparison. The primary path was unavailable, so no "
+            "confident description of change was produced."
+        ),
+        bullets=[
+            "Comparison could not be completed — retry after confirming "
+            "storage access and model availability.",
+        ],
+        uniformity_delta=UniformityDelta.unknown,
+        confidence=0.0,
+        analyzed_at=datetime.now(tz=UTC),
+        model_version=MODEL_VERSION,
+        analysis_mode="fallback",
+        is_fallback=True,
+        fallback_reason=reason,
+        request_id=get_request_id(),
     )
+
+
+def _coerce_uniformity(value: object) -> UniformityDelta:
+    if isinstance(value, str):
+        try:
+            return UniformityDelta(value)
+        except ValueError:
+            return UniformityDelta.unknown
+    return UniformityDelta.unknown
+
+
+def _coerce_bullets(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        if isinstance(item, str):
+            trimmed = item.strip()
+            if trimmed:
+                out.append(trimmed)
+        if len(out) >= _MAX_BULLETS:
+            break
+    return out
+
+
+async def _call_vision_model(
+    request: CompareRequest,
+    *,
+    current_bytes: bytes,
+    current_content_type: str,
+    previous_bytes: bytes,
+    previous_content_type: str,
+) -> CompareResponse:
+    if not settings.openai_api_key:
+        raise ConfigurationError("OPENAI_API_KEY is not configured")
+
+    from openai import AsyncOpenAI
+
+    previous_data_url = (
+        f"data:{previous_content_type};base64,"
+        f"{base64.b64encode(previous_bytes).decode('utf-8')}"
+    )
+    current_data_url = (
+        f"data:{current_content_type};base64,"
+        f"{base64.b64encode(current_bytes).decode('utf-8')}"
+    )
+
+    client = AsyncOpenAI(api_key=settings.openai_api_key)
+    try:
+        completion = await client.chat.completions.create(
+            model=MODEL_VERSION,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": COMPARISON_SYSTEM_PROMPT},
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": build_comparison_prompt(request.grow_context),
+                        },
+                        {"type": "image_url", "image_url": {"url": previous_data_url}},
+                        {"type": "image_url", "image_url": {"url": current_data_url}},
+                    ],
+                },
+            ],
+        )
+    except Exception as exc:
+        cls_name = exc.__class__.__name__
+        status = getattr(exc, "status_code", None) or getattr(
+            getattr(exc, "response", None), "status_code", None
+        )
+        if cls_name in {"APITimeoutError", "TimeoutError"} or isinstance(
+            exc, TimeoutError
+        ):
+            raise ModelUnavailable("Model call timed out.") from exc
+        if status == 429 or cls_name == "RateLimitError":
+            raise ModelRateLimited("Model rate limited.") from exc
+        if isinstance(status, int) and status >= 500:
+            raise ModelUnavailable(
+                f"Model upstream returned HTTP {status}."
+            ) from exc
+        if cls_name in {"APIConnectionError", "ConnectionError"}:
+            raise ModelUnavailable("Model upstream is unreachable.") from exc
+        if isinstance(status, int) and status in (401, 403):
+            raise ConfigurationError("Model rejected our credentials.") from exc
+        raise
+
+    raw_content = completion.choices[0].message.content or "{}"
+    try:
+        parsed = json.loads(raw_content)
+    except (ValueError, TypeError) as exc:
+        raise ModelBadResponse("Model returned non-JSON content.") from exc
+    if not isinstance(parsed, dict):
+        raise ModelBadResponse("Model returned a non-object JSON payload.")
+
+    bullets = _coerce_bullets(parsed.get("bullets"))
+    if not bullets:
+        # Treat an empty bullet list as a soft signal rather than a hard
+        # error — surface a single low-confidence note so the UI never
+        # renders a "0 changes" empty state silently.
+        bullets = ["No visible change detected."]
+
+    summary = parsed.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        summary = "Comparison completed but the summary was incomplete."
+
+    confidence_raw = parsed.get("confidence")
+    confidence = (
+        float(confidence_raw)
+        if isinstance(confidence_raw, (int, float))
+        else 0.0
+    )
+    confidence = max(0.0, min(1.0, confidence))
+
+    return CompareResponse(
+        plant_id=request.plant_id,
+        image_id_current=request.image_id_current,
+        image_id_previous=request.image_id_previous,
+        summary=summary.strip(),
+        bullets=bullets,
+        uniformity_delta=_coerce_uniformity(parsed.get("uniformity_delta")),
+        confidence=confidence,
+        analyzed_at=datetime.now(tz=UTC),
+        model_version=MODEL_VERSION,
+        analysis_mode="model",
+        is_fallback=False,
+        fallback_reason=None,
+        request_id=get_request_id(),
+    )
+
+
+async def compare_images(request: CompareRequest) -> CompareResponse:
+    """Compare two plant images and return a structured "what changed" payload.
+
+    Both images are pre-gated by ``assess_image_quality`` so an unanalysable
+    capture surfaces as an explicit inconclusive envelope rather than a
+    low-confidence vision diagnosis. Only one bad image is needed to fall
+    back.
+    """
+    try:
+        current_bytes, current_content_type = await with_retry(
+            lambda: fetch_image(request.storage_path_current),
+            operation="storage.fetch.current",
+            max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
+        )
+        previous_bytes, previous_content_type = await with_retry(
+            lambda: fetch_image(request.storage_path_previous),
+            operation="storage.fetch.previous",
+            max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
+        )
+        assess_image_quality(current_bytes)
+        assess_image_quality(previous_bytes)
+        response = await with_retry(
+            lambda: _call_vision_model(
+                request,
+                current_bytes=current_bytes,
+                current_content_type=current_content_type,
+                previous_bytes=previous_bytes,
+                previous_content_type=previous_content_type,
+            ),
+            operation="model.compare",
+            max_attempts=_MODEL_CALL_MAX_ATTEMPTS,
+        )
+        log_event(
+            logging.INFO,
+            "comparison completed",
+            plant_id=request.plant_id,
+            image_id_current=request.image_id_current,
+            image_id_previous=request.image_id_previous,
+            analysis_mode=response.analysis_mode,
+            is_fallback=response.is_fallback,
+        )
+        return response
+    except AnalysisError as exc:
+        log_kwargs: dict[str, object] = {
+            "plant_id": request.plant_id,
+            "image_id_current": request.image_id_current,
+            "image_id_previous": request.image_id_previous,
+            "fallback_reason": exc.code,
+        }
+        if hasattr(exc, "reason"):
+            log_kwargs["image_quality_reason"] = exc.reason
+        log_event(logging.WARNING, "comparison fallback triggered", **log_kwargs)
+        return _build_fallback_response(request, reason=exc.code)

--- a/apps/analysis/app/services/image_comparison.py
+++ b/apps/analysis/app/services/image_comparison.py
@@ -13,6 +13,7 @@ monitoring rather than masquerading as a low-confidence diagnosis.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -211,15 +212,23 @@ async def compare_images(request: CompareRequest) -> CompareResponse:
     back.
     """
     try:
-        current_bytes, current_content_type = await with_retry(
-            lambda: fetch_image(request.storage_path_current),
-            operation="storage.fetch.current",
-            max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
-        )
-        previous_bytes, previous_content_type = await with_retry(
-            lambda: fetch_image(request.storage_path_previous),
-            operation="storage.fetch.previous",
-            max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
+        # The two fetches are independent — run them concurrently so the
+        # comparison's wall-clock is one storage round-trip + one model
+        # call instead of two storage round-trips serialised.
+        (
+            (current_bytes, current_content_type),
+            (previous_bytes, previous_content_type),
+        ) = await asyncio.gather(
+            with_retry(
+                lambda: fetch_image(request.storage_path_current),
+                operation="storage.fetch.current",
+                max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
+            ),
+            with_retry(
+                lambda: fetch_image(request.storage_path_previous),
+                operation="storage.fetch.previous",
+                max_attempts=_STORAGE_FETCH_MAX_ATTEMPTS,
+            ),
         )
         assess_image_quality(current_bytes)
         assess_image_quality(previous_bytes)

--- a/apps/analysis/app/services/prompts.py
+++ b/apps/analysis/app/services/prompts.py
@@ -36,6 +36,57 @@ When strain/cultivar context is supplied, use it as a weak prior only — never 
 """
 
 
+COMPARISON_SYSTEM_PROMPT = """You are an expert cannabis cultivation consultant.
+You will be shown two photos of the same plant or canopy: the FIRST image is
+the previous capture, the SECOND image is the most recent. Describe what
+changed *from previous to current* — focus on differences a grower can act on.
+
+Return ONLY a JSON object in this exact shape:
+{
+  "summary": "<one short sentence describing the overall change>",
+  "bullets": [
+    "<short concrete observation about a single change>",
+    "<another change>"
+  ],
+  "uniformity_delta": "<improved|unchanged|declined|unknown>",
+  "confidence": <number 0-1>
+}
+
+Rules:
+- 1 to 5 bullets, each a single concrete observation (color shift, canopy density,
+  flower development, leaf curl, stress signs, growth/stretch, etc.).
+- Do NOT speculate about causes; describe visible differences only.
+- If the two images are indistinguishable, set bullets to a single
+  "No visible change detected" entry, uniformity_delta to "unchanged",
+  and confidence <= 0.4.
+- If lighting/angle differs so dramatically that comparison is unreliable,
+  set uniformity_delta to "unknown" and confidence <= 0.3.
+- Never include camera-only observations (lighting temperature, framing) as
+  bullets unless they prevent a confident comparison — in which case mention
+  the limitation in the summary.
+"""
+
+
+def build_comparison_prompt(grow_context: GrowContext) -> str:
+    """Build the user-message text for a two-image comparison call."""
+    parts = [
+        "Compare these two cannabis plant images. The FIRST image is the "
+        "previous capture; the SECOND image is the most recent.",
+    ]
+    if grow_context.strain:
+        parts.append(f"Strain / cultivar: {grow_context.strain}")
+    if grow_context.stage:
+        parts.append(f"Growth stage: {grow_context.stage}")
+    if grow_context.days_since_start is not None:
+        parts.append(f"Days since start: {grow_context.days_since_start}")
+    if grow_context.notes:
+        parts.append(f"Grower notes: {grow_context.notes}")
+    parts.append(
+        "Report ONLY what changed between the two images in the specified JSON format."
+    )
+    return "\n".join(parts)
+
+
 def build_analysis_prompt(grow_context: GrowContext) -> str:
     """Build a user prompt incorporating grow context."""
     parts = ["Analyze this cannabis plant image."]

--- a/apps/analysis/app/services/storage.py
+++ b/apps/analysis/app/services/storage.py
@@ -1,0 +1,95 @@
+"""Supabase Storage fetch helper, shared by ``image_analysis`` and
+``image_comparison``.
+
+The single source of truth for path sanitisation + service-role auth used
+by every analysis-side image download. Keeping it in one place ensures the
+two production code paths cannot drift on encoding or error classification.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import quote
+
+import httpx
+
+from app.config import settings
+from app.errors import (
+    ConfigurationError,
+    InvalidStoragePath,
+    StorageUnavailable,
+)
+from app.middleware import get_request_id
+
+_STORAGE_PATH_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+
+def _sanitize_storage_path(storage_path: str) -> str:
+    path = storage_path.strip()
+    if (
+        not path
+        or path.startswith("/")
+        or path.startswith(".")
+        or ".." in path
+        or "\\" in path
+        or "?" in path
+        or "#" in path
+        or not _STORAGE_PATH_PATTERN.fullmatch(path)
+    ):
+        raise InvalidStoragePath()
+    return quote(path, safe="/-._~")
+
+
+async def fetch_image(storage_path: str) -> tuple[bytes, str]:
+    """Download an image from Supabase Storage using the service-role key.
+
+    Returns
+    -------
+    (bytes, content_type) where ``content_type`` is the value of the
+    ``content-type`` response header (defaulting to ``image/jpeg``).
+
+    Raises
+    ------
+    ConfigurationError
+        Missing Supabase credentials or service-role rejection (auth/config
+        problems are never retried).
+    InvalidStoragePath
+        Defence-in-depth path-traversal guard.
+    StorageUnavailable
+        Transient network / 5xx — caller may retry via ``with_retry``.
+    """
+    if not settings.supabase_url or not settings.supabase_service_role_key:
+        raise ConfigurationError("Supabase storage credentials are not configured")
+
+    safe_storage_path = _sanitize_storage_path(storage_path)
+    base_url = settings.supabase_url.rstrip("/")
+    url = (
+        f"{base_url}/storage/v1/object/authenticated/plant-images/"
+        f"{safe_storage_path}"
+    )
+    headers = {
+        "Authorization": f"Bearer {settings.supabase_service_role_key}",
+        "x-request-id": get_request_id(),
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            response = await client.get(url, headers=headers)
+            response.raise_for_status()
+            content_type = response.headers.get("content-type", "image/jpeg")
+            return response.content, content_type
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in (401, 403):
+            raise ConfigurationError(
+                "Supabase rejected the service-role credential."
+            ) from exc
+        raise StorageUnavailable(
+            f"Supabase storage returned HTTP {exc.response.status_code}."
+        ) from exc
+    except (httpx.TimeoutException, httpx.TransportError, ConnectionError) as exc:
+        raise StorageUnavailable(
+            "Supabase storage is unreachable or timed out."
+        ) from exc
+
+
+__all__ = ["fetch_image"]

--- a/apps/analysis/tests/test_analyze_router.py
+++ b/apps/analysis/tests/test_analyze_router.py
@@ -23,8 +23,11 @@ from app.models.analysis import (
     AnalysisFinding,
     AnalyzeRequest,
     AnalyzeResponse,
+    CompareRequest,
+    CompareResponse,
     FindingCategory,
     FindingSeverity,
+    UniformityDelta,
 )
 from app.routers import analyze as analyze_router_module
 
@@ -173,3 +176,92 @@ async def test_router_500s_when_run_analysis_raises(
         )
 
     assert response.status_code == 500
+
+
+def _valid_compare_body(**overrides: object) -> dict[str, object]:
+    body: dict[str, object] = {
+        "plant_id": "plant-xyz",
+        "image_id_current": "img-current",
+        "storage_path_current": "plants/plant-xyz/img-current.jpg",
+        "image_id_previous": "img-previous",
+        "storage_path_previous": "plants/plant-xyz/img-previous.jpg",
+        "grow_context": {
+            "grow_id": "grow-1",
+            "strain": "Blue Dream",
+            "stage": "flower",
+        },
+    }
+    body.update(overrides)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_compare_router_serializes_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, CompareRequest] = {}
+
+    async def fake_compare(request: CompareRequest) -> CompareResponse:
+        captured["request"] = request
+        return CompareResponse(
+            plant_id=request.plant_id,
+            image_id_current=request.image_id_current,
+            image_id_previous=request.image_id_previous,
+            summary="Visible flower development in the upper canopy.",
+            bullets=[
+                "New flower sites in the top third of the canopy.",
+                "Leaves a touch darker than the prior capture.",
+            ],
+            uniformity_delta=UniformityDelta.improved,
+            confidence=0.78,
+            analyzed_at=datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC),
+            model_version="gpt-4o-test-1.0",
+            analysis_mode="model",
+            is_fallback=False,
+        )
+
+    monkeypatch.setattr(analyze_router_module, "compare_images", fake_compare)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/compare", headers=_auth_headers(), json=_valid_compare_body()
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["plant_id"] == "plant-xyz"
+    assert data["image_id_current"] == "img-current"
+    assert data["image_id_previous"] == "img-previous"
+    assert data["uniformity_delta"] == "improved"
+    assert data["confidence"] == 0.78
+    assert len(data["bullets"]) == 2
+    assert data["is_fallback"] is False
+    assert captured["request"].grow_context.strain == "Blue Dream"
+
+
+@pytest.mark.asyncio
+async def test_compare_router_requires_bearer() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/compare",
+            headers={"Authorization": "Bearer wrong-key"},
+            json=_valid_compare_body(),
+        )
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_compare_router_rejects_invalid_storage_path() -> None:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/compare",
+            headers=_auth_headers(),
+            json=_valid_compare_body(storage_path_current="../etc/passwd"),
+        )
+    assert response.status_code == 422

--- a/apps/analysis/tests/test_image_analysis.py
+++ b/apps/analysis/tests/test_image_analysis.py
@@ -13,6 +13,7 @@ from PIL import Image
 from app.config import settings
 from app.models.analysis import AnalyzeRequest
 from app.services import image_analysis
+from app.services import storage as storage_service
 
 
 def _valid_png_bytes() -> bytes:
@@ -329,7 +330,10 @@ async def test_fetch_storage_image_returns_bytes_and_content_type(
             captured["headers"] = headers
             return FakeResponse()
 
-    monkeypatch.setattr(image_analysis.httpx, "AsyncClient", FakeClient)
+    # `image_analysis._fetch_storage_image` is an alias for
+    # `app.services.storage.fetch_image`; patching the storage module's
+    # httpx is the only seam that actually intercepts the network call.
+    monkeypatch.setattr(storage_service.httpx, "AsyncClient", FakeClient)
 
     body, content_type = await image_analysis._fetch_storage_image("plants/p/img.jpg")
 

--- a/apps/analysis/tests/test_image_comparison.py
+++ b/apps/analysis/tests/test_image_comparison.py
@@ -1,51 +1,306 @@
-"""
-Tests for `app.services.image_comparison`.
+"""Tests for `app.services.image_comparison`.
 
-The implementation is currently a stub. These tests lock in the public
-signature and the placeholder behaviour so any future wiring to the OpenAI
-Vision API is a deliberate, observable change.
+The service was previously a ``NotImplementedError`` stub; these tests
+exercise the real two-image comparison path by patching the storage fetch
+and OpenAI call seams. Network and pixel-level dependencies are avoided
+so the suite stays fast and deterministic.
 """
 
 from __future__ import annotations
 
-import inspect
+import io
+import itertools
+import json
+import random
+import sys
+from types import SimpleNamespace
 
 import pytest
+from PIL import Image
 
+from app.config import settings
+from app.errors import ModelUnavailable, StorageUnavailable
+from app.models.analysis import (
+    CompareRequest,
+    CompareResponse,
+    GrowContext,
+    UniformityDelta,
+)
 from app.services import image_comparison
-from app.services.image_comparison import compare_images
+
+
+def _valid_png_bytes() -> bytes:
+    """Mid-luminance noisy 256×256 PNG that passes ``assess_image_quality``."""
+    rng = random.Random(7)
+    img = Image.new("L", (256, 256))
+    px = img.load()
+    assert px is not None
+    for y, x in itertools.product(range(256), range(256)):
+        px[x, y] = rng.randint(60, 180)
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _request() -> CompareRequest:
+    return CompareRequest(
+        plant_id="plant-1",
+        image_id_current="img-current",
+        storage_path_current="plants/plant-1/img-current.jpg",
+        image_id_previous="img-previous",
+        storage_path_previous="plants/plant-1/img-previous.jpg",
+        grow_context=GrowContext(grow_id="grow-1", strain="Blue Dream"),
+    )
+
+
+def _install_fake_openai(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    raw_content: str | None = None,
+    raise_exc: BaseException | None = None,
+) -> None:
+    """Install a fake ``openai`` module so ``_call_vision_model`` can run
+    without the real SDK. ``raw_content`` becomes the model's JSON; if
+    ``raise_exc`` is set, the call raises that exception instead."""
+
+    class FakeMessage:
+        def __init__(self, content: str) -> None:
+            self.content = content
+
+    class FakeChoice:
+        def __init__(self, content: str) -> None:
+            self.message = FakeMessage(content)
+
+    class FakeCompletion:
+        def __init__(self, content: str) -> None:
+            self.choices = [FakeChoice(content)]
+
+    class FakeCompletions:
+        async def create(self, **_kwargs: object) -> FakeCompletion:
+            if raise_exc is not None:
+                raise raise_exc
+            assert raw_content is not None
+            return FakeCompletion(raw_content)
+
+    class FakeChat:
+        def __init__(self) -> None:
+            self.completions = FakeCompletions()
+
+    class FakeAsyncOpenAI:
+        def __init__(self, *, api_key: str) -> None:  # noqa: D401
+            assert api_key
+            self.chat = FakeChat()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(AsyncOpenAI=FakeAsyncOpenAI),
+    )
 
 
 @pytest.mark.asyncio
-async def test_compare_images_raises_not_implemented() -> None:
-    """The stub must fail loudly if it's ever called from a production path.
+async def test_compare_images_happy_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
 
-    Returning a placeholder string previously hid the unfinished state from
-    callers. Raising ``NotImplementedError`` instead makes accidental
-    wiring an observable bug rather than a silent UX defect.
-    """
-    with pytest.raises(NotImplementedError, match="Milestone 2"):
-        await compare_images(
-            image_id_a="img-a",
-            storage_path_a="plants/p/img-a.jpg",
-            image_id_b="img-b",
-            storage_path_b="plants/p/img-b.jpg",
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_comparison, "fetch_image", fake_fetch)
+    _install_fake_openai(
+        monkeypatch,
+        raw_content=json.dumps(
+            {
+                "summary": "Canopy darker, more flower sites.",
+                "bullets": [
+                    "Leaves darker green than the previous capture.",
+                    "Visible new flower sites in the upper canopy.",
+                ],
+                "uniformity_delta": "improved",
+                "confidence": 0.82,
+            }
+        ),
+    )
+
+    response = await image_comparison.compare_images(_request())
+
+    assert isinstance(response, CompareResponse)
+    assert response.is_fallback is False
+    assert response.analysis_mode == "model"
+    assert response.summary == "Canopy darker, more flower sites."
+    assert len(response.bullets) == 2
+    assert response.bullets[0].startswith("Leaves darker green")
+    assert response.uniformity_delta == UniformityDelta.improved
+    assert response.confidence == pytest.approx(0.82)
+
+
+@pytest.mark.asyncio
+async def test_compare_images_clamps_confidence_and_caps_bullets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defence-in-depth: a misbehaving model can't pollute confidence
+    (>1) or flood the UI with 20 bullets."""
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_comparison, "fetch_image", fake_fetch)
+    _install_fake_openai(
+        monkeypatch,
+        raw_content=json.dumps(
+            {
+                "summary": "Lots changed.",
+                "bullets": [f"Change {i}" for i in range(20)],
+                "uniformity_delta": "improved",
+                "confidence": 5.5,
+            }
+        ),
+    )
+
+    response = await image_comparison.compare_images(_request())
+
+    assert len(response.bullets) == 5  # capped
+    assert response.confidence == 1.0  # clamped
+
+
+@pytest.mark.asyncio
+async def test_compare_images_invalid_uniformity_becomes_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_comparison, "fetch_image", fake_fetch)
+    _install_fake_openai(
+        monkeypatch,
+        raw_content=json.dumps(
+            {
+                "summary": "Test.",
+                "bullets": ["one"],
+                "uniformity_delta": "nonsense-value",
+                "confidence": 0.5,
+            }
+        ),
+    )
+
+    response = await image_comparison.compare_images(_request())
+    assert response.uniformity_delta == UniformityDelta.unknown
+
+
+@pytest.mark.asyncio
+async def test_compare_images_empty_bullets_get_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty list from the model becomes a single "no change detected"
+    line so the UI never renders a silent 0-bullet result."""
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_comparison, "fetch_image", fake_fetch)
+    _install_fake_openai(
+        monkeypatch,
+        raw_content=json.dumps(
+            {
+                "summary": "",
+                "bullets": [],
+                "uniformity_delta": "unchanged",
+                "confidence": 0.2,
+            }
+        ),
+    )
+
+    response = await image_comparison.compare_images(_request())
+    assert len(response.bullets) == 1
+    assert "no visible change" in response.bullets[0].lower()
+    # Empty summary string falls back to the canned "comparison completed
+    # but the summary was incomplete." sentence.
+    assert response.summary.startswith("Comparison completed")
+
+
+@pytest.mark.asyncio
+async def test_compare_images_falls_back_when_storage_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    async def boom_fetch(storage_path: str) -> tuple[bytes, str]:
+        raise StorageUnavailable("simulated outage")
+
+    monkeypatch.setattr(image_comparison, "fetch_image", boom_fetch)
+
+    # Skip the retry backoff sleeps so this test stays under a millisecond.
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    from app.services import retry as retry_module
+
+    monkeypatch.setattr(retry_module, "_DEFAULT_SLEEP", no_sleep)
+
+    response = await image_comparison.compare_images(_request())
+
+    assert response.is_fallback is True
+    assert response.analysis_mode == "fallback"
+    assert response.fallback_reason == "STORAGE_UNAVAILABLE"
+    assert response.uniformity_delta == UniformityDelta.unknown
+    assert response.confidence == 0.0
+
+
+@pytest.mark.asyncio
+async def test_compare_images_falls_back_when_model_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "sk-test")
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_comparison, "fetch_image", fake_fetch)
+    _install_fake_openai(
+        monkeypatch,
+        raise_exc=ModelUnavailable("model down"),
+    )
+
+    response = await image_comparison.compare_images(_request())
+    assert response.is_fallback is True
+    assert response.fallback_reason == "MODEL_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_compare_images_falls_back_when_openai_key_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "openai_api_key", "")
+
+    async def fake_fetch(storage_path: str) -> tuple[bytes, str]:
+        return _valid_png_bytes(), "image/png"
+
+    monkeypatch.setattr(image_comparison, "fetch_image", fake_fetch)
+
+    response = await image_comparison.compare_images(_request())
+    assert response.is_fallback is True
+    assert response.fallback_reason == "CONFIGURATION_ERROR"
+
+
+def test_storage_path_validators_reject_traversal() -> None:
+    with pytest.raises(Exception):
+        CompareRequest(
+            plant_id="p",
+            image_id_current="c",
+            storage_path_current="../etc/passwd",
+            image_id_previous="p2",
+            storage_path_previous="plants/p/img.jpg",
+            grow_context=GrowContext(grow_id="g"),
         )
-
-
-def test_compare_images_signature_is_stable() -> None:
-    """
-    The signature is part of the internal contract used by `image_analysis`.
-    Renames here must be coordinated with that caller.
-    """
-    sig = inspect.signature(compare_images)
-    assert list(sig.parameters) == [
-        "image_id_a",
-        "storage_path_a",
-        "image_id_b",
-        "storage_path_b",
-    ]
-
-
-def test_compare_images_is_coroutine_function() -> None:
-    assert inspect.iscoroutinefunction(image_comparison.compare_images)
+    with pytest.raises(Exception):
+        CompareRequest(
+            plant_id="p",
+            image_id_current="c",
+            storage_path_current="plants/p/img.jpg",
+            image_id_previous="p2",
+            storage_path_previous="/absolute/path.jpg",
+            grow_context=GrowContext(grow_id="g"),
+        )

--- a/apps/web/src/app/(app)/plants/[plantId]/page.tsx
+++ b/apps/web/src/app/(app)/plants/[plantId]/page.tsx
@@ -24,7 +24,7 @@ import {
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 import { StatCard } from "@/components/ui/stat-card";
-import { ImageComparison } from "@/components/image-comparison";
+import { WhatChangedPanel } from "@/components/what-changed-panel";
 import { HealthTrendChart } from "@/components/health-trend-chart";
 import { getAuthorizedPlantContext } from "@/lib/server/plant-access";
 import { getLatestPlantAnalysis, getPlantTimeline } from "@/lib/server/plants";
@@ -442,15 +442,16 @@ export default async function PlantPage({ params }: Props) {
 
           <Card>
             <CardHeader>
-              <CardTitle>Comparison workspace</CardTitle>
+              <CardTitle>What changed?</CardTitle>
               <CardDescription>
-                Side-by-side review appears only when this plant has enough real
-                image history.
+                Side-by-side review of the two latest captures, with an
+                on-demand AI summary of the differences when you&rsquo;re ready
+                to look.
               </CardDescription>
             </CardHeader>
             <CardContent>
               {comparisonImages ? (
-                <ImageComparison
+                <WhatChangedPanel
                   after={comparisonImages.after}
                   before={comparisonImages.before}
                   plantId={plantId}

--- a/apps/web/src/app/api/plants/[plantId]/what-changed/__tests__/route.test.ts
+++ b/apps/web/src/app/api/plants/[plantId]/what-changed/__tests__/route.test.ts
@@ -1,0 +1,235 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+const getServerSession = vi.fn();
+const getServerUser = vi.fn();
+const rateLimit = vi.fn();
+const rateLimitKeyFromRequest = vi.fn();
+const getAuthorizedPlantContext = vi.fn();
+const compareImages = vi.fn();
+const getDbClient = vi.fn();
+
+vi.mock("@/lib/server/auth", () => ({
+  getServerSession: (...args: unknown[]) => getServerSession(...args),
+  getServerUser: (...args: unknown[]) => getServerUser(...args),
+}));
+vi.mock("@/lib/server/rate-limit", () => ({
+  rateLimit: (...args: unknown[]) => rateLimit(...args),
+  rateLimitKeyFromRequest: (...args: unknown[]) =>
+    rateLimitKeyFromRequest(...args),
+}));
+vi.mock("@/lib/server/plant-access", () => ({
+  getAuthorizedPlantContext: (...args: unknown[]) =>
+    getAuthorizedPlantContext(...args),
+}));
+vi.mock("@/lib/server/analysis-proxy", () => ({
+  compareImages: (...args: unknown[]) => compareImages(...args),
+}));
+vi.mock("@/lib/server/db", () => ({
+  getDbClient: (...args: unknown[]) => getDbClient(...args),
+}));
+
+import { POST } from "../route";
+import { UpstreamError } from "@/lib/server/resilience";
+
+const PLANT_ID = "11111111-1111-4111-8111-111111111111";
+const SESSION_OK = { user: { id: "u1" } } as const;
+const CONTEXT_OK = {
+  userId: "u1",
+  plantId: PLANT_ID,
+  plantName: "Plant 1",
+  strain: "Blue Dream",
+  notes: null,
+  growId: "g1",
+  growStage: "flower",
+  medium: "soil",
+  lightType: "led",
+  startDate: "2026-04-01",
+};
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new NextRequest(
+    `http://localhost/api/plants/${PLANT_ID}/what-changed`,
+    { method: "POST", headers },
+  );
+}
+
+function makeParams(plantId: string) {
+  return { params: Promise.resolve({ plantId }) };
+}
+
+function makeDb(rows: object[] | null, error: { message: string } | null) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    order: () => builder,
+    limit: async () => ({ data: rows, error }),
+  };
+  return { from: () => builder };
+}
+
+describe("POST /api/plants/[plantId]/what-changed", () => {
+  beforeEach(() => {
+    (getServerSession as Mock).mockReset();
+    (getServerUser as Mock).mockReset();
+    (rateLimit as Mock).mockReset();
+    (rateLimitKeyFromRequest as Mock).mockReset();
+    (getAuthorizedPlantContext as Mock).mockReset();
+    (compareImages as Mock).mockReset();
+    (getDbClient as Mock).mockReset();
+    rateLimit.mockReturnValue({ ok: true });
+    rateLimitKeyFromRequest.mockReturnValue("k");
+    getServerUser.mockResolvedValue({ id: "u1" });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(401);
+    expect(compareImages).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when plant id is not a uuid", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    const res = await POST(makeRequest(), makeParams("not-a-uuid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    rateLimit.mockReturnValue({ ok: false });
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("30");
+  });
+
+  it("returns 404 when the plant is not accessible", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    getAuthorizedPlantContext.mockResolvedValue(null);
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(404);
+    expect(compareImages).not.toHaveBeenCalled();
+  });
+
+  it("returns 422 when there is only one stored image", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    getAuthorizedPlantContext.mockResolvedValue(CONTEXT_OK);
+    getDbClient.mockReturnValue(
+      makeDb(
+        [
+          {
+            id: "i1",
+            storage_path: "plants/x/i1.jpg",
+            taken_at: null,
+            created_at: "2026-05-19",
+          },
+        ],
+        null,
+      ),
+    );
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(422);
+    expect(compareImages).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the image query fails", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    getAuthorizedPlantContext.mockResolvedValue(CONTEXT_OK);
+    getDbClient.mockReturnValue(makeDb(null, { message: "db down" }));
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(500);
+    expect(compareImages).not.toHaveBeenCalled();
+  });
+
+  it("returns the comparison on the happy path", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    getAuthorizedPlantContext.mockResolvedValue(CONTEXT_OK);
+    getDbClient.mockReturnValue(
+      makeDb(
+        [
+          {
+            id: "i-current",
+            storage_path: "plants/x/current.jpg",
+            taken_at: null,
+            created_at: "2026-05-19",
+          },
+          {
+            id: "i-prev",
+            storage_path: "plants/x/prev.jpg",
+            taken_at: null,
+            created_at: "2026-05-17",
+          },
+        ],
+        null,
+      ),
+    );
+    compareImages.mockResolvedValue({
+      plantId: PLANT_ID,
+      imageIdCurrent: "i-current",
+      imageIdPrevious: "i-prev",
+      summary: "Visible flower development.",
+      bullets: ["More flower sites.", "Slightly darker leaves."],
+      uniformityDelta: "improved",
+      confidence: 0.78,
+      analyzedAt: "2026-05-19T00:00:00Z",
+      modelVersion: "gpt-4o-test",
+    });
+
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.imageIdCurrent).toBe("i-current");
+    expect(body.data.imageIdPrevious).toBe("i-prev");
+    expect(body.data.bullets).toHaveLength(2);
+    expect(compareImages).toHaveBeenCalledTimes(1);
+    const firstCall = (compareImages as Mock).mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const args = firstCall![0] as {
+      storagePathCurrent: string;
+      storagePathPrevious: string;
+      growContext: { strain?: string; stage?: string };
+    };
+    expect(args.storagePathCurrent).toBe("plants/x/current.jpg");
+    expect(args.storagePathPrevious).toBe("plants/x/prev.jpg");
+    expect(args.growContext.strain).toBe("Blue Dream");
+    expect(args.growContext.stage).toBe("flower");
+  });
+
+  it("maps an upstream-unavailable error to 503", async () => {
+    getServerSession.mockResolvedValue(SESSION_OK);
+    getAuthorizedPlantContext.mockResolvedValue(CONTEXT_OK);
+    getDbClient.mockReturnValue(
+      makeDb(
+        [
+          {
+            id: "i-current",
+            storage_path: "plants/x/current.jpg",
+            taken_at: null,
+            created_at: "2026-05-19",
+          },
+          {
+            id: "i-prev",
+            storage_path: "plants/x/prev.jpg",
+            taken_at: null,
+            created_at: "2026-05-17",
+          },
+        ],
+        null,
+      ),
+    );
+    compareImages.mockRejectedValue(
+      new UpstreamError({
+        code: "UPSTREAM_UNAVAILABLE",
+        message: "analysis dead",
+        operation: "analysis-service",
+        requestId: "r",
+        attempt: 1,
+        retryable: false,
+      }),
+    );
+    const res = await POST(makeRequest(), makeParams(PLANT_ID));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.code).toBe("UPSTREAM_UNAVAILABLE");
+  });
+});

--- a/apps/web/src/app/api/plants/[plantId]/what-changed/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/what-changed/route.ts
@@ -1,0 +1,193 @@
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { apiError, apiSuccess } from "@/lib/server/api-errors";
+import {
+  compareImages,
+  type AnalyzeGrowContext,
+} from "@/lib/server/analysis-proxy";
+import { getServerSession, getServerUser } from "@/lib/server/auth";
+import { getDbClient } from "@/lib/server/db";
+import { getAuthorizedPlantContext } from "@/lib/server/plant-access";
+import { rateLimit, rateLimitKeyFromRequest } from "@/lib/server/rate-limit";
+import { getOrCreateRequestId, logServerEvent } from "@/lib/server/request-id";
+import { UpstreamError } from "@/lib/server/resilience";
+import { traceContextFromRequest } from "@/lib/server/trace-context";
+
+const PlantIdSchema = z.string().uuid();
+
+interface RouteParams {
+  params: Promise<{ plantId: string }>;
+}
+
+function daysSinceStart(startDate: string | null): number | undefined {
+  if (!startDate) return undefined;
+  const start = new Date(startDate);
+  if (Number.isNaN(start.getTime())) return undefined;
+  return Math.max(0, Math.floor((Date.now() - start.getTime()) / 86_400_000));
+}
+
+/**
+ * POST /api/plants/[plantId]/what-changed
+ *
+ * Returns a structured "what changed" comparison between the plant's two
+ * most recent images. Pulls one extra dependency hop (vision model with two
+ * images) so it's gated more tightly than analyze:
+ *
+ *   - 401 when unauthenticated
+ *   - 404 when the plant doesn't exist or the caller doesn't own / collaborate
+ *     on the grow (RLS)
+ *   - 422 when the plant has fewer than two stored images (nothing to compare)
+ *   - 429 when the per-user rate budget is exhausted
+ *   - 502/503 when the analysis service is unhealthy
+ *
+ * On success the body is `{ data: ImageComparisonResult }`. The result is
+ * NOT persisted — every call re-runs the vision call. Client should cache
+ * locally per `(imageIdCurrent, imageIdPrevious)` pair.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const requestId = getOrCreateRequestId(request);
+  const session = await getServerSession();
+  if (!session) {
+    return apiError(401, "UNAUTHORIZED", "Unauthorized", requestId);
+  }
+
+  const { plantId } = await params;
+  const parsedId = PlantIdSchema.safeParse(plantId);
+  if (!parsedId.success) {
+    return apiError(400, "BAD_REQUEST", "Invalid plant id", requestId);
+  }
+
+  const user = await getServerUser();
+  // Vision-on-vision calls are dramatically more expensive than analyze; cap
+  // tighter (6/min per user) so a stuck UI loop can't run up the bill.
+  const rate = await rateLimit({
+    key: `what-changed:${rateLimitKeyFromRequest(request, user?.id ?? null)}`,
+    limit: 6,
+    windowMs: 60_000,
+  });
+  if (!rate.ok) {
+    return apiError(
+      429,
+      "RATE_LIMITED",
+      "Too many comparison requests. Try again shortly.",
+      requestId,
+      { retryAfterSeconds: 30 },
+    );
+  }
+
+  const context = await getAuthorizedPlantContext(parsedId.data);
+  if (!context) {
+    return apiError(
+      404,
+      "NOT_FOUND",
+      "Plant not found or access denied",
+      requestId,
+    );
+  }
+
+  const db = getDbClient();
+  const { data: imageRows, error: imageError } = await db
+    .from("plant_images")
+    .select("id, storage_path, taken_at, created_at")
+    .eq("plant_id", context.plantId)
+    .order("created_at", { ascending: false })
+    .limit(2);
+
+  if (imageError) {
+    logServerEvent("error", "what-changed image lookup failed", {
+      requestId,
+      plantId: context.plantId,
+      error: imageError.message,
+    });
+    return apiError(
+      500,
+      "INTERNAL_ERROR",
+      "Failed to load plant images",
+      requestId,
+    );
+  }
+
+  type ImageRow = {
+    id: string;
+    storage_path: string;
+    taken_at: string | null;
+    created_at: string;
+  };
+  const images = (imageRows ?? []) as ImageRow[];
+  if (images.length < 2) {
+    return apiError(
+      422,
+      "UNPROCESSABLE_ENTITY",
+      "Need at least two captures to compare.",
+      requestId,
+    );
+  }
+
+  const [current, previous] = images;
+
+  const growContext: AnalyzeGrowContext = { growId: context.growId };
+  if (context.strain) growContext.strain = context.strain;
+  if (context.growStage) growContext.stage = context.growStage;
+  if (context.medium) growContext.medium = context.medium;
+  if (context.lightType) growContext.lightType = context.lightType;
+  const days = daysSinceStart(context.startDate);
+  if (days !== undefined) growContext.daysSinceStart = days;
+  if (context.notes) growContext.notes = context.notes;
+
+  const traceContext = traceContextFromRequest(request);
+
+  try {
+    const result = await compareImages({
+      plantId: context.plantId,
+      imageIdCurrent: current!.id,
+      storagePathCurrent: current!.storage_path,
+      imageIdPrevious: previous!.id,
+      storagePathPrevious: previous!.storage_path,
+      growContext,
+      requestId,
+      traceparent: traceContext.traceparent,
+    });
+    return apiSuccess(200, result, requestId);
+  } catch (error) {
+    if (error instanceof UpstreamError) {
+      logServerEvent("warn", "what-changed upstream failed", {
+        requestId,
+        plantId: context.plantId,
+        code: error.code,
+        status: error.status ?? null,
+      });
+      const status =
+        error.code === "UPSTREAM_RATE_LIMITED"
+          ? 429
+          : error.code === "UPSTREAM_UNAVAILABLE"
+            ? 503
+            : 502;
+      const code =
+        error.code === "UPSTREAM_RATE_LIMITED"
+          ? "UPSTREAM_RATE_LIMITED"
+          : error.code === "UPSTREAM_UNAVAILABLE"
+            ? "UPSTREAM_UNAVAILABLE"
+            : "UPSTREAM_UNAVAILABLE";
+      return apiError(
+        status,
+        code,
+        "Comparison service is temporarily unavailable.",
+        requestId,
+        error.retryAfterSeconds !== undefined
+          ? { retryAfterSeconds: error.retryAfterSeconds }
+          : {},
+      );
+    }
+    logServerEvent("error", "what-changed unexpected failure", {
+      requestId,
+      plantId: context.plantId,
+      error: error instanceof Error ? error.message : "unknown_error",
+    });
+    return apiError(
+      500,
+      "INTERNAL_ERROR",
+      "Failed to generate comparison.",
+      requestId,
+    );
+  }
+}

--- a/apps/web/src/app/api/plants/[plantId]/what-changed/route.ts
+++ b/apps/web/src/app/api/plants/[plantId]/what-changed/route.ts
@@ -165,9 +165,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const code =
         error.code === "UPSTREAM_RATE_LIMITED"
           ? "UPSTREAM_RATE_LIMITED"
-          : error.code === "UPSTREAM_UNAVAILABLE"
-            ? "UPSTREAM_UNAVAILABLE"
-            : "UPSTREAM_UNAVAILABLE";
+          : "UPSTREAM_UNAVAILABLE";
       return apiError(
         status,
         code,

--- a/apps/web/src/components/what-changed-panel.tsx
+++ b/apps/web/src/components/what-changed-panel.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { ImageComparisonResult, UniformityDelta } from "@phenosage/shared";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ImageComparison } from "@/components/image-comparison";
+
+interface ComparisonFrame {
+  imageId: string;
+  signedUrl: string;
+  label: string;
+}
+
+interface WhatChangedPanelProps {
+  plantId: string;
+  before: ComparisonFrame;
+  after: ComparisonFrame;
+}
+
+type RequestState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ready"; result: ImageComparisonResult }
+  | { status: "error"; message: string; retryable: boolean };
+
+const UNIFORMITY_LABEL: Record<UniformityDelta, string> = {
+  improved: "Improved",
+  unchanged: "Unchanged",
+  declined: "Declined",
+  unknown: "Unknown",
+};
+
+const UNIFORMITY_TONE: Record<
+  UniformityDelta,
+  "accent" | "warning" | "danger" | "default"
+> = {
+  improved: "accent",
+  unchanged: "default",
+  declined: "danger",
+  unknown: "warning",
+};
+
+/**
+ * "What Changed?" panel: side-by-side images plus an on-demand AI
+ * description of the differences. The comparison is computed server-side
+ * via `POST /api/plants/[plantId]/what-changed` and is intentionally NOT
+ * persisted — every fresh click re-runs the vision call, gated by the
+ * 6/min/user rate limit on that route. Result is cached client-side per
+ * `(beforeImageId, afterImageId)` so the user can flip away from the
+ * card and back without paying again.
+ */
+export function WhatChangedPanel({
+  plantId,
+  before,
+  after,
+}: WhatChangedPanelProps) {
+  const [state, setState] = useState<RequestState>({ status: "idle" });
+
+  const fetchComparison = useCallback(async () => {
+    setState({ status: "loading" });
+    try {
+      const response = await fetch(
+        `/api/plants/${encodeURIComponent(plantId)}/what-changed`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as {
+          error?: { message?: string; code?: string };
+        } | null;
+        const message =
+          body?.error?.message ??
+          (response.status === 429
+            ? "Too many comparisons in a short window. Try again in a minute."
+            : response.status === 422
+              ? "Two captures are required before PhenoSage can compare."
+              : "Could not generate a comparison. Please try again.");
+        setState({
+          status: "error",
+          message,
+          retryable: response.status >= 500 || response.status === 429,
+        });
+        return;
+      }
+      const body = (await response.json()) as {
+        data: ImageComparisonResult;
+      };
+      setState({ status: "ready", result: body.data });
+    } catch (_err) {
+      setState({
+        status: "error",
+        message: "Network error while contacting PhenoSage.",
+        retryable: true,
+      });
+    }
+  }, [plantId]);
+
+  return (
+    <div className="space-y-4">
+      <ImageComparison plantId={plantId} before={before} after={after} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          onClick={fetchComparison}
+          disabled={state.status === "loading"}
+          size="sm"
+          variant="primary"
+        >
+          {state.status === "loading"
+            ? "Analyzing changes…"
+            : state.status === "ready"
+              ? "Re-run comparison"
+              : "What changed?"}
+        </Button>
+        {state.status === "ready" ? (
+          <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+            {Math.round(state.result.confidence * 100)}% confidence ·{" "}
+            {state.result.isFallback ? "Inconclusive" : "Model"}
+          </span>
+        ) : null}
+      </div>
+
+      {state.status === "error" ? (
+        <div
+          role="alert"
+          className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-3 text-sm text-foreground"
+        >
+          {state.message}
+        </div>
+      ) : null}
+
+      {state.status === "ready" ? (
+        <ComparisonReadout result={state.result} />
+      ) : null}
+    </div>
+  );
+}
+
+function ComparisonReadout({ result }: { result: ImageComparisonResult }) {
+  return (
+    <div className="rounded-[1.25rem] border border-border/70 bg-background-subtle/70 p-5 space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge tone={UNIFORMITY_TONE[result.uniformityDelta]}>
+          {UNIFORMITY_LABEL[result.uniformityDelta]}
+        </Badge>
+        {result.isFallback ? (
+          <Badge tone="warning">Fallback output</Badge>
+        ) : null}
+      </div>
+      <p className="text-sm leading-7 text-foreground">{result.summary}</p>
+      <ul className="space-y-2">
+        {result.bullets.map((bullet, idx) => (
+          <li
+            key={`${idx}-${bullet.slice(0, 32)}`}
+            className="flex gap-3 text-sm leading-6 text-foreground"
+          >
+            <span
+              aria-hidden
+              className="mt-2 inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-accent"
+            />
+            <span>{bullet}</span>
+          </li>
+        ))}
+      </ul>
+      {result.isFallback ? (
+        <p className="text-xs text-muted-foreground">
+          The comparison service was unavailable. The output above is a
+          placeholder — treat it as inconclusive.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/lib/server/analysis-proxy.ts
+++ b/apps/web/src/lib/server/analysis-proxy.ts
@@ -1,5 +1,9 @@
 import "server-only";
-import type { AnalysisResponse } from "@phenosage/shared";
+import type {
+  AnalysisResponse,
+  ImageComparisonResult,
+  UniformityDelta,
+} from "@phenosage/shared";
 import { getAnalysisServiceConfig } from "./analysis-config";
 import { CircuitOpenError, getCircuitBreaker } from "./circuit-breaker";
 import { REQUEST_ID_HEADER, withRequestIdHeader } from "./request-id";
@@ -128,13 +132,15 @@ export async function callAnalysisService<T = unknown>(
     return await breaker.run(() =>
       withResilience<T>(
         async (_attempt, signal) => {
-          const headers = new Headers(withRequestIdHeader(
-            {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${apiKey}`,
-            },
-            effectiveRequestId,
-          ));
+          const headers = new Headers(
+            withRequestIdHeader(
+              {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${apiKey}`,
+              },
+              effectiveRequestId,
+            ),
+          );
           // Forward W3C `traceparent` so the analysis service can
           // continue the trace on its side. We pass the value
           // through verbatim — the route handler is the span owner
@@ -421,4 +427,131 @@ export async function analyzeImage(params: {
     },
   });
   return normalizeAnalysisResponse(raw);
+}
+
+// --- Image comparison ("What Changed?") -------------------------------
+
+type RawCompareResponse = {
+  plant_id?: string;
+  plantId?: string;
+  image_id_current?: string;
+  imageIdCurrent?: string;
+  image_id_previous?: string;
+  imageIdPrevious?: string;
+  summary: string;
+  bullets: string[];
+  uniformity_delta?: UniformityDelta;
+  uniformityDelta?: UniformityDelta;
+  confidence: number;
+  analyzed_at?: string;
+  analyzedAt?: string;
+  model_version?: string;
+  modelVersion?: string;
+  analysis_mode?: "fallback" | "model";
+  analysisMode?: "fallback" | "model";
+  is_fallback?: boolean;
+  isFallback?: boolean;
+  fallback_reason?: string | null;
+  fallbackReason?: string | null;
+  request_id?: string;
+  requestId?: string;
+};
+
+function normalizeCompareResponse(
+  payload: RawCompareResponse,
+): ImageComparisonResult {
+  const result: ImageComparisonResult = {
+    plantId: payload.plantId ?? payload.plant_id ?? "",
+    imageIdCurrent: payload.imageIdCurrent ?? payload.image_id_current ?? "",
+    imageIdPrevious: payload.imageIdPrevious ?? payload.image_id_previous ?? "",
+    summary: payload.summary,
+    bullets: Array.isArray(payload.bullets) ? payload.bullets : [],
+    uniformityDelta:
+      payload.uniformityDelta ?? payload.uniformity_delta ?? "unknown",
+    confidence: typeof payload.confidence === "number" ? payload.confidence : 0,
+    analyzedAt:
+      payload.analyzedAt ?? payload.analyzed_at ?? new Date().toISOString(),
+    modelVersion: payload.modelVersion ?? payload.model_version ?? "unknown",
+  };
+  const analysisMode = payload.analysisMode ?? payload.analysis_mode ?? null;
+  if (analysisMode) {
+    result.analysisMode = analysisMode;
+  }
+  if (payload.isFallback ?? payload.is_fallback) {
+    result.isFallback = true;
+  }
+  const fallbackReason =
+    payload.fallbackReason ?? payload.fallback_reason ?? null;
+  if (fallbackReason) {
+    result.fallbackReason = fallbackReason;
+  }
+  const requestId = payload.requestId ?? payload.request_id ?? null;
+  if (requestId) {
+    result.requestId = requestId;
+  }
+  return result;
+}
+
+/**
+ * Compare the two most recent images for a plant and return a structured
+ * "what changed?" payload. Safe to retry: the FastAPI side is idempotent
+ * (no DB writes happen on /compare, only the vision call repeats).
+ */
+export async function compareImages(params: {
+  plantId: string;
+  imageIdCurrent: string;
+  storagePathCurrent: string;
+  imageIdPrevious: string;
+  storagePathPrevious: string;
+  growContext: AnalyzeGrowContext;
+  requestId?: string;
+  traceparent?: string;
+}): Promise<ImageComparisonResult> {
+  const growContext: Record<string, unknown> = {
+    grow_id: params.growContext.growId,
+  };
+  if (params.growContext.strain !== undefined) {
+    growContext["strain"] = params.growContext.strain;
+  }
+  if (params.growContext.stage !== undefined) {
+    growContext["stage"] = params.growContext.stage;
+  }
+  if (params.growContext.medium !== undefined) {
+    growContext["medium"] = params.growContext.medium;
+  }
+  if (params.growContext.lightType !== undefined) {
+    growContext["light_type"] = params.growContext.lightType;
+  }
+  if (params.growContext.daysSinceStart !== undefined) {
+    growContext["days_since_start"] = params.growContext.daysSinceStart;
+  }
+  if (params.growContext.notes !== undefined) {
+    growContext["notes"] = params.growContext.notes;
+  }
+
+  const body: Record<string, unknown> = {
+    plant_id: params.plantId,
+    image_id_current: params.imageIdCurrent,
+    storage_path_current: params.storagePathCurrent,
+    image_id_previous: params.imageIdPrevious,
+    storage_path_previous: params.storagePathPrevious,
+    grow_context: growContext,
+  };
+
+  const raw = await callAnalysisService<RawCompareResponse>({
+    endpoint: "/compare",
+    method: "POST",
+    body,
+    ...(params.requestId ? { requestId: params.requestId } : {}),
+    ...(params.traceparent ? { traceparent: params.traceparent } : {}),
+    // /compare has no persisted side effects on either side — every retry
+    // is identical, idempotent, and safe to attempt again on transient
+    // 5xx/timeouts. We pay a vision call per retry; the bounded
+    // maxAttempts caps that cost.
+    resilience: {
+      maxAttempts: 2,
+      idempotencyKey: `compare:${params.plantId}:${params.imageIdCurrent}:${params.imageIdPrevious}`,
+    },
+  });
+  return normalizeCompareResponse(raw);
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -179,6 +179,28 @@ export interface PlantAnalysis extends AnalysisResponse {
   createdAt: string;
 }
 
+// Image comparison — returned by the analysis service's `/compare`
+// endpoint through the Next.js proxy. Powers the "What Changed?" panel on
+// the plant detail page. Wire field names mirror the pydantic model
+// (snake_case → camelCase happens in the proxy normaliser).
+export type UniformityDelta = "improved" | "unchanged" | "declined" | "unknown";
+
+export interface ImageComparisonResult {
+  plantId: string;
+  imageIdCurrent: string;
+  imageIdPrevious: string;
+  summary: string;
+  bullets: string[];
+  uniformityDelta: UniformityDelta;
+  confidence: number; // 0–1
+  analyzedAt: string; // ISO timestamp
+  modelVersion: string;
+  analysisMode?: "fallback" | "model";
+  isFallback?: boolean;
+  fallbackReason?: string;
+  requestId?: string;
+}
+
 // GrowEvent
 export type EventType =
   | "water"


### PR DESCRIPTION
## Summary

Applies the highest-leverage idea from the two executive-summary PDFs (Canopy Sentinel AI / mobile cockpit): a camera-first **"What changed?"** comparison feature on the plant detail page. Replaces the intentionally-stubbed `image_comparison` service with a real two-image vision call and ships the route + UI to use it.

The PDFs propose ~30 features (rooms/zones hierarchy, sensor fusion, compliance, native mobile, etc.). After reviewing them I ranked four near-term candidates with the user; "What changed?" was chosen as the smallest end-to-end slice with the largest visual payoff, since the image-comparison stub was already sitting in the codebase waiting to be wired.

### What ships

- **`POST /api/plants/[plantId]/what-changed`** — authenticated, RLS-scoped via `getAuthorizedPlantContext`, rate-limited at 6/min/user (vision-on-vision is expensive), loads the plant's two latest `plant_images`, delegates to the analysis service.
- **FastAPI `POST /compare`** — accepts two storage paths + grow context, fetches both images, gates each through `assess_image_quality`, calls a single multimodal vision request, returns structured `{ summary, bullets, uniformity_delta, confidence }`. Same retry / fallback / circuit-breaker discipline as `/analyze`.
- **`<WhatChangedPanel>`** client component — wraps the existing `<ImageComparison>` with a "What changed?" button that fetches and renders AI bullets + a coloured `improved | unchanged | declined | unknown` badge. Result is held in component state so the user can re-trigger explicitly.
- **`storage.fetch_image`** helper extracted from `image_analysis` so both code paths share one sanitised fetch.
- **Shared types** (`ImageComparisonResult`, `UniformityDelta`) in `packages/shared`.
- Tests added; nothing existing was removed.

### What didn't ship (deferred)

- **Persistence of comparisons** — every click re-runs the vision call. Persisting per `(imageIdCurrent, imageIdPrevious)` would cut repeat-cost but adds a migration and an invalidation question (does an edited finding invalidate the cache?). Punted to a follow-up; the 6/min/user limit caps cost in the meantime.
- **Auto-trigger on upload** — fires only on explicit user click. A passive "since last upload, here's what changed" banner is in the PDFs but felt like scope creep for this slice.
- All other PDF features (rooms/batches hierarchy, sensor fusion, compliance, capture coach, plant passport timeline, confidence ledger). See the chat thread for the prioritised list — happy to open separate PRs.

## Risks & sensitive paths

- Touches `packages/shared/src/types.ts` (additive — new types only).
- Touches `apps/analysis/app/models/**` and `apps/analysis/app/routers/**` (additive — new `CompareRequest` / `CompareResponse` and `POST /compare`; existing `/analyze` unchanged).
- Touches `apps/web/src/lib/server/analysis-proxy.ts` (additive — new `compareImages()` alongside `analyzeImage()`).
- Extracted `_fetch_storage_image` from `image_analysis.py` into `app/services/storage.py`. `image_analysis._fetch_storage_image` remains a re-exported alias so the existing test surface (which monkeypatches `image_analysis._fetch_storage_image` and references `image_analysis.StorageUnavailable`) still passes — only one test that patched `image_analysis.httpx` was updated to patch the new module location.
- No schema changes. No new env vars. No new dependencies.

## Test plan

- [x] `pnpm --filter web exec vitest run` — 903/903 pass (8 new for the route handler)
- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter shared type-check` — clean
- [x] `python -m pytest` in `apps/analysis` — 138/138 pass (8 new for `/compare` + comparison service)
- [x] `pnpm run validate` — passes (skips powershell smoke tests, no infra change)
- [x] `pnpm run security:routes` — passes; the only advisory is informational (new POST takes no request body — intentional, the route always operates on the latest two images)
- [ ] Manual: open a plant with ≥2 stored images, click "What changed?", verify bullets render; click again to re-run; revoke OpenAI key, verify fallback envelope renders with "Inconclusive" badge
- [ ] Manual: load with only 1 image — confirm the empty state still shows instead of the panel

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6GPxrCj62oNSW2H45QAZF)_