### PR TITLE
fix(web): bulletproof realtime hook + explicit wss CSP for Supabase

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -26,15 +26,17 @@ function parseOrigin(value) {
 function parseWsOrigin(value) {
   const origin = parseOrigin(value);
   if (!origin) return null;
-  // Supabase Realtime upgrades over `wss://`. Browsers' CSP-3 host-source
-  // matching treats `https://` and `wss://` as the same host, but iOS
-  // Safari (and other webkit variants) have shipped stricter
-  // interpretations that block the WebSocket unless `wss://` is listed
-  // explicitly — surfacing as a page-crashing throw out of
-  // `supabase.channel(...).subscribe()` on the dashboard + grows
-  // surfaces (both render <LiveAnalysisRefresher />). Emit the wss
-  // equivalent so the directive is unambiguous on every engine.
-  return origin.replace(/^https:\/\//, "wss://");
+  // Supabase Realtime upgrades over `wss://` (prod) or `ws://` (local
+  // dev against the Supabase CLI on `http://localhost:54321`).
+  // Browsers' CSP-3 host-source matching treats `https://` and
+  // `wss://` as the same host, but iOS Safari (and other webkit
+  // variants) have shipped stricter interpretations that block the
+  // WebSocket unless the ws scheme is listed explicitly — surfacing
+  // as a page-crashing throw out of `supabase.channel(...).subscribe()`
+  // on the dashboard + grows surfaces (both render <LiveAnalysisRefresher />).
+  // Emit the matching ws/wss equivalent so the directive is unambiguous
+  // on every engine, in both prod and local dev.
+  return origin.replace(/^http/, "ws");
 }
 
 function buildCSP() {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -23,10 +23,25 @@ function parseOrigin(value) {
   }
 }
 
+function parseWsOrigin(value) {
+  const origin = parseOrigin(value);
+  if (!origin) return null;
+  // Supabase Realtime upgrades over `wss://`. Browsers' CSP-3 host-source
+  // matching treats `https://` and `wss://` as the same host, but iOS
+  // Safari (and other webkit variants) have shipped stricter
+  // interpretations that block the WebSocket unless `wss://` is listed
+  // explicitly — surfacing as a page-crashing throw out of
+  // `supabase.channel(...).subscribe()` on the dashboard + grows
+  // surfaces (both render <LiveAnalysisRefresher />). Emit the wss
+  // equivalent so the directive is unambiguous on every engine.
+  return origin.replace(/^https:\/\//, "wss://");
+}
+
 function buildCSP() {
   const supabase = parseOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
+  const supabaseWs = parseWsOrigin(process.env.NEXT_PUBLIC_SUPABASE_URL);
   const appUrl = parseOrigin(process.env.NEXT_PUBLIC_APP_URL);
-  const extraConnect = [supabase, appUrl].filter(Boolean).join(" ");
+  const extraConnect = [supabase, supabaseWs, appUrl].filter(Boolean).join(" ");
 
   const directives = [
     "default-src 'self'",

--- a/apps/web/src/lib/use-live-analysis.ts
+++ b/apps/web/src/lib/use-live-analysis.ts
@@ -45,6 +45,7 @@ export function useLiveAnalysis({ growIds }: { growIds: string[] }) {
     let channels: RealtimeChannel[] = [];
     try {
       supabase = createSupabaseBrowserClient();
+      const client = supabase;
 
       const scheduleRefresh = () => {
         setLastEventAt(Date.now());
@@ -54,8 +55,13 @@ export function useLiveAnalysis({ growIds }: { growIds: string[] }) {
         }, 300);
       };
 
-      channels = growIds.map((growId) => {
-        const channel = supabase!
+      // Build channels with a for-of + push (not `.map`) so that if any
+      // `.subscribe()` throws partway through the list, the channels
+      // array reflects what actually subscribed and the catch block
+      // can clean them up. A `.map` would discard the partial result
+      // on throw and leak the already-subscribed channels.
+      for (const growId of growIds) {
+        const channel = client
           .channel(`live-analysis:${growId}`)
           .on(
             "postgres_changes",
@@ -81,8 +87,8 @@ export function useLiveAnalysis({ growIds }: { growIds: string[] }) {
             scheduleRefresh,
           )
           .subscribe();
-        return channel;
-      });
+        channels.push(channel);
+      }
     } catch (err) {
       if (typeof console !== "undefined") {
         console.warn(

--- a/apps/web/src/lib/use-live-analysis.ts
+++ b/apps/web/src/lib/use-live-analysis.ts
@@ -30,67 +30,91 @@ export function useLiveAnalysis({ growIds }: { growIds: string[] }) {
 
   useEffect(() => {
     if (growIds.length === 0) return;
-    // `createSupabaseBrowserClient` throws when the public env vars
-    // aren't bundled (e.g. a Vercel deploy that built before the
-    // Supabase integration synced its keys). Swallow that throw so a
-    // live-update side-effect can never take the entire dashboard
-    // page down via React's error boundary — losing realtime is a
-    // graceful degradation; losing the page isn't.
-    let supabase;
+
+    // Realtime is a non-critical UX nicety: losing it should degrade to
+    // "no auto-refresh" — never to "the whole page crashed into the
+    // workspace error boundary." Wrap the entire setup body in
+    // try/catch so any synchronous throw from supabase-js (env vars
+    // missing, breaking API change in `.channel().on().subscribe()`,
+    // malformed filter string) becomes a console.warn instead of
+    // taking the dashboard or grows surface down via React's error
+    // boundary on hydration.
+    type SupabaseBrowserClient = ReturnType<typeof createSupabaseBrowserClient>;
+    type RealtimeChannel = ReturnType<SupabaseBrowserClient["channel"]>;
+    let supabase: SupabaseBrowserClient | undefined;
+    let channels: RealtimeChannel[] = [];
     try {
       supabase = createSupabaseBrowserClient();
+
+      const scheduleRefresh = () => {
+        setLastEventAt(Date.now());
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(() => {
+          router.refresh();
+        }, 300);
+      };
+
+      channels = growIds.map((growId) => {
+        const channel = supabase!
+          .channel(`live-analysis:${growId}`)
+          .on(
+            "postgres_changes",
+            {
+              event: "INSERT",
+              schema: "public",
+              table: "plant_analyses",
+              filter: `grow_id=eq.${growId}`,
+            },
+            scheduleRefresh,
+          )
+          .on(
+            "postgres_changes",
+            {
+              event: "INSERT",
+              schema: "public",
+              table: "plant_findings",
+              // plant_findings has no grow_id column; we just listen
+              // for any insert and let the upstream debounce + RLS
+              // handle the rest. RLS ensures we only receive findings
+              // for plants in grows the user can read.
+            },
+            scheduleRefresh,
+          )
+          .subscribe();
+        return channel;
+      });
     } catch (err) {
       if (typeof console !== "undefined") {
         console.warn(
-          "useLiveAnalysis: browser supabase client unavailable, realtime disabled",
+          "useLiveAnalysis: realtime setup failed, live updates disabled",
           err,
         );
+      }
+      // Best-effort cleanup of anything that did get subscribed before
+      // the throw.
+      if (supabase) {
+        for (const ch of channels) {
+          try {
+            void supabase.removeChannel(ch);
+          } catch {
+            // ignore
+          }
+        }
       }
       return;
     }
 
-    const scheduleRefresh = () => {
-      setLastEventAt(Date.now());
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      debounceRef.current = setTimeout(() => {
-        router.refresh();
-      }, 300);
-    };
-
-    const channels = growIds.map((growId) => {
-      const channel = supabase
-        .channel(`live-analysis:${growId}`)
-        .on(
-          "postgres_changes",
-          {
-            event: "INSERT",
-            schema: "public",
-            table: "plant_analyses",
-            filter: `grow_id=eq.${growId}`,
-          },
-          scheduleRefresh,
-        )
-        .on(
-          "postgres_changes",
-          {
-            event: "INSERT",
-            schema: "public",
-            table: "plant_findings",
-            // plant_findings has no grow_id column; we just listen for
-            // any insert and let the upstream debounce + RLS handle the
-            // rest. RLS ensures we only receive findings for plants in
-            // grows the user can read.
-          },
-          scheduleRefresh,
-        )
-        .subscribe();
-      return channel;
-    });
-
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (!supabase) return;
       for (const ch of channels) {
-        void supabase.removeChannel(ch);
+        try {
+          void supabase.removeChannel(ch);
+        } catch (err) {
+          if (typeof console !== "undefined") {
+            console.warn("useLiveAnalysis: channel teardown failed", err);
+          }
+        }
       }
     };
   }, [growIds, router]);


### PR DESCRIPTION
## Summary

Production dashboard and grows surfaces were hitting their client-side error boundaries with copy "client-side hiccup (no server reference)" — the **exact failure mode the dashboard's own `error.tsx` documents at lines 11-14**:

> A client-side throw during hydration (e.g., a realtime hook can't initialise because public Supabase env vars haven't finished syncing). These show `digest === undefined`.

Vercel runtime logs were empty across 12h, confirming the throw never reached the server.

Both surfaces render `<LiveAnalysisRefresher growIds=… />` at the bottom of the page (dashboard/page.tsx:457, grows/page.tsx:362), which calls `useLiveAnalysis`. Two real holes:

### 1. `useLiveAnalysis`: only `createSupabaseBrowserClient()` was guarded

The `.channel().on().on().subscribe()` chain ran unguarded. Any synchronous throw out of supabase-js — a breaking API shape from a version bump, a malformed channel name, an internal invariant — bubbled out of the useEffect to React's error boundary on hydration. Live updates are a non-critical UX nicety; losing them should degrade silently, never crash the page.

**Fix:** wrap the entire setup body (client creation + channel construction + subscribe) in one try/catch. Cleanup is also try-wrapped because `removeChannel()` on a half-subscribed channel can throw too. Failure path runs best-effort cleanup of any channels that did subscribe before the throw, then logs and returns.

### 2. CSP `connect-src` only listed `https://*.supabase.co`

Supabase Realtime upgrades to `wss://`. CSP-3 host-source matching nominally treats `https://` and `wss://` as the same host on Chrome / Firefox, but webkit (iOS Safari) has shipped stricter interpretations that block the WebSocket. The screenshots that triggered this fix were taken on iOS Safari (visible 5G status indicator).

**Fix:** add a `parseWsOrigin()` helper that derives the `wss://` form from `NEXT_PUBLIC_SUPABASE_URL` and appends it to the `connect-src` directive. Now the directive is unambiguous on every engine.

Both fixes are independently defensible — they tighten the contract whether or not either alone caused the current crash. Realtime feature behaviour is unchanged on the happy path.

## Files

- `apps/web/src/lib/use-live-analysis.ts` — wrap full useEffect body in try/catch with best-effort cleanup on failure path
- `apps/web/next.config.mjs` — add `wss://` Supabase origin to CSP `connect-src`

## Test plan

- [ ] CI: `pnpm turbo run test type-check lint`
- [ ] CI: `pnpm run validate`
- [ ] Manual: open Vercel preview on iOS Safari; dashboard + grows render workspace content, not the error boundary
- [ ] Manual: open Network → WS in DevTools, confirm `wss://*.supabase.co/realtime/v1/websocket` connects (no CSP block)
- [ ] Manual: in DevTools console, run `localStorage.setItem('sb-test', '0'); window.NEXT_PUBLIC_SUPABASE_URL = ''; location.reload()` — confirm the page still renders and console shows the warn from `useLiveAnalysis`

---
_Generated by [Claude Code](https://claude.ai/code/session_018ukSvTvedX14kPuezqXRCD)_