### PR TITLE
fix(timeline): hotfix broken getPlantTimeline ternary on main

### DIFF
--- a/apps/web/src/lib/server/__tests__/plants.test.ts
+++ b/apps/web/src/lib/server/__tests__/plants.test.ts
@@ -1348,20 +1348,40 @@ describe("plants server helpers", () => {
       plant_findings: params.findings ?? [],
       grow_tasks: params.tasks ?? [],
     };
+    // The timeline subquery uses `.order(...).limit(...)` after the
+    // Phase 3.3 pagination cap. supabase-js builders are thenable AND
+    // chainable, so the fixture's `order` returns a value that
+    // resolves directly (existing callers) AND exposes `.limit()`
+    // returning the same data (post-3.3 callers).
+    function thenableOrderReturn(
+      data: unknown[] | null,
+      error: { message: string } | null,
+    ) {
+      const result = { data, error };
+      const limit = vi.fn().mockResolvedValue(result);
+      return {
+        limit,
+        then: (
+          _onFulfilled?: (_v: typeof result) => unknown,
+          _onRejected?: (_r: unknown) => unknown,
+        ) => Promise.resolve(result).then(_onFulfilled, _onRejected),
+      } as PromiseLike<typeof result> & { limit: typeof limit };
+    }
     const from = vi.fn((table: string) => {
       if (table === "grow_tasks") {
-        const order = vi.fn().mockResolvedValue({
-          data: params.tasksError ? null : tableData.grow_tasks,
-          error: params.tasksError ? { message: params.tasksError } : null,
-        });
+        const order = vi.fn(() =>
+          thenableOrderReturn(
+            params.tasksError ? null : (tableData.grow_tasks ?? []),
+            params.tasksError ? { message: params.tasksError } : null,
+          ),
+        );
         const eq = vi.fn(() => ({ order }));
         const select = vi.fn(() => ({ eq }));
         return { select };
       }
-      const order = vi.fn().mockResolvedValue({
-        data: tableData[table] ?? [],
-        error: null,
-      });
+      const order = vi.fn(() =>
+        thenableOrderReturn(tableData[table] ?? [], null),
+      );
       const eq = vi.fn(() => ({ order }));
       const select = vi.fn(() => ({ eq }));
       return { select };

--- a/apps/web/src/lib/server/plants.ts
+++ b/apps/web/src/lib/server/plants.ts
@@ -390,8 +390,7 @@ export async function getPlantTimeline(
   const requested = options.limit ?? DEFAULT_TIMELINE_LIMIT;
   const safeRequested = Number.isFinite(requested)
     ? requested
-  const requested = options.limit ?? DEFAULT_TIMELINE_LIMIT;
-  const safeRequested = Number.isFinite(requested) ? requested : DEFAULT_TIMELINE_LIMIT;
+    : DEFAULT_TIMELINE_LIMIT;
   const limit = Math.max(
     1,
     Math.min(MAX_TIMELINE_LIMIT, Math.floor(safeRequested)),


### PR DESCRIPTION
## Critical: main currently doesn't compile

PR #218 was merged despite failing CI on `Web — Lint, Type, Test, Build`, `Containers — Build + SBOM`, and `CI — All green`. The merged `getPlantTimeline` body has the syntax error codex flagged as P1:

```ts
const requested = options.limit ?? DEFAULT_TIMELINE_LIMIT;
const safeRequested = Number.isFinite(requested)
  ? requested                                              // ← ternary never closed
const requested = options.limit ?? DEFAULT_TIMELINE_LIMIT; // ← redeclared
const safeRequested = Number.isFinite(requested) ? requested
                                                 : DEFAULT_TIMELINE_LIMIT;
```

This was almost certainly a botched merge-resolution / autofix on top of the gemini-review fix on #218. Nothing in `apps/web` will compile until this is corrected.

## Fix

- **plants.ts**: collapse the duplicated declarations to the single, well-formed ternary that was the intent.
- **plants.test.ts**: the post-3.3 `getPlantTimeline` chains `.order(...).limit(...)`, and `getPlantPassport` (which landed in main while #218 was open) calls `getPlantTimeline` internally — so the `makePassportDb` test fixture's `.order(...)` chain now needs to expose `.limit(...)` too. Updated to use the same thenable-with-limit pattern `makeSelectOrderResult` uses.

## Out of scope (tracked, not in this PR)

Same codex review on #218 raised three P2 concerns that are real but each their own follow-up:

1. `plant_images` query orders by `created_at desc` but the merged timeline displays by `taken_at desc`. A backfilled photo (`taken_at < created_at`) can be wrongly excluded from a capped page. Fix: switch order to `taken_at desc nulls last`.
2. `plant_analyses` / `plant_findings` still load **all** rows for the plant, not just the visible image set. Should be bounded by `image_id IN (...visible ids)` once the image query has resolved.
3. The existing `/api/plants/[plantId]/images` route calls `getPlantTimeline(plantId)` with no `limit` and now silently truncates to 50.

This PR keeps the scope as tight as possible — just unblock main.

## Test plan

- [x] **954** web vitest pass.
- [x] `pnpm run type-check`: clean (was broken on main).
- [x] `validate`, `security:routes`: clean.
- [x] Local `gitleaks --no-git`: no leaks.

The one pre-existing guardrail failure (`check-action-pins` pointing at `/api/plants/[plantId]/what-changed`) is in code added by a separate PR and is **not** part of this hotfix.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KaLKqjMpPKPtTv64emZySr)_