### PR TITLE
feat(triage): supabase realtime on the triage queue

### DIFF
--- a/apps/web/src/app/(app)/triage/page.tsx
+++ b/apps/web/src/app/(app)/triage/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { redirect } from "next/navigation";
 import { FindingResolutionControls } from "@/components/finding-resolution-controls";
 import { CheckCircleIcon, SparkIcon } from "@/components/icons";
+import { TriageLiveRefresh } from "@/components/triage-live-refresh";
 import { Badge } from "@/components/ui/badge";
 import { buttonStyles } from "@/components/ui/button";
 import {
@@ -43,6 +44,7 @@ export default async function TriagePage() {
 
   return (
     <main className="app-page">
+      <TriageLiveRefresh />
       <PageHeader
         breadcrumbs={[
           { href: "/dashboard", label: "Dashboard" },

--- a/apps/web/src/components/triage-live-refresh.tsx
+++ b/apps/web/src/components/triage-live-refresh.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useTriageRealtime } from "@/lib/use-triage-realtime";
+
+/**
+ * Invisible side-effect component that mounts the triage Realtime
+ * subscription. Lives as its own component so the page itself can
+ * stay a Server Component — `useTriageRealtime` needs the browser
+ * supabase client, which is client-only.
+ */
+export function TriageLiveRefresh() {
+  useTriageRealtime();
+  return null;
+}

--- a/apps/web/src/lib/__tests__/use-triage-realtime.test.tsx
+++ b/apps/web/src/lib/__tests__/use-triage-realtime.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import React from "react";
+
+const refresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+type Handler = (_payload: unknown) => void;
+
+interface FakeChannel {
+  handlers: Map<string, Handler>;
+  on: (
+    _event: string,
+    _opts: Record<string, unknown>,
+    _h: Handler,
+  ) => FakeChannel;
+  subscribe: () => FakeChannel;
+}
+
+const removeChannel = vi.fn();
+const channels: FakeChannel[] = [];
+
+function makeChannel(): FakeChannel {
+  const ch: FakeChannel = {
+    handlers: new Map(),
+    on(event, opts, h) {
+      // Key by (channel event, postgres event type, table) so the test
+      // can fire any of the four subscriptions independently.
+      const o = opts as { event?: string; table?: string };
+      const key = `${event}:${o.event ?? ""}:${o.table ?? ""}`;
+      this.handlers.set(key, h);
+      return this;
+    },
+    subscribe() {
+      return this;
+    },
+  };
+  return ch;
+}
+
+vi.mock("@/lib/supabase-client", () => ({
+  createSupabaseBrowserClient: () => ({
+    channel: () => {
+      const ch = makeChannel();
+      channels.push(ch);
+      return ch;
+    },
+    removeChannel: (...args: unknown[]) => removeChannel(...args),
+  }),
+}));
+
+import { useTriageRealtime } from "../use-triage-realtime";
+
+function Probe() {
+  useTriageRealtime();
+  return null;
+}
+
+describe("useTriageRealtime", () => {
+  beforeEach(() => {
+    refresh.mockReset();
+    removeChannel.mockReset();
+    channels.length = 0;
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("subscribes to a single channel with the four expected listeners", () => {
+    render(<Probe />);
+    expect(channels.length).toBe(1);
+    const ch = channels[0]!;
+    expect(ch.handlers.has("postgres_changes:INSERT:plant_findings")).toBe(
+      true,
+    );
+    expect(ch.handlers.has("postgres_changes:UPDATE:plant_findings")).toBe(
+      true,
+    );
+    expect(ch.handlers.has("postgres_changes:INSERT:grow_tasks")).toBe(true);
+    expect(ch.handlers.has("postgres_changes:UPDATE:grow_tasks")).toBe(true);
+  });
+
+  it("debounces a burst across both tables into a single refresh()", () => {
+    render(<Probe />);
+    const ch = channels[0]!;
+    // Simulate the typical "confirm finding" cascade: finding UPDATE
+    // (resolution_state -> confirmed) plus the spawned task INSERT a
+    // moment later.
+    ch.handlers.get("postgres_changes:UPDATE:plant_findings")?.({});
+    ch.handlers.get("postgres_changes:INSERT:grow_tasks")?.({});
+    ch.handlers.get("postgres_changes:INSERT:plant_findings")?.({});
+
+    expect(refresh).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(299);
+    expect(refresh).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(2);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes its channel on unmount", () => {
+    const { unmount } = render(<Probe />);
+    expect(channels.length).toBe(1);
+    unmount();
+    expect(removeChannel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/use-triage-realtime.ts
+++ b/apps/web/src/lib/use-triage-realtime.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { createSupabaseBrowserClient } from "@/lib/supabase-client";
+
+/**
+ * Subscribes to Supabase Realtime events that can change what the
+ * `/triage` page shows and triggers a Next App Router `router.refresh()`
+ * whenever one fires. Specifically:
+ *
+ *   * `plant_findings` INSERT  — a new pending finding lands.
+ *   * `plant_findings` UPDATE  — a finding's resolution_state changed
+ *     (confirm / reject / false-positive moves it out of the pending bucket).
+ *   * `grow_tasks`     INSERT  — a new task spawned from a finding or
+ *     manually created.
+ *   * `grow_tasks`     UPDATE  — status transitions to/from open /
+ *     in_progress / done / dismissed.
+ *
+ * RLS does the filtering for us — Realtime only delivers row changes
+ * the user can SELECT, so we don't need to scope by growIds. This
+ * mirrors the `useLiveAnalysis` precedent.
+ *
+ * Implementation notes:
+ *   * Debounce with a short trailing window — a single confirm-finding
+ *     action produces a finding UPDATE + a task UPDATE in quick
+ *     succession; one refresh covers both.
+ *   * The browser supabase client can throw if public env vars are
+ *     missing (e.g. a deploy that built before the Supabase integration
+ *     synced its keys). Swallow that throw so a missing realtime
+ *     connection degrades gracefully instead of taking the page down.
+ *   * Requires `plant_findings` and `grow_tasks` to be in the
+ *     `supabase_realtime` publication. Added in
+ *     `006_chat_attachments.sql` (findings) and
+ *     `20260520170000_grow_tasks_realtime.sql` (tasks).
+ */
+export function useTriageRealtime() {
+  const router = useRouter();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let supabase;
+    try {
+      supabase = createSupabaseBrowserClient();
+    } catch (err) {
+      if (typeof console !== "undefined") {
+        console.warn(
+          "useTriageRealtime: browser supabase client unavailable, realtime disabled",
+          err,
+        );
+      }
+      return;
+    }
+
+    const scheduleRefresh = () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        router.refresh();
+      }, 300);
+    };
+
+    const channel = supabase
+      .channel("triage:inbox")
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "plant_findings" },
+        scheduleRefresh,
+      )
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "plant_findings" },
+        scheduleRefresh,
+      )
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "grow_tasks" },
+        scheduleRefresh,
+      )
+      .on(
+        "postgres_changes",
+        { event: "UPDATE", schema: "public", table: "grow_tasks" },
+        scheduleRefresh,
+      )
+      .subscribe();
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      void supabase.removeChannel(channel);
+    };
+  }, [router]);
+}

--- a/supabase/migrations/20260520170000_grow_tasks_realtime.sql
+++ b/supabase/migrations/20260520170000_grow_tasks_realtime.sql
@@ -1,0 +1,24 @@
+-- Migration: grow_tasks_realtime
+--
+-- Adds `grow_tasks` to the `supabase_realtime` publication so the
+-- cross-grow triage queue (`/triage`, shipped in PR #225) and any
+-- future task-aware surface can subscribe to live INSERT / UPDATE
+-- events. Today the page renders server-side at request time, so a
+-- grower had to manually reload to see a newly spawned task or a
+-- status change from a collaborator.
+--
+-- Wrapped in a DO block because re-running the migration on an
+-- environment where the table is already published would otherwise
+-- throw. Mirrors the pattern from 006_chat_attachments.sql.
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_publication_tables
+    where pubname = 'supabase_realtime'
+      and schemaname = 'public'
+      and tablename = 'grow_tasks'
+  ) then
+    execute 'alter publication supabase_realtime add table public.grow_tasks';
+  end if;
+end$$;


### PR DESCRIPTION
## Summary

Closes the Milestone 2 "Supabase Realtime for live findings updates" item. The cross-grow triage queue at `/triage` now refreshes itself the moment:

- A new finding lands (INSERT on `plant_findings`)
- A finding's `resolution_state` changes (UPDATE on `plant_findings`)
- A new task spawns (INSERT on `grow_tasks`)
- A task's status transitions (UPDATE on `grow_tasks`)

No manual reload required, no polling. RLS handles authorization — Realtime only delivers row events the user can SELECT, so no manual grow filter is needed.

### What ships

**Migration `20260520170000_grow_tasks_realtime.sql`**
- Adds `grow_tasks` to the `supabase_realtime` publication. `plant_findings` and `plant_analyses` were already in the publication (added in `006_chat_attachments.sql`); we just needed to admit tasks too. Wrapped in `DO $$ ... $$;` + `IF NOT EXISTS` so re-running on an already-published env is a no-op.

**Hook `apps/web/src/lib/use-triage-realtime.ts`**
- `useTriageRealtime()` subscribes to a single channel with the four postgres_changes listeners above.
- **300ms trailing debounce** — a "confirm finding" cascade (finding UPDATE + spawned task INSERT/UPDATE) collapses into one `router.refresh()`.
- **Graceful degradation** — browser supabase client init failure (e.g. missing env vars on a fresh deploy) logs a console warning and returns; the page stays interactive without live updates.
- Mirrors the established `useLiveAnalysis` pattern.

**Wrapper `apps/web/src/components/triage-live-refresh.tsx`**
- Invisible client component (`return null`) that just mounts the hook. Lives in its own file so the triage page can stay a Server Component.

**Triage page**
- Mounts `<TriageLiveRefresh />` at the top of `<main>`. Zero visible UI change.

### Behaviour matrix

| Trigger | Result |
| --- | --- |
| Another collaborator confirms a finding on the same grow | This user's open `/triage` tab refreshes within ~300ms |
| A new analysis spawns a high-severity finding via the auto-task trigger | Both the finding and the task appear after a single refresh |
| User's browser is offline / Realtime channel drops | Page stays interactive; reconnect resumes pushes (Supabase SDK default) |
| Public Supabase env vars missing on the deploy | Console warn, no live updates, page still renders fine |

## Risks & sensitive paths

- `supabase/migrations/**` — **new file only**, idempotent. Just publishes one table for Realtime.
- `apps/web/src/lib/use-triage-realtime.ts`, `apps/web/src/components/triage-live-refresh.tsx` — both new.
- `apps/web/src/app/(app)/triage/page.tsx` — adds one import and one component mount.
- No new API routes, no new env vars, no new dependencies, no RLS changes (RLS already does the filtering).

## Test plan

- [x] `pnpm --filter web type-check` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web exec vitest run` — **941/941 pass** (3 new hook tests covering wiring, debounce, cleanup)
- [x] `pnpm run validate` — clean
- [ ] Manual: open `/triage` in two browsers signed in as the same user; confirm a finding in one; verify the other auto-refreshes within ~300ms; verify the page still renders if `NEXT_PUBLIC_SUPABASE_URL` is missing on the deploy


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6GPxrCj62oNSW2H45QAZF)_