### PR TITLE
feat(passport): unified Plant Passport page — images + observations + tasks on one feed

### DIFF
--- a/apps/web/src/app/(app)/plants/[plantId]/page.tsx
+++ b/apps/web/src/app/(app)/plants/[plantId]/page.tsx
@@ -180,6 +180,12 @@ export default async function PlantPage({ params }: Props) {
           <>
             <Link
               className={buttonStyles({ size: "md", variant: "surface" })}
+              href={`/plants/${plantId}/passport`}
+            >
+              View passport
+            </Link>
+            <Link
+              className={buttonStyles({ size: "md", variant: "surface" })}
               href="/assistant"
             >
               Ask copilot

--- a/apps/web/src/app/(app)/plants/[plantId]/passport/page.tsx
+++ b/apps/web/src/app/(app)/plants/[plantId]/passport/page.tsx
@@ -1,0 +1,345 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import type { GrowTask } from "@phenosage/shared";
+import { FindingResolutionControls } from "@/components/finding-resolution-controls";
+import {
+  CheckCircleIcon,
+  PlantIcon,
+  SparkIcon,
+  TimelineIcon,
+} from "@/components/icons";
+import { SignedImage } from "@/components/signed-image";
+import { Badge } from "@/components/ui/badge";
+import { buttonStyles } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import { StatCard } from "@/components/ui/stat-card";
+import { getAuthorizedPlantContext } from "@/lib/server/plant-access";
+import { getPlantPassport } from "@/lib/server/plants";
+import { getStorageClient } from "@/lib/server/storage";
+
+export const metadata: Metadata = { title: "Plant Passport" };
+
+interface Props {
+  params: Promise<{ plantId: string }>;
+}
+
+// Plant IDs are persisted as Postgres UUIDs. Reject malformed inputs at the
+// edge so we don't waste a Supabase round trip on accidental URL typos.
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function taskTone(
+  task: GrowTask,
+): "default" | "accent" | "success" | "warning" | "danger" {
+  if (task.status === "done") return "success";
+  if (task.status === "dismissed") return "default";
+  if (task.priority === "urgent") return "danger";
+  if (task.priority === "high") return "warning";
+  return "accent";
+}
+
+export default async function PlantPassportPage({ params }: Props) {
+  const { plantId } = await params;
+  if (!UUID_RE.test(plantId)) {
+    notFound();
+  }
+  const context = await getAuthorizedPlantContext(plantId);
+  if (!context) {
+    notFound();
+  }
+
+  const passport = await getPlantPassport(plantId);
+  if (!passport) {
+    notFound();
+  }
+
+  // Pre-sign every image URL in a single fan-out so the page renders
+  // without a waterfall. 10-minute TTL matches the plant detail page;
+  // the SignedImage component re-signs once on the first 403.
+  const storage = getStorageClient().from("plant-images");
+  const imageSignings = await Promise.all(
+    passport.items
+      .filter((item) => item.type === "image")
+      .map(async (item) => {
+        const { data } = await storage.createSignedUrl(
+          item.storagePath,
+          60 * 10,
+        );
+        return [item.id, data?.signedUrl ?? null] as const;
+      }),
+  );
+  const signedByImageId = new Map(imageSignings);
+
+  const shortId = context.plantId.slice(0, 8).toUpperCase();
+  const hasAnyActivity = passport.items.length > 0;
+
+  return (
+    <main className="app-page">
+      <PageHeader
+        actions={
+          <Link
+            className={buttonStyles({ size: "md", variant: "surface" })}
+            href={`/plants/${plantId}`}
+          >
+            Back to plant
+          </Link>
+        }
+        breadcrumbs={[
+          { href: "/dashboard", label: "Dashboard" },
+          { href: "/grows", label: "Grows" },
+          { href: `/plants/${plantId}`, label: passport.plantName },
+          { label: "Passport" },
+        ]}
+        description="Every capture, observation, and action on one chronological feed — the operating record of this plant."
+        eyebrow={<Badge tone="accent">Plant passport</Badge>}
+        title={`${passport.plantName || `Plant ${shortId}`} — passport`}
+      />
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <StatCard
+          detail={
+            passport.pendingFindingCount === 0
+              ? "Every AI signal has been triaged."
+              : "Open the items below and confirm, reject, or mark false positive."
+          }
+          icon={<SparkIcon className="h-5 w-5" />}
+          label="Findings awaiting review"
+          tone={passport.pendingFindingCount === 0 ? "accent" : "warning"}
+          value={String(passport.pendingFindingCount)}
+        />
+        <StatCard
+          detail={
+            passport.openTaskCount === 0
+              ? "No tasks blocking the next cycle."
+              : "Work items spawned from findings or grower input."
+          }
+          icon={<CheckCircleIcon className="h-5 w-5" />}
+          label="Open tasks"
+          tone={passport.openTaskCount === 0 ? "accent" : "warning"}
+          value={String(passport.openTaskCount)}
+        />
+        <StatCard
+          detail="Total entries across images, observations, and tasks."
+          icon={<TimelineIcon className="h-5 w-5" />}
+          label="Timeline entries"
+          tone="accent"
+          value={String(passport.items.length)}
+        />
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Chronological feed</CardTitle>
+          <CardDescription>
+            Newest first. Confirm or reject AI findings inline — the
+            corresponding task auto-dismisses when you reject or mark a finding
+            as false positive.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {hasAnyActivity ? (
+            <ol className="space-y-5">
+              {passport.items.map((item) => {
+                if (item.type === "image") {
+                  const signedUrl = signedByImageId.get(item.id);
+                  return (
+                    <li
+                      key={`image-${item.id}`}
+                      className="rounded-[1.25rem] border border-border/70 bg-background-subtle/50 p-5"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="flex items-center gap-2">
+                          <Badge tone="accent">Image</Badge>
+                          <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                            {item.source}
+                          </span>
+                        </div>
+                        <time
+                          className="text-xs text-muted-foreground"
+                          dateTime={item.takenAt}
+                        >
+                          {formatDateTime(item.takenAt)}
+                        </time>
+                      </div>
+                      {signedUrl ? (
+                        <div className="mt-4 overflow-hidden rounded-[1.15rem] border border-border/70">
+                          <SignedImage
+                            alt={`Plant capture from ${formatDateTime(item.takenAt)}`}
+                            className="h-auto w-full"
+                            imageId={item.id}
+                            initialSrc={signedUrl}
+                            plantId={plantId}
+                          />
+                        </div>
+                      ) : null}
+                      {item.notes ? (
+                        <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                          {item.notes}
+                        </p>
+                      ) : null}
+                      {item.analysis ? (
+                        <p className="mt-3 text-sm leading-6 text-foreground">
+                          <strong className="font-semibold">
+                            Analysis ({item.analysis.overallHealthScore}/100):
+                          </strong>{" "}
+                          {item.analysis.summary}
+                        </p>
+                      ) : null}
+                      {item.findings.length > 0 ? (
+                        <div className="mt-4 space-y-3">
+                          {item.findings.map((finding) => (
+                            <div
+                              className="rounded-[1.15rem] border border-border/70 bg-surface px-4 py-4"
+                              key={
+                                finding.id ??
+                                `${finding.title}-${finding.description}`
+                              }
+                            >
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Badge
+                                  tone={
+                                    finding.severity === "critical" ||
+                                    finding.severity === "high"
+                                      ? "danger"
+                                      : finding.severity === "medium"
+                                        ? "warning"
+                                        : "accent"
+                                  }
+                                >
+                                  {finding.severity}
+                                </Badge>
+                                <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                                  {finding.category.replaceAll("_", " ")}
+                                </span>
+                                {finding.source === "user_reported" ? (
+                                  <Badge tone="info">User reported</Badge>
+                                ) : null}
+                              </div>
+                              <p className="mt-2 text-sm font-semibold text-foreground">
+                                {finding.title}
+                              </p>
+                              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                                {finding.description}
+                              </p>
+                              {finding.recommendation ? (
+                                <p className="mt-2 text-sm leading-6 text-foreground">
+                                  {finding.recommendation}
+                                </p>
+                              ) : null}
+                              {finding.id && finding.resolutionState ? (
+                                <FindingResolutionControls
+                                  findingId={finding.id}
+                                  initialState={finding.resolutionState}
+                                  plantId={plantId}
+                                />
+                              ) : null}
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </li>
+                  );
+                }
+                if (item.type === "observation") {
+                  return (
+                    <li
+                      key={`obs-${item.id}`}
+                      className="rounded-[1.25rem] border border-border/70 bg-background-subtle/50 p-5"
+                    >
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <Badge tone="accent">Observation</Badge>
+                        <time
+                          className="text-xs text-muted-foreground"
+                          dateTime={item.observedAt}
+                        >
+                          {formatDateTime(item.observedAt)}
+                        </time>
+                      </div>
+                      {item.heightCm !== undefined ? (
+                        <p className="mt-3 text-sm leading-6 text-foreground">
+                          Height: <strong>{item.heightCm} cm</strong>
+                        </p>
+                      ) : null}
+                      {item.notes ? (
+                        <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                          {item.notes}
+                        </p>
+                      ) : null}
+                    </li>
+                  );
+                }
+                const task = item.task;
+                return (
+                  <li
+                    key={`task-${task.id}`}
+                    className="rounded-[1.25rem] border border-border/70 bg-background-subtle/50 p-5"
+                  >
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Badge tone={taskTone(task)}>
+                          Task · {task.status}
+                        </Badge>
+                        <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                          {task.priority} priority
+                        </span>
+                        {task.findingId ? (
+                          <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                            from AI finding
+                          </span>
+                        ) : null}
+                      </div>
+                      <time
+                        className="text-xs text-muted-foreground"
+                        dateTime={task.createdAt}
+                      >
+                        {formatDateTime(task.createdAt)}
+                      </time>
+                    </div>
+                    <p className="mt-3 text-sm font-semibold text-foreground">
+                      {task.title}
+                    </p>
+                    {task.description ? (
+                      <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                        {task.description}
+                      </p>
+                    ) : null}
+                    {task.dueAt ? (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        Due {formatDateTime(task.dueAt)}
+                      </p>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ol>
+          ) : (
+            <EmptyState
+              description="Upload a baseline image or add an observation to start the plant's passport."
+              icon={<PlantIcon className="h-5 w-5" />}
+              title="No activity yet"
+            />
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/apps/web/src/lib/server/__tests__/plants.test.ts
+++ b/apps/web/src/lib/server/__tests__/plants.test.ts
@@ -35,6 +35,7 @@ vi.mock("../storage", () => ({
 
 import {
   getLatestPlantAnalysis,
+  getPlantPassport,
   getPlantTimeline,
   persistPlantImageUpload,
   preparePlantImageUpload,
@@ -1171,4 +1172,146 @@ describe("plants server helpers", () => {
       ).rejects.toThrow(message);
     },
   );
+
+  // ───────────────────────────────────────────────────────────────────────
+  // getPlantPassport — chronological feed (images + observations + tasks)
+  // ───────────────────────────────────────────────────────────────────────
+
+  function makePassportDb(params: {
+    images?: unknown[];
+    observations?: unknown[];
+    analyses?: unknown[];
+    findings?: unknown[];
+    tasks?: unknown[];
+    tasksError?: string;
+  }) {
+    const tableData: Record<string, unknown[]> = {
+      plant_images: params.images ?? [],
+      plant_observations: params.observations ?? [],
+      plant_analyses: params.analyses ?? [],
+      plant_findings: params.findings ?? [],
+      grow_tasks: params.tasks ?? [],
+    };
+    const from = vi.fn((table: string) => {
+      if (table === "grow_tasks") {
+        const order = vi.fn().mockResolvedValue({
+          data: params.tasksError ? null : tableData.grow_tasks,
+          error: params.tasksError ? { message: params.tasksError } : null,
+        });
+        const eq = vi.fn(() => ({ order }));
+        const select = vi.fn(() => ({ eq }));
+        return { select };
+      }
+      const order = vi.fn().mockResolvedValue({
+        data: tableData[table] ?? [],
+        error: null,
+      });
+      const eq = vi.fn(() => ({ order }));
+      const select = vi.fn(() => ({ eq }));
+      return { select };
+    });
+    return { from };
+  }
+
+  it("returns null from passport when the plant is not authorized", async () => {
+    getAuthorizedPlantContext.mockResolvedValue(null);
+    await expect(getPlantPassport("plant-1")).resolves.toBeNull();
+  });
+
+  it("interleaves images, observations, and tasks by occurredAt desc", async () => {
+    getDbClient.mockReturnValue(
+      makePassportDb({
+        images: [
+          {
+            id: "img-1",
+            created_at: "2026-05-15T09:00:00Z",
+            taken_at: "2026-05-15T09:00:00Z",
+            source: "upload",
+            storage_path: "plant-1/img-1.jpg",
+            notes: null,
+            plant_id: "plant-1",
+            grow_id: "grow-1",
+            user_id: "user-1",
+          },
+        ],
+        observations: [
+          {
+            id: "obs-1",
+            observed_at: "2026-05-14T18:00:00Z",
+            created_at: "2026-05-14T18:00:00Z",
+            height_cm: 42,
+            notes: "tucked",
+          },
+        ],
+        tasks: [
+          {
+            id: "task-1",
+            grow_id: "grow-1",
+            plant_id: "plant-1",
+            finding_id: "finding-1",
+            title: "Address: N deficiency",
+            description: null,
+            priority: "high",
+            status: "open",
+            due_at: null,
+            created_at: "2026-05-13T10:00:00Z",
+            updated_at: "2026-05-13T10:00:00Z",
+            completed_at: null,
+          },
+        ],
+      }),
+    );
+
+    const passport = await getPlantPassport("plant-1");
+    expect(passport).not.toBeNull();
+    const types = passport!.items.map((i) => i.type);
+    expect(types).toEqual(["image", "observation", "task"]);
+    expect(passport!.openTaskCount).toBe(1);
+    expect(passport!.pendingFindingCount).toBe(0);
+  });
+
+  it("counts pending findings + soft-degrades failed task fetches", async () => {
+    getDbClient.mockReturnValue(
+      makePassportDb({
+        images: [
+          {
+            id: "img-2",
+            created_at: "2026-05-12T09:00:00Z",
+            taken_at: "2026-05-12T09:00:00Z",
+            source: "upload",
+            storage_path: "plant-1/img-2.jpg",
+            notes: null,
+            plant_id: "plant-1",
+            grow_id: "grow-1",
+            user_id: "user-1",
+          },
+        ],
+        findings: [
+          {
+            id: "finding-pending",
+            plant_id: "plant-1",
+            grow_id: "grow-1",
+            image_id: "img-2",
+            category: "nutrient_deficiency",
+            severity: "medium",
+            confidence_score: null,
+            title: "Cal-Mag",
+            description: "Tip burn",
+            recommendation: null,
+            source: "ai",
+            resolution_state: "pending",
+            resolution_note: null,
+            created_at: "2026-05-12T09:01:00Z",
+          },
+        ],
+        tasksError: "rls denied",
+      }),
+    );
+
+    const passport = await getPlantPassport("plant-1");
+    expect(passport!.pendingFindingCount).toBe(1);
+    expect(passport!.openTaskCount).toBe(0);
+    // Tasks failed → no task items in the feed, but images still show.
+    expect(passport!.items.map((i) => i.type)).toEqual(["image"]);
+  });
 });

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -1,5 +1,9 @@
 import "server-only";
-import type { AnalysisFinding, AnalysisResponse } from "@phenosage/shared";
+import type {
+  AnalysisFinding,
+  AnalysisResponse,
+  GrowTask,
+} from "@phenosage/shared";
 import { analyzeImage, type AnalyzeGrowContext } from "./analysis-proxy";
 import { createSupabaseServerClient } from "./auth";
 import { getAuthorizedPlantContext } from "./plant-access";
@@ -737,4 +741,185 @@ export async function getOrCreateQuickCapturePlant(params: {
     return null;
   }
   return { plantId: (created as { id: string }).id };
+}
+
+// ─── Plant Passport ────────────────────────────────────────────────────────
+//
+// Unified chronological view of everything that has happened to a plant:
+// images (with their findings + analysis), grower observations, and the
+// grow_tasks the AI/user have spawned. Sorted newest-first so the freshest
+// activity is at the top.
+//
+// Reuses `getPlantTimeline` for images + observations rather than
+// duplicating the four-table fetch. Tasks are fetched separately because
+// the existing timeline contract intentionally scopes to images +
+// observations only — extending it would ripple into the plant detail
+// page and the dashboard.
+
+type PassportImageItem = {
+  type: "image";
+  occurredAt: string;
+  id: string;
+  createdAt: string;
+  takenAt: string;
+  source: string;
+  notes?: string;
+  storagePath: string;
+  analysis: AnalysisResponse | null;
+  findings: AnalysisFinding[];
+};
+
+type PassportObservationItem = {
+  type: "observation";
+  occurredAt: string;
+  id: string;
+  observedAt: string;
+  createdAt: string;
+  heightCm?: number;
+  notes?: string;
+};
+
+type PassportTaskItem = {
+  type: "task";
+  occurredAt: string;
+  task: GrowTask;
+};
+
+export type PlantPassportItem =
+  | PassportImageItem
+  | PassportObservationItem
+  | PassportTaskItem;
+
+type GrowTaskRow = {
+  id: string;
+  grow_id: string;
+  plant_id: string | null;
+  finding_id: string | null;
+  title: string;
+  description: string | null;
+  priority: GrowTask["priority"];
+  status: GrowTask["status"];
+  due_at: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+function mapTaskFromRow(row: GrowTaskRow): GrowTask {
+  const task: GrowTask = {
+    id: row.id,
+    growId: row.grow_id,
+    title: row.title,
+    priority: row.priority,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+  if (row.plant_id) task.plantId = row.plant_id;
+  if (row.finding_id) task.findingId = row.finding_id;
+  if (row.description) task.description = row.description;
+  if (row.due_at) task.dueAt = row.due_at;
+  if (row.completed_at) task.completedAt = row.completed_at;
+  return task;
+}
+
+export async function getPlantPassport(plantId: string) {
+  const context = await getAuthorizedPlantContext(plantId);
+  if (!context) {
+    return null;
+  }
+
+  // Run both reads concurrently — the timeline already fans out four
+  // queries internally, so we don't gain from sequencing.
+  const db = getDbClient();
+  const [timeline, taskResult] = await Promise.all([
+    getPlantTimeline(plantId),
+    db
+      .from("grow_tasks")
+      .select("*")
+      .eq("plant_id", context.plantId)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  if (!timeline) {
+    return null;
+  }
+
+  let tasks: GrowTask[] = [];
+  if (taskResult.error) {
+    // Soft-degrade: missing tasks don't take down the passport.
+    logServerEvent("error", "plant passport tasks query failed", {
+      plantId: context.plantId,
+      error: taskResult.error.message,
+    });
+  } else {
+    tasks = ((taskResult.data ?? []) as GrowTaskRow[]).map(mapTaskFromRow);
+  }
+
+  // Hoist each timeline item's "occurred at" so we can sort the merged
+  // stream by a single key without re-discriminating on type every loop.
+  // Explicit construction avoids exactOptionalPropertyTypes mismatches when
+  // spreading items whose `notes` is typed `string | undefined`.
+  const fromTimeline: PlantPassportItem[] = timeline.items.map(
+    (item): PlantPassportItem => {
+      if (item.type === "image") {
+        const out: PassportImageItem = {
+          type: "image",
+          occurredAt: item.takenAt,
+          id: item.id,
+          createdAt: item.createdAt,
+          takenAt: item.takenAt,
+          source: item.source,
+          storagePath: item.storagePath,
+          analysis: item.analysis,
+          findings: item.findings,
+        };
+        if (item.notes !== undefined) out.notes = item.notes;
+        return out;
+      }
+      const out: PassportObservationItem = {
+        type: "observation",
+        occurredAt: item.observedAt,
+        id: item.id,
+        observedAt: item.observedAt,
+        createdAt: item.createdAt,
+      };
+      if (item.heightCm !== undefined) out.heightCm = item.heightCm;
+      if (item.notes !== undefined) out.notes = item.notes;
+      return out;
+    },
+  );
+  const fromTasks: PlantPassportItem[] = tasks.map((task) => ({
+    type: "task",
+    occurredAt: task.createdAt,
+    task,
+  }));
+
+  const items = [...fromTimeline, ...fromTasks].sort(
+    (left, right) =>
+      new Date(right.occurredAt).getTime() -
+      new Date(left.occurredAt).getTime(),
+  );
+
+  // Pending = "needs your review"; surfaced as the lead callout so the
+  // grower knows the ledger isn't empty.
+  const pendingFindingCount = timeline.items.reduce((count, item) => {
+    if (item.type !== "image") return count;
+    return (
+      count +
+      item.findings.filter((f) => f.resolutionState === "pending").length
+    );
+  }, 0);
+
+  const openTaskCount = tasks.filter(
+    (t) => t.status === "open" || t.status === "in_progress",
+  ).length;
+
+  return {
+    plantId: context.plantId,
+    plantName: context.plantName,
+    items,
+    pendingFindingCount,
+    openTaskCount,
+  };
 }


### PR DESCRIPTION
## Summary

Ships the third feature from the executive-summary PDF: a **Plant Passport** — a single chronological feed per plant that interleaves every event (images with their findings + analysis, grower observations, and grow_tasks) into one newest-first stream.

No schema changes. Pure UI + server composition on top of the existing tables and the resolution controls from #223.

### What ships

**Server (`apps/web/src/lib/server/plants.ts`)**
- `getPlantPassport(plantId)` reuses `getPlantTimeline` for images + observations and adds a separate `grow_tasks` fetch scoped to the plant. **Soft-degrades** a failing task query to "no tasks in the feed" rather than killing the whole passport.
- Returns aggregate counts (`pendingFindingCount`, `openTaskCount`, `items.length`) so the page renders stat cards without re-reducing on the client.

**Web**
- New route `/plants/[plantId]/passport`.
- Image entries embed their findings + the `FindingResolutionControls` component from #223, so confirm/reject/false-positive actions work inline. Observations + tasks render as their own card variants with priority + status badges.
- All image signed URLs are pre-signed in a single fan-out (no waterfall). 10-minute TTL matches the plant detail page; `SignedImage` handles re-signing on the first 403.
- "View passport" link added to the plant detail header for discoverability.

### Behaviour matrix

| Source data | Sort key | Render |
| --- | --- | --- |
| `plant_images` | `taken_at` | Card with signed photo, source badge, analysis summary, findings rail (with resolution controls) |
| `plant_observations` | `observed_at` | Card with optional height + notes |
| `grow_tasks` | `created_at` | Card with status + priority badges; "from AI finding" hint when `finding_id` is set |
| `grow_tasks` fetch fails | — | Logged server-side; passport still renders with images + observations |

### What didn't ship (deferred)

- **Print / export** — the passport is the obvious surface for a "share this plant's story" PDF, but it adds a print-stylesheet pass that's worth its own PR.
- **Filter chips** (images only / tasks only / unresolved only) — UX polish; not core to landing the consolidated feed.
- **Resolution event log entries** — `plant_findings` has no `resolved_state_changed_at` column. Surfacing a "marked false positive on May 18" event requires a schema bump and is out of scope here.

## Risks & sensitive paths

- `apps/web/src/lib/server/plants.ts` — additive (new helper + types alongside `getPlantTimeline`); existing callers untouched.
- `apps/web/src/app/(app)/plants/[plantId]/page.tsx` — one new header link, no behaviour change.
- No new env vars. No new dependencies. No new routes (page-only, no API surface).

## Test plan

- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web exec vitest run` — **928/928 pass** (3 new server tests: null-when-unauthorized, interleaved ordering, pending-finding count + soft-degraded task fetch)
- [x] `pnpm run security:routes` — passes (24 route files scanned; no new API routes to audit)
- [ ] Manual: visit `/plants/<plantId>/passport`; confirm images + observations + tasks render in chronological order; confirm a finding inline → state badge updates and the spawned task moves to "dismissed" on next refresh; reject a finding → same effect; observe stat cards drop the pending count


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6GPxrCj62oNSW2H45QAZF)_