### PR TITLE
fix(grow-trend): fetch newest analyses first + add (grow_id, analyzed_at) index

### DIFF
--- a/apps/web/src/lib/server/grow-health-trend.ts
+++ b/apps/web/src/lib/server/grow-health-trend.ts
@@ -66,12 +66,18 @@ export async function getGrowHealthTrend(
     Date.now() - windowDays * 24 * 60 * 60 * 1000,
   ).toISOString();
 
+  // Fetch newest-first so the `MAX_ANALYSES` cap drops the oldest rows,
+  // not the most recent. Larger grows can produce > 1k analyses inside
+  // the window; the chart already re-sorts ascending before drawing.
+  // A `(grow_id, analyzed_at desc)` index added in
+  // `20260520150000_plant_analyses_grow_analyzed_at_idx.sql` lets
+  // Postgres stream this without a sort.
   const { data, error } = await supabase
     .from("plant_analyses")
     .select("overall_health_score,analyzed_at")
     .eq("grow_id", growId)
     .gte("analyzed_at", since)
-    .order("analyzed_at", { ascending: true })
+    .order("analyzed_at", { ascending: false })
     .limit(MAX_ANALYSES);
 
   if (error) {
@@ -105,12 +111,19 @@ export async function getGrowHealthTrend(
     }
   }
 
-  const points: HealthTrendPoint[] = Array.from(buckets.entries()).map(
-    ([analyzedAt, { sum, count }]) => ({
+  // Emit oldest-first so the helper's contract is independent of the
+  // underlying query order. The chart already re-sorts but anyone else
+  // consuming this helper (sparkline summaries, exports) gets a stable
+  // time-ordered series for free.
+  const points: HealthTrendPoint[] = Array.from(buckets.entries())
+    .map(([analyzedAt, { sum, count }]) => ({
       analyzedAt,
       score: sum / count,
-    }),
-  );
+    }))
+    .sort(
+      (a, b) =>
+        new Date(a.analyzedAt).getTime() - new Date(b.analyzedAt).getTime(),
+    );
 
   return { points, totalAnalyses: rows.length, windowDays };
 }

--- a/supabase/migrations/20260520150000_plant_analyses_grow_analyzed_at_idx.sql
+++ b/supabase/migrations/20260520150000_plant_analyses_grow_analyzed_at_idx.sql
@@ -1,0 +1,18 @@
+-- Migration: plant_analyses_grow_analyzed_at_idx
+--
+-- The grow detail page (`apps/web/src/app/(app)/grows/[id]/page.tsx`)
+-- introduced `getGrowHealthTrend(growId)` which filters
+-- `plant_analyses` by `grow_id` and `analyzed_at`. The existing
+-- indexes from migration 004 cover `(plant_id, analyzed_at)` and
+-- `(image_id)` but not `grow_id`, so the new query path can fall
+-- back to a sequential scan + in-memory sort on grows with many
+-- analyses.
+--
+-- This index makes the trend query a direct index range scan and
+-- keeps the grow detail page snappy regardless of the underlying
+-- analysis volume. DESC on `analyzed_at` matches the query's
+-- ordering (newest-first, post-fix on PR #226 follow-up) so the
+-- planner can stream the limited result set without a sort node.
+
+create index if not exists idx_plant_analyses_grow_id_analyzed_at
+  on plant_analyses (grow_id, analyzed_at desc);


### PR DESCRIPTION
## Summary

Addresses post-merge review feedback on PR #226. Two real fixes — one correctness, one performance — both flagged by automated reviewers minutes after the squash landed.

### Fix 1: order DESC, not ASC (P1 codex / medium gemini)

The trend query in `getGrowHealthTrend` was capped at `MAX_ANALYSES = 1000` but ordered `analyzed_at ASC`. For a grow with > 1k analyses in the 30-day window, that returned the **oldest** 1k rows and silently omitted the most recent data — the part users actually care about for current health.

Switched to `ascending: false`. The helper now also sorts its emitted daily-bucket points ascending so callers (chart, future exports/sparklines) still get a stable time-ordered series regardless of upstream query order.

### Fix 2: new `(grow_id, analyzed_at desc)` index (P2 codex)

Migration `004_plant_analyses` indexed `(plant_id, analyzed_at)` and `(image_id)` but not `grow_id`. The new grow-detail request path filters by `grow_id` + `analyzed_at`, so without an index it can degrade into a seq scan + in-memory sort on larger tenants.

New migration `20260520150000_plant_analyses_grow_analyzed_at_idx.sql` adds `idx_plant_analyses_grow_id_analyzed_at` on `(grow_id, analyzed_at desc)`. DESC matches the query's ordering post Fix 1, so Postgres can stream the limited result set with no sort node.

## Risks & sensitive paths

- `supabase/migrations/**` — **new file only** (never edits existing), CLAUDE.md compliant. `create index if not exists` is idempotent.
- `apps/web/src/lib/server/grow-health-trend.ts` — one-line `ascending` flip plus an explicit ascending sort on the emitted points. Public contract (return shape) unchanged.
- No new API routes, no new env vars, no new dependencies, no schema *shape* changes.

## Test plan

- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web exec vitest run` — **938/938 pass** (existing 6 trend tests still green — emitted point order unchanged thanks to the explicit ascending sort)
- [x] `pnpm run validate` — clean (smoke skipped: pwsh not on PATH in this env)
- [ ] Manual: visit `/grows/[id]` for a grow with > 1 analysis, confirm chart still renders the same trend; verify migration applies cleanly on Supabase preview branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6GPxrCj62oNSW2H45QAZF)_