### PR TITLE
feat(grow): grow-level health trend chart on the detail page

### DIFF
--- a/apps/web/src/app/(app)/grows/[id]/page.tsx
+++ b/apps/web/src/app/(app)/grows/[id]/page.tsx
@@ -14,7 +14,9 @@ import {
 } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { HealthTrendChart } from "@/components/health-trend-chart";
 import { getServerUser } from "@/lib/server/auth";
+import { getGrowHealthTrend } from "@/lib/server/grow-health-trend";
 import { fetchGrowDetail } from "@/lib/server/workspace-records";
 import { ArchiveButton } from "./archive-button";
 import { DeleteGrowButton } from "./delete-button";
@@ -62,9 +64,10 @@ function titleCase(value: string | null | undefined): string {
 //   * Footer with the Archive / Restore action.
 export default async function GrowDetailPage({ params, searchParams }: Props) {
   const { id } = await params;
-  const [user, detail] = await Promise.all([
+  const [user, detail, healthTrend] = await Promise.all([
     getServerUser(),
     fetchGrowDetail(id),
+    getGrowHealthTrend(id),
   ]);
   if (!detail) {
     notFound();
@@ -138,6 +141,24 @@ export default async function GrowDetailPage({ params, searchParams }: Props) {
           </p>
         </div>
       ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Grow health trend</CardTitle>
+          <CardDescription>
+            Daily-averaged overall health score across every plant in this grow
+            over the last {healthTrend.windowDays} days
+            {healthTrend.totalAnalyses > 0
+              ? ` (${healthTrend.totalAnalyses} ${
+                  healthTrend.totalAnalyses === 1 ? "analysis" : "analyses"
+                }).`
+              : "."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <HealthTrendChart points={healthTrend.points} />
+        </CardContent>
+      </Card>
 
       <section className="grid gap-6 xl:grid-cols-[minmax(0,1.4fr)_minmax(320px,0.9fr)]">
         <Card>

--- a/apps/web/src/lib/server/__tests__/grow-health-trend.test.ts
+++ b/apps/web/src/lib/server/__tests__/grow-health-trend.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+const createSupabaseServerClient = vi.fn();
+const logServerEvent = vi.fn();
+
+vi.mock("../auth", () => ({
+  createSupabaseServerClient: (...args: unknown[]) =>
+    createSupabaseServerClient(...args),
+}));
+vi.mock("../request-id", () => ({
+  logServerEvent: (...args: unknown[]) => logServerEvent(...args),
+}));
+
+import { getGrowHealthTrend } from "../grow-health-trend";
+
+type AnalysisRow = { overall_health_score: number; analyzed_at: string };
+type Settled = {
+  data: AnalysisRow[] | null;
+  error: { message: string } | null;
+};
+
+function makeSupabase(settle: () => Settled | Promise<Settled>) {
+  // Every grow-health-trend query is a single `from("plant_analyses")` →
+  // builder chain, so we only need to model that one table.
+  return {
+    from: () => {
+      const settled = async (): Promise<Settled> => settle();
+      const builder: {
+        select: () => typeof builder;
+        eq: () => typeof builder;
+        gte: () => typeof builder;
+        order: () => typeof builder;
+        limit: () => typeof builder;
+        then: (
+          _onfulfilled: (_value: Settled) => unknown,
+          _onrejected?: (_reason: unknown) => unknown,
+        ) => Promise<unknown>;
+      } = {
+        select: () => builder,
+        eq: () => builder,
+        gte: () => builder,
+        order: () => builder,
+        limit: () => builder,
+        then: (onfulfilled, onrejected) =>
+          settled().then(onfulfilled, onrejected),
+      };
+      return builder;
+    },
+  };
+}
+
+describe("getGrowHealthTrend", () => {
+  beforeEach(() => {
+    (createSupabaseServerClient as Mock).mockReset();
+    (logServerEvent as Mock).mockReset();
+  });
+
+  it("returns an empty trend when no growId is provided", async () => {
+    const trend = await getGrowHealthTrend("");
+    expect(trend.points).toEqual([]);
+    expect(trend.totalAnalyses).toBe(0);
+    // The supabase client should never be initialized for an empty growId.
+    expect(createSupabaseServerClient).not.toHaveBeenCalled();
+  });
+
+  it("returns an empty trend if the supabase client init throws", async () => {
+    createSupabaseServerClient.mockRejectedValue(new Error("boom"));
+    const trend = await getGrowHealthTrend("g1");
+    expect(trend.points).toEqual([]);
+    expect(trend.totalAnalyses).toBe(0);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "grow health trend client init failed",
+      expect.objectContaining({ error: "boom", growId: "g1" }),
+    );
+  });
+
+  it("returns an empty trend (no log noise on empty result) when the grow has no analyses", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase(() => ({ data: [], error: null })),
+    );
+    const trend = await getGrowHealthTrend("g1");
+    expect(trend.points).toEqual([]);
+    expect(trend.totalAnalyses).toBe(0);
+    expect(logServerEvent).not.toHaveBeenCalled();
+  });
+
+  it("buckets analyses by UTC day and averages the score across plants", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase(() => ({
+        data: [
+          // Two plants analyzed on the same UTC day -> one bucket, averaged.
+          { overall_health_score: 80, analyzed_at: "2026-05-10T03:00:00Z" },
+          { overall_health_score: 60, analyzed_at: "2026-05-10T18:30:00Z" },
+          // Next day, single plant.
+          { overall_health_score: 90, analyzed_at: "2026-05-11T09:15:00Z" },
+        ],
+        error: null,
+      })),
+    );
+    const trend = await getGrowHealthTrend("g1");
+    expect(trend.totalAnalyses).toBe(3);
+    expect(trend.points).toHaveLength(2);
+    // Bucket key is "noon UTC of the analysis day" for chart-stable rendering.
+    expect(trend.points[0]).toEqual({
+      analyzedAt: "2026-05-10T12:00:00.000Z",
+      score: 70,
+    });
+    expect(trend.points[1]).toEqual({
+      analyzedAt: "2026-05-11T12:00:00.000Z",
+      score: 90,
+    });
+  });
+
+  it("soft-degrades when the query errors", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase(() => ({
+        data: null,
+        error: { message: "rls denied" },
+      })),
+    );
+    const trend = await getGrowHealthTrend("g1");
+    expect(trend.points).toEqual([]);
+    expect(trend.totalAnalyses).toBe(0);
+    expect(logServerEvent).toHaveBeenCalledWith(
+      "error",
+      "grow health trend query failed",
+      expect.objectContaining({ error: "rls denied", growId: "g1" }),
+    );
+  });
+
+  it("honors a custom window in the returned summary", async () => {
+    createSupabaseServerClient.mockResolvedValue(
+      makeSupabase(() => ({ data: [], error: null })),
+    );
+    const trend = await getGrowHealthTrend("g1", 7);
+    expect(trend.windowDays).toBe(7);
+  });
+});

--- a/apps/web/src/lib/server/grow-health-trend.ts
+++ b/apps/web/src/lib/server/grow-health-trend.ts
@@ -1,0 +1,116 @@
+import "server-only";
+import type { HealthTrendPoint } from "@/components/health-trend-chart";
+import { createSupabaseServerClient } from "./auth";
+import { logServerEvent } from "./request-id";
+
+// ─── Grow Health Trend ─────────────────────────────────────────────────────
+//
+// Aggregates per-image `overall_health_score` rows from `plant_analyses`
+// for every plant under a grow into a single daily-averaged time series.
+// Designed to drop straight into the existing `HealthTrendChart` component,
+// which already handles empty / single-point / hover states.
+//
+// Authorization piggy-backs on RLS: the user-scoped supabase client only
+// returns analyses for grows the user owns or collaborates on. No manual
+// membership check is needed here.
+
+const DEFAULT_WINDOW_DAYS = 30;
+const MAX_ANALYSES = 1000;
+
+type AnalysisRow = {
+  overall_health_score: number;
+  analyzed_at: string;
+};
+
+export interface GrowHealthTrend {
+  points: HealthTrendPoint[];
+  totalAnalyses: number;
+  windowDays: number;
+}
+
+const EMPTY_TREND: GrowHealthTrend = {
+  points: [],
+  totalAnalyses: 0,
+  windowDays: DEFAULT_WINDOW_DAYS,
+};
+
+function startOfDayUtc(value: string): string {
+  // Bucket by UTC date — the chart only needs a stable per-day key.
+  // Using UTC keeps the bucketing deterministic regardless of the user's
+  // browser locale, which matters because the score is averaged on the
+  // server and re-rendered without further timezone math.
+  const d = new Date(value);
+  return new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), 12, 0, 0),
+  ).toISOString();
+}
+
+export async function getGrowHealthTrend(
+  growId: string,
+  windowDays: number = DEFAULT_WINDOW_DAYS,
+): Promise<GrowHealthTrend> {
+  if (!growId) return { ...EMPTY_TREND, windowDays };
+
+  let supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  try {
+    supabase = await createSupabaseServerClient();
+  } catch (err) {
+    logServerEvent("error", "grow health trend client init failed", {
+      growId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { ...EMPTY_TREND, windowDays };
+  }
+
+  const since = new Date(
+    Date.now() - windowDays * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const { data, error } = await supabase
+    .from("plant_analyses")
+    .select("overall_health_score,analyzed_at")
+    .eq("grow_id", growId)
+    .gte("analyzed_at", since)
+    .order("analyzed_at", { ascending: true })
+    .limit(MAX_ANALYSES);
+
+  if (error) {
+    logServerEvent("error", "grow health trend query failed", {
+      growId,
+      error: error.message,
+    });
+    return { ...EMPTY_TREND, windowDays };
+  }
+
+  const rows = (data ?? []) as AnalysisRow[];
+  if (rows.length === 0) {
+    return { points: [], totalAnalyses: 0, windowDays };
+  }
+
+  // Bucket by UTC day, then average. Map insertion order matches the
+  // `analyzed_at ASC` order from the query, so we get a sorted timeline
+  // for free.
+  const buckets = new Map<string, { sum: number; count: number }>();
+  for (const row of rows) {
+    const key = startOfDayUtc(row.analyzed_at);
+    const current = buckets.get(key);
+    if (current) {
+      current.sum += Number(row.overall_health_score);
+      current.count += 1;
+    } else {
+      buckets.set(key, {
+        sum: Number(row.overall_health_score),
+        count: 1,
+      });
+    }
+  }
+
+  const points: HealthTrendPoint[] = Array.from(buckets.entries()).map(
+    ([analyzedAt, { sum, count }]) => ({
+      analyzedAt,
+      score: sum / count,
+    }),
+  );
+
+  return { points, totalAnalyses: rows.length, windowDays };
+}


### PR DESCRIPTION
## Summary

Closes the remaining Milestone 2 "longitudinal intelligence" gap: the per-plant `HealthTrendChart` already ships, but the grow detail page had no rolled-up view of how the whole grow was trending. This PR adds a daily-averaged grow-level health trend at `/grows/[id]`.

### What ships

**Server (`apps/web/src/lib/server/grow-health-trend.ts`)**
- `getGrowHealthTrend(growId, windowDays = 30)` selects every `plant_analyses` row for the grow inside the window (default 30 days), buckets by **UTC day**, and averages `overall_health_score` across plants per day. Returns `{ points, totalAnalyses, windowDays }` ready to feed straight into the existing `HealthTrendChart` component.
- **RLS handles authorization** — the user-scoped supabase client only returns analyses for grows the user owns or collaborates on, so no manual membership check is needed.
- Empty `growId`, client init failure, and query error all soft-degrade to an empty trend with structured server logging. Same pattern as `workspace-overview` and `triage`.
- UTC-noon bucket keys keep rendering deterministic regardless of the viewer's browser locale.

**Web**
- Grow detail page (`/grows/[id]`) renders a new **Grow health trend** Card above the plants/metadata grid. Reuses `HealthTrendChart` verbatim (its existing empty / single-point fallback already covers the "needs more data" state). Card copy reports the window size and underlying analysis count for transparency.

### Behaviour matrix

| Scenario | Result |
| --- | --- |
| Grow with multiple plants, multiple analyses per day | One daily point per bucket, averaged across plants |
| Grow with no analyses in window | `points: []` — chart shows the friendly "needs more data" state |
| Empty `growId` | Early return — supabase client never instantiated |
| Supabase client init throws | Empty trend, error logged |
| Query errors / RLS denial | Empty trend, error logged |

## Risks & sensitive paths

- `apps/web/src/lib/server/grow-health-trend.ts` — **new file**, mirrors the established workspace-overview / triage server-helper pattern.
- `apps/web/src/app/(app)/grows/[id]/page.tsx` — adds a Card render and one more `Promise.all` branch.
- **No new API routes**, **no new env vars**, **no new dependencies**, **no schema changes**, **no migrations**.

## Test plan

- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web exec vitest run` — **938/938 pass** (6 new server tests)
- [ ] Manual: visit `/grows/[id]` for a grow with > 1 analysis day; verify chart renders and tooltips work; visit for a brand-new grow with 0 analyses; verify the friendly empty state replaces the chart


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6GPxrCj62oNSW2H45QAZF)_