### PR TITLE
feat(triage): cross-grow triage queue — one inbox for everything that needs attention

### DIFF
--- a/apps/web/src/app/(app)/triage/page.tsx
+++ b/apps/web/src/app/(app)/triage/page.tsx
@@ -30,12 +30,12 @@ function formatDateTime(value: string) {
 }
 
 export default async function TriagePage() {
-  // Unauthed users get sent back to login — the rest of the (app) group
+  // Unauthed users get sent back to /auth — the rest of the (app) group
   // already enforces this, but we double-check so a missing session never
   // hits the user-scoped Supabase client below.
   const session = await getServerSession();
   if (!session) {
-    redirect("/login");
+    redirect("/auth?next=/triage");
   }
 
   const { findings, tasks } = await getTriageInbox();
@@ -48,7 +48,7 @@ export default async function TriagePage() {
           { href: "/dashboard", label: "Dashboard" },
           { label: "Triage" },
         ]}
-        description="Pending AI findings and open work items across every grow you have access to. Confirm, reject, or mark false positive inline — the spawned task auto-dismisses on reject/false-positive."
+        description="Pending findings and open work items across every grow you have access to. Confirm, reject, or mark false positive inline — the spawned task auto-dismisses on reject/false-positive."
         eyebrow={<Badge tone="accent">Triage queue</Badge>}
         title="What needs your attention"
       />
@@ -57,7 +57,7 @@ export default async function TriagePage() {
         <StatCard
           detail={
             findings.length === 0
-              ? "Every AI signal has been triaged."
+              ? "Every signal has been triaged."
               : "Confirm or reject below."
           }
           icon={<SparkIcon className="h-5 w-5" />}
@@ -96,7 +96,7 @@ export default async function TriagePage() {
         <CardContent>
           {findings.length === 0 ? (
             <EmptyState
-              description="Every AI-generated finding has been triaged. Upload a new photo to keep the loop going."
+              description="Every pending finding has been triaged. Upload a new photo or log an observation to keep the loop going."
               icon={<SparkIcon className="h-5 w-5" />}
               title="Inbox zero"
             />

--- a/apps/web/src/app/(app)/triage/page.tsx
+++ b/apps/web/src/app/(app)/triage/page.tsx
@@ -1,0 +1,257 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { FindingResolutionControls } from "@/components/finding-resolution-controls";
+import { CheckCircleIcon, SparkIcon } from "@/components/icons";
+import { Badge } from "@/components/ui/badge";
+import { buttonStyles } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { PageHeader } from "@/components/ui/page-header";
+import { StatCard } from "@/components/ui/stat-card";
+import { getServerSession } from "@/lib/server/auth";
+import { getTriageInbox } from "@/lib/server/triage";
+
+export const metadata: Metadata = { title: "Triage" };
+
+function formatDateTime(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+export default async function TriagePage() {
+  // Unauthed users get sent back to login — the rest of the (app) group
+  // already enforces this, but we double-check so a missing session never
+  // hits the user-scoped Supabase client below.
+  const session = await getServerSession();
+  if (!session) {
+    redirect("/login");
+  }
+
+  const { findings, tasks } = await getTriageInbox();
+  const totalCount = findings.length + tasks.length;
+
+  return (
+    <main className="app-page">
+      <PageHeader
+        breadcrumbs={[
+          { href: "/dashboard", label: "Dashboard" },
+          { label: "Triage" },
+        ]}
+        description="Pending AI findings and open work items across every grow you have access to. Confirm, reject, or mark false positive inline — the spawned task auto-dismisses on reject/false-positive."
+        eyebrow={<Badge tone="accent">Triage queue</Badge>}
+        title="What needs your attention"
+      />
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <StatCard
+          detail={
+            findings.length === 0
+              ? "Every AI signal has been triaged."
+              : "Confirm or reject below."
+          }
+          icon={<SparkIcon className="h-5 w-5" />}
+          label="Findings awaiting review"
+          tone={findings.length === 0 ? "accent" : "warning"}
+          value={String(findings.length)}
+        />
+        <StatCard
+          detail={
+            tasks.length === 0
+              ? "No open work items."
+              : "Tasks spawned from findings or grower input."
+          }
+          icon={<CheckCircleIcon className="h-5 w-5" />}
+          label="Open tasks"
+          tone={tasks.length === 0 ? "accent" : "warning"}
+          value={String(tasks.length)}
+        />
+        <StatCard
+          detail="Combined inbox across every accessible grow."
+          icon={<SparkIcon className="h-5 w-5" />}
+          label="Total items"
+          tone="accent"
+          value={String(totalCount)}
+        />
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Findings awaiting review</CardTitle>
+          <CardDescription>
+            Severity-ranked. Click through to the plant for full context, or
+            triage in place.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {findings.length === 0 ? (
+            <EmptyState
+              description="Every AI-generated finding has been triaged. Upload a new photo to keep the loop going."
+              icon={<SparkIcon className="h-5 w-5" />}
+              title="Inbox zero"
+            />
+          ) : (
+            <ol className="space-y-4">
+              {findings.map((finding) => (
+                <li
+                  key={`finding-${finding.id}`}
+                  className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-4"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge
+                      tone={
+                        finding.severity === "critical" ||
+                        finding.severity === "high"
+                          ? "danger"
+                          : finding.severity === "medium"
+                            ? "warning"
+                            : "accent"
+                      }
+                    >
+                      {finding.severity}
+                    </Badge>
+                    <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                      {finding.category.replaceAll("_", " ")}
+                    </span>
+                    <Link
+                      className="text-xs uppercase tracking-[0.14em] text-accent hover:underline"
+                      href={`/plants/${finding.plantId}`}
+                    >
+                      {finding.growName} → {finding.plantName}
+                    </Link>
+                    <time
+                      className="ml-auto text-xs text-muted-foreground"
+                      dateTime={finding.createdAt}
+                    >
+                      {formatDateTime(finding.createdAt)}
+                    </time>
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
+                    {finding.title}
+                  </p>
+                  <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                    {finding.description}
+                  </p>
+                  {finding.recommendation ? (
+                    <p className="mt-2 text-sm leading-6 text-foreground">
+                      {finding.recommendation}
+                    </p>
+                  ) : null}
+                  <FindingResolutionControls
+                    findingId={finding.id}
+                    initialState={finding.resolutionState}
+                    plantId={finding.plantId}
+                  />
+                </li>
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Open tasks</CardTitle>
+          <CardDescription>
+            Priority-ranked. Use the plant passport to mark progress or complete
+            a task.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {tasks.length === 0 ? (
+            <EmptyState
+              description="No open or in-progress tasks across your grows. Confirmed AI findings will land here when they spawn work."
+              icon={<CheckCircleIcon className="h-5 w-5" />}
+              title="Inbox zero"
+            />
+          ) : (
+            <ol className="space-y-4">
+              {tasks.map((task) => (
+                <li
+                  key={`task-${task.id}`}
+                  className="rounded-[1.15rem] border border-border/70 bg-background-subtle/60 px-4 py-4"
+                >
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge
+                      tone={
+                        task.priority === "urgent"
+                          ? "danger"
+                          : task.priority === "high"
+                            ? "warning"
+                            : "accent"
+                      }
+                    >
+                      {task.priority} priority
+                    </Badge>
+                    <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                      {task.status}
+                    </span>
+                    {task.plantId ? (
+                      <Link
+                        className="text-xs uppercase tracking-[0.14em] text-accent hover:underline"
+                        href={`/plants/${task.plantId}`}
+                      >
+                        {task.growName} → {task.plantName}
+                      </Link>
+                    ) : (
+                      <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                        {task.growName}
+                      </span>
+                    )}
+                    {task.findingId ? (
+                      <span className="text-xs uppercase tracking-[0.14em] text-muted-foreground">
+                        from AI finding
+                      </span>
+                    ) : null}
+                    <time
+                      className="ml-auto text-xs text-muted-foreground"
+                      dateTime={task.createdAt}
+                    >
+                      {formatDateTime(task.createdAt)}
+                    </time>
+                  </div>
+                  <p className="mt-2 text-sm font-semibold text-foreground">
+                    {task.title}
+                  </p>
+                  {task.description ? (
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      {task.description}
+                    </p>
+                  ) : null}
+                  {task.dueAt ? (
+                    <p className="mt-2 text-xs text-muted-foreground">
+                      Due {formatDateTime(task.dueAt)}
+                    </p>
+                  ) : null}
+                  {task.plantId ? (
+                    <div className="mt-3">
+                      <Link
+                        className={buttonStyles({
+                          size: "sm",
+                          variant: "surface",
+                        })}
+                        href={`/plants/${task.plantId}/passport`}
+                      >
+                        Open passport
+                      </Link>
+                    </div>
+                  ) : null}
+                </li>
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/apps/web/src/components/app-shell/nav.tsx
+++ b/apps/web/src/components/app-shell/nav.tsx
@@ -8,6 +8,7 @@ import {
   ChatIcon,
   SettingsIcon,
   ImageIcon,
+  BellIcon,
 } from "@/components/ui/icons";
 import { cn } from "@/lib/cn";
 
@@ -21,6 +22,7 @@ export const NAV_ITEMS: NavItem[] = [
   { href: "/dashboard", label: "Dashboard", Icon: HomeIcon },
   { href: "/grows", label: "Grows", Icon: LeafIcon },
   { href: "/plants", label: "Plants", Icon: ImageIcon },
+  { href: "/triage", label: "Triage", Icon: BellIcon },
   { href: "/assistant", label: "Assistant", Icon: ChatIcon },
   { href: "/settings", label: "Settings", Icon: SettingsIcon },
 ];
@@ -78,7 +80,7 @@ export function MobileBottomNav() {
       className="fixed bottom-3 left-3 right-3 z-30 md:hidden"
       style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
-      <ul className="grid grid-cols-5 gap-1 rounded-full border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface))] p-1.5 shadow-soft">
+      <ul className="grid grid-cols-6 gap-1 rounded-full border border-[rgb(var(--ps-line)/var(--ps-line-strength))] bg-[rgb(var(--ps-surface))] p-1.5 shadow-soft">
         {NAV_ITEMS.map(({ href, label, Icon }) => {
           const active = isActive(pathname, href);
           return (

--- a/apps/web/src/lib/server/__tests__/triage.test.ts
+++ b/apps/web/src/lib/server/__tests__/triage.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const createSupabaseServerClient = vi.fn();
+const logServerEvent = vi.fn();
+
+vi.mock("../auth", () => ({
+  createSupabaseServerClient: (...args: unknown[]) =>
+    createSupabaseServerClient(...args),
+}));
+vi.mock("../request-id", () => ({
+  logServerEvent: (...args: unknown[]) => logServerEvent(...args),
+}));
+
+import { getTriageInbox } from "../triage";
+
+type Settled = { data: unknown[] | null; error: { message: string } | null };
+
+function makeSupabase(
+  handlers: Record<string, () => Settled | Promise<Settled>>,
+) {
+  // Each table returns a fluent builder whose terminal `.limit()` or
+  // `.order()` resolves to the handler's settled shape. The builder is
+  // intentionally lax — every callable on it returns itself (or a
+  // thenable on terminal calls).
+  return {
+    from: (table: string) => {
+      const settle = handlers[table];
+      const settled = async (): Promise<Settled> => {
+        if (!settle) return { data: [], error: null };
+        const res = await settle();
+        return res;
+      };
+      const builder: {
+        select: () => typeof builder;
+        eq: () => typeof builder;
+        in: () => typeof builder;
+        order: () => typeof builder;
+        limit: () => typeof builder;
+        then: (
+          _onfulfilled: (_value: Settled) => unknown,
+          _onrejected?: (_reason: unknown) => unknown,
+        ) => Promise<unknown>;
+      } = {
+        select: () => builder,
+        eq: () => builder,
+        in: () => builder,
+        order: () => builder,
+        limit: () => builder,
+        then: (onfulfilled, onrejected) =>
+          settled().then(onfulfilled, onrejected),
+      };
+      return builder;
+    },
+  };
+}
+
+describe("getTriageInbox", () => {
+  beforeEach(() => {
+    (createSupabaseServerClient as Mock).mockReset();
+    (logServerEvent as Mock).mockReset();
+  });
+
+  it("returns an empty inbox if the supabase client init throws", async () => {
+    createSupabaseServerClient.mockRejectedValue(new Error("boom"));
+    const inbox = await getTriageInbox();
+    expect(inbox).toEqual({ findings: [], tasks: [] });
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "triage inbox client init failed",
+      expect.objectContaining({ error: "boom" }),
+    );
+  });
+
+  it("joins grow + plant names onto findings and sorts by severity desc", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase({
+        grows: () => ({
+          data: [
+            { id: "g1", name: "Tent A" },
+            { id: "g2", name: "Tent B" },
+          ],
+          error: null,
+        }),
+        plants: () => ({
+          data: [
+            { id: "p1", name: "Blue Dream #1", grow_id: "g1" },
+            { id: "p2", name: "Wedding Cake #2", grow_id: "g2" },
+          ],
+          error: null,
+        }),
+        plant_findings: () => ({
+          data: [
+            {
+              id: "f-low",
+              plant_id: "p1",
+              grow_id: "g1",
+              image_id: null,
+              category: "training",
+              severity: "low",
+              confidence_score: 0.8,
+              title: "Minor stretch",
+              description: "Mild stretch",
+              recommendation: null,
+              source: "ai",
+              resolution_state: "pending",
+              resolution_note: null,
+              created_at: "2026-05-15T00:00:00Z",
+            },
+            {
+              id: "f-critical",
+              plant_id: "p2",
+              grow_id: "g2",
+              image_id: null,
+              category: "pest",
+              severity: "critical",
+              confidence_score: 0.95,
+              title: "Spider mites",
+              description: "Webbing visible",
+              recommendation: "Spray neem",
+              source: "ai",
+              resolution_state: "pending",
+              resolution_note: null,
+              created_at: "2026-05-14T00:00:00Z",
+            },
+          ],
+          error: null,
+        }),
+        grow_tasks: () => ({ data: [], error: null }),
+      }),
+    );
+
+    const inbox = await getTriageInbox();
+    expect(inbox.findings).toHaveLength(2);
+    // Critical sorts ahead of low even though low is newer.
+    expect(inbox.findings[0]!.id).toBe("f-critical");
+    expect(inbox.findings[0]!.growName).toBe("Tent B");
+    expect(inbox.findings[0]!.plantName).toBe("Wedding Cake #2");
+    expect(inbox.findings[0]!.recommendation).toBe("Spray neem");
+    expect(inbox.findings[1]!.id).toBe("f-low");
+  });
+
+  it("sorts tasks by priority desc and preserves nullable plant linkage", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase({
+        grows: () => ({ data: [{ id: "g1", name: "Tent A" }], error: null }),
+        plants: () => ({
+          data: [{ id: "p1", name: "Blue Dream #1", grow_id: "g1" }],
+          error: null,
+        }),
+        plant_findings: () => ({ data: [], error: null }),
+        grow_tasks: () => ({
+          data: [
+            {
+              id: "t-low",
+              grow_id: "g1",
+              plant_id: "p1",
+              finding_id: null,
+              title: "Top later",
+              description: null,
+              priority: "low",
+              status: "open",
+              due_at: null,
+              created_at: "2026-05-15T00:00:00Z",
+              updated_at: "2026-05-15T00:00:00Z",
+              completed_at: null,
+            },
+            {
+              id: "t-urgent",
+              grow_id: "g1",
+              plant_id: null,
+              finding_id: "f-x",
+              title: "Pest sweep",
+              description: "All plants in tent",
+              priority: "urgent",
+              status: "in_progress",
+              due_at: "2026-05-16T00:00:00Z",
+              created_at: "2026-05-13T00:00:00Z",
+              updated_at: "2026-05-14T00:00:00Z",
+              completed_at: null,
+            },
+          ],
+          error: null,
+        }),
+      }),
+    );
+
+    const inbox = await getTriageInbox();
+    expect(inbox.tasks).toHaveLength(2);
+    expect(inbox.tasks[0]!.id).toBe("t-urgent");
+    expect(inbox.tasks[0]!.plantId).toBeUndefined();
+    expect(inbox.tasks[0]!.findingId).toBe("f-x");
+    expect(inbox.tasks[0]!.dueAt).toBe("2026-05-16T00:00:00Z");
+    expect(inbox.tasks[1]!.id).toBe("t-low");
+    expect(inbox.tasks[1]!.plantName).toBe("Blue Dream #1");
+  });
+
+  it("soft-degrades failed sources without taking the inbox down", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase({
+        grows: () => ({ data: [{ id: "g1", name: "Tent A" }], error: null }),
+        plants: () => ({ data: [], error: { message: "rls denied" } }),
+        plant_findings: () => ({
+          data: [
+            {
+              id: "f-1",
+              plant_id: "p-missing",
+              grow_id: "g1",
+              image_id: null,
+              category: "general",
+              severity: "medium",
+              confidence_score: null,
+              title: "Check VPD",
+              description: "Trending high",
+              recommendation: null,
+              source: "ai",
+              resolution_state: "pending",
+              resolution_note: null,
+              created_at: "2026-05-14T00:00:00Z",
+            },
+          ],
+          error: null,
+        }),
+        grow_tasks: () => Promise.reject(new Error("network blip")),
+      }),
+    );
+
+    const inbox = await getTriageInbox();
+    expect(inbox.findings).toHaveLength(1);
+    // Plant fetch failed → unknown plant fallback string.
+    expect(inbox.findings[0]!.plantName).toBe("Unknown plant");
+    expect(inbox.tasks).toEqual([]);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "triage inbox query failed",
+      expect.objectContaining({ source: "plants" }),
+    );
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "triage inbox query rejected",
+      expect.objectContaining({ source: "grow_tasks" }),
+    );
+  });
+});

--- a/apps/web/src/lib/server/triage.ts
+++ b/apps/web/src/lib/server/triage.ts
@@ -1,0 +1,240 @@
+import "server-only";
+import type {
+  AnalysisFinding,
+  FindingResolutionState,
+  GrowTask,
+} from "@phenosage/shared";
+import { createSupabaseServerClient } from "./auth";
+import { logServerEvent } from "./request-id";
+
+// ─── Triage Inbox ──────────────────────────────────────────────────────────
+//
+// Cross-grow "what needs my attention" view. Pulls pending AI findings
+// (resolution_state = 'pending') and open/in-progress tasks across every
+// grow the current user belongs to, joined with grow + plant context so
+// the UI doesn't need to follow up with N name lookups.
+//
+// Authorization is enforced entirely by RLS via the user-scoped supabase
+// client — there is no manual grow-membership filter here. If a user is
+// removed from a grow mid-session, the next render correctly hides those
+// rows.
+
+const PENDING_STATE: FindingResolutionState = "pending";
+
+type GrowRow = {
+  id: string;
+  name: string;
+};
+
+type PlantRow = {
+  id: string;
+  name: string;
+  grow_id: string;
+};
+
+type FindingRow = {
+  id: string;
+  plant_id: string;
+  grow_id: string;
+  image_id: string | null;
+  category: AnalysisFinding["category"];
+  severity: AnalysisFinding["severity"];
+  confidence_score: number | null;
+  title: string;
+  description: string;
+  recommendation: string | null;
+  source: NonNullable<AnalysisFinding["source"]>;
+  resolution_state: NonNullable<AnalysisFinding["resolutionState"]>;
+  resolution_note: string | null;
+  created_at: string;
+};
+
+type TaskRow = {
+  id: string;
+  grow_id: string;
+  plant_id: string | null;
+  finding_id: string | null;
+  title: string;
+  description: string | null;
+  priority: GrowTask["priority"];
+  status: GrowTask["status"];
+  due_at: string | null;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export interface TriageFinding {
+  id: string;
+  plantId: string;
+  plantName: string;
+  growId: string;
+  growName: string;
+  category: AnalysisFinding["category"];
+  severity: AnalysisFinding["severity"];
+  title: string;
+  description: string;
+  recommendation?: string;
+  resolutionState: FindingResolutionState;
+  createdAt: string;
+}
+
+export interface TriageTask {
+  id: string;
+  plantId?: string;
+  plantName?: string;
+  growId: string;
+  growName: string;
+  findingId?: string;
+  title: string;
+  description?: string;
+  priority: GrowTask["priority"];
+  status: GrowTask["status"];
+  dueAt?: string;
+  createdAt: string;
+}
+
+export interface TriageInbox {
+  findings: TriageFinding[];
+  tasks: TriageTask[];
+}
+
+const EMPTY_INBOX: TriageInbox = { findings: [], tasks: [] };
+
+// Stable severity / priority rank so the inbox shows the most urgent
+// item first regardless of which row the caller iterates.
+const SEVERITY_RANK: Record<AnalysisFinding["severity"], number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+const PRIORITY_RANK: Record<GrowTask["priority"], number> = {
+  urgent: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+export async function getTriageInbox(): Promise<TriageInbox> {
+  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  try {
+    supabase = await createSupabaseServerClient();
+  } catch (err) {
+    logServerEvent("error", "triage inbox client init failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return EMPTY_INBOX;
+  }
+
+  // Per-source soft-degrade: a single failing query never takes down the
+  // page. Mirrors the workspace-overview pattern.
+  const [growsSettled, plantsSettled, findingsSettled, tasksSettled] =
+    await Promise.allSettled([
+      supabase.from("grows").select("id,name"),
+      supabase.from("plants").select("id,name,grow_id").limit(500),
+      supabase
+        .from("plant_findings")
+        .select(
+          "id,plant_id,grow_id,image_id,category,severity,confidence_score,title,description,recommendation,source,resolution_state,resolution_note,created_at",
+        )
+        .eq("resolution_state", PENDING_STATE)
+        .order("created_at", { ascending: false })
+        .limit(200),
+      supabase
+        .from("grow_tasks")
+        .select("*")
+        .in("status", ["open", "in_progress"])
+        .order("created_at", { ascending: false })
+        .limit(200),
+    ]);
+
+  function unwrap<T>(
+    label: string,
+    settled: PromiseSettledResult<{
+      data: T[] | null;
+      error: { message: string } | null;
+    }>,
+  ): T[] {
+    if (settled.status === "rejected") {
+      logServerEvent("error", "triage inbox query rejected", {
+        source: label,
+        error:
+          settled.reason instanceof Error
+            ? settled.reason.message
+            : String(settled.reason),
+      });
+      return [];
+    }
+    if (settled.value.error) {
+      logServerEvent("error", "triage inbox query failed", {
+        source: label,
+        error: settled.value.error.message,
+      });
+      return [];
+    }
+    return settled.value.data ?? [];
+  }
+
+  const grows = unwrap<GrowRow>("grows", growsSettled);
+  const plants = unwrap<PlantRow>("plants", plantsSettled);
+  const findings = unwrap<FindingRow>("plant_findings", findingsSettled);
+  const tasks = unwrap<TaskRow>("grow_tasks", tasksSettled);
+
+  const growNameById = new Map(grows.map((g) => [g.id, g.name]));
+  const plantNameById = new Map(plants.map((p) => [p.id, p.name]));
+
+  const triageFindings: TriageFinding[] = findings
+    .map((row) => {
+      const finding: TriageFinding = {
+        id: row.id,
+        plantId: row.plant_id,
+        plantName: plantNameById.get(row.plant_id) ?? "Unknown plant",
+        growId: row.grow_id,
+        growName: growNameById.get(row.grow_id) ?? "Unknown grow",
+        category: row.category,
+        severity: row.severity,
+        title: row.title,
+        description: row.description,
+        resolutionState: row.resolution_state,
+        createdAt: row.created_at,
+      };
+      if (row.recommendation) finding.recommendation = row.recommendation;
+      return finding;
+    })
+    .sort((a, b) => {
+      const rank = SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity];
+      if (rank !== 0) return rank;
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+
+  const triageTasks: TriageTask[] = tasks
+    .map((row) => {
+      const task: TriageTask = {
+        id: row.id,
+        growId: row.grow_id,
+        growName: growNameById.get(row.grow_id) ?? "Unknown grow",
+        title: row.title,
+        priority: row.priority,
+        status: row.status,
+        createdAt: row.created_at,
+      };
+      if (row.plant_id) {
+        task.plantId = row.plant_id;
+        task.plantName = plantNameById.get(row.plant_id) ?? "Unknown plant";
+      }
+      if (row.finding_id) task.findingId = row.finding_id;
+      if (row.description) task.description = row.description;
+      if (row.due_at) task.dueAt = row.due_at;
+      return task;
+    })
+    .sort((a, b) => {
+      const rank = PRIORITY_RANK[a.priority] - PRIORITY_RANK[b.priority];
+      if (rank !== 0) return rank;
+      return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
+    });
+
+  return { findings: triageFindings, tasks: triageTasks };
+}

--- a/apps/web/src/lib/server/triage.ts
+++ b/apps/web/src/lib/server/triage.ts
@@ -131,22 +131,32 @@ export async function getTriageInbox(): Promise<TriageInbox> {
 
   // Per-source soft-degrade: a single failing query never takes down the
   // page. Mirrors the workspace-overview pattern.
+  //
+  // Ordering is delegated to Postgres so the LIMIT below truncates the
+  // *least* urgent rows. `finding_severity` enum order is
+  // info < low < medium < high < critical, and `task_priority` is
+  // low < medium < high < urgent, so DESC puts the most-urgent value
+  // first. A secondary created_at DESC tiebreaks within a severity bucket.
   const [growsSettled, plantsSettled, findingsSettled, tasksSettled] =
     await Promise.allSettled([
       supabase.from("grows").select("id,name"),
-      supabase.from("plants").select("id,name,grow_id").limit(500),
+      supabase.from("plants").select("id,name,grow_id").limit(2000),
       supabase
         .from("plant_findings")
         .select(
           "id,plant_id,grow_id,image_id,category,severity,confidence_score,title,description,recommendation,source,resolution_state,resolution_note,created_at",
         )
         .eq("resolution_state", PENDING_STATE)
+        .order("severity", { ascending: false })
         .order("created_at", { ascending: false })
         .limit(200),
       supabase
         .from("grow_tasks")
-        .select("*")
+        .select(
+          "id,grow_id,plant_id,finding_id,title,description,priority,status,due_at,created_at,updated_at,completed_at",
+        )
         .in("status", ["open", "in_progress"])
+        .order("priority", { ascending: false })
         .order("created_at", { ascending: false })
         .limit(200),
     ]);


### PR DESCRIPTION
## Summary

Ships a `/triage` page that lists every **pending AI finding** (`resolution_state = 'pending'`) and **open / in-progress grow_task** across every grow the current user can access. Closes the Milestone 2 "what needs my attention" gap.

Builds directly on the confidence ledger (#223) and plant passport (#224): the resolution controls embedded inline are the same component, and "Open passport" shortcuts route through the new per-plant feed.

### What ships

**Server (`apps/web/src/lib/server/triage.ts`)**
- `getTriageInbox()` runs four parallel queries (grows, plants, pending findings, open tasks) on the user-scoped Supabase client. **RLS enforces grow membership** — no manual filter needed.
- Per-source soft-degrade via `Promise.allSettled` mirrors the `workspace-overview` pattern: a failing source returns `[]` instead of blowing up the whole inbox.
- Findings sort by severity desc then created_at desc; tasks sort by priority desc then created_at desc, so the most urgent items are always at the top regardless of insertion order.

**Web**
- New `/triage` route with two stacked Card sections (findings + tasks), stat cards at the top, and inline `FindingResolutionControls` so confirm / reject / mark-false-positive work without leaving the page. Each row links back to the plant and offers an "Open passport" shortcut for tasks.
- Sidebar nav gains a **Triage** entry (BellIcon) between Plants and Assistant. Mobile bottom nav bumps from `grid-cols-5 → grid-cols-6` to make room.

### Behaviour matrix

| Source | Filter | Sort |
| --- | --- | --- |
| `plant_findings` | `resolution_state = 'pending'` | severity desc → created_at desc |
| `grow_tasks` | `status in ('open', 'in_progress')` | priority desc → created_at desc |
| Any source fails | Logged, returns `[]` | Inbox still renders with remaining sources |

### What didn't ship (deferred)

- **Mark task done inline** — requires a new PATCH route on `grow_tasks`. Today the user goes through the plant passport to interact with a task. Worth its own PR.
- **"Snooze" / dismiss findings** — the current ledger has `pending → confirmed/rejected/false_positive`, no explicit snooze. Could land alongside the inline-task-done work.
- **Filter chips** (severity ≥ medium, my grows only, etc.) — UX polish; the default severity sort already buries the noise.

## Risks & sensitive paths

- `apps/web/src/components/app-shell/nav.tsx` — adds a sixth nav item; bumps mobile bottom-nav grid to 6 cols.
- `apps/web/src/lib/server/triage.ts` — new file; no changes to existing helpers.
- No new API routes (page-only). No new env vars. No new dependencies. No schema changes.

## Test plan

- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web exec vitest run` — **932/932 pass** (4 new server tests)
- [x] `pnpm run security:routes` — passes (24 route files scanned)
- [ ] Manual: visit `/triage` with multiple grows that have pending findings + open tasks; confirm sort order; confirm/reject a finding inline → it disappears from the list on refresh; task list still renders if RLS denies one source


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6GPxrCj62oNSW2H45QAZF)_