### PR TITLE
ci: phase-2 pre-deploy checklist gate (surfacing copilot/phase-2-implementation)

### DIFF
--- a/.github/workflows/pre-deploy-checklist.yml
+++ b/.github/workflows/pre-deploy-checklist.yml
@@ -1,0 +1,65 @@
+name: Pre-deploy checklist
+
+# Phase 2 slice (e): enforces the PR template's required checklists before a
+# PR targeting `main` can merge. Parses the PR body and fails the check if
+# any required item under "## Validation", "## Architecture & Forbidden
+# Changes", or "## Rollback" is unchecked.
+#
+# Waivers:
+#   * Draft PRs are skipped (no failure) — checklist is enforced once the PR
+#     is marked ready for review.
+#   * PRs labelled `guardian:approved` are skipped — same waiver pattern as
+#     scripts/pr-guardian.mjs.
+#
+# To make this a required status check, an operator must edit branch
+# protection for `main` in GitHub repo settings:
+#   Settings → Branches → main → Require status checks → add
+#   "Pre-deploy checklist / Verify".
+# That cannot be configured from code.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pre-deploy-checklist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # Skip drafts and waived PRs entirely so the check shows as "skipped"
+    # rather than failing while work is in progress.
+    if: |
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'guardian:approved')
+    steps:
+      - uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@v6
+
+      - name: Evaluate checklist
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { evaluate } = await import(
+              `${process.env.GITHUB_WORKSPACE}/scripts/check-pr-checklist.mjs`
+            );
+            const body = context.payload.pull_request.body ?? '';
+            const result = evaluate(body);
+            core.summary.addRaw(result.summary);
+            await core.summary.write();
+            if (!result.ok) {
+              core.setFailed(result.summary);
+            } else {
+              core.info(result.summary);
+            }

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,6 +4,53 @@ Handoff log between sessions. Keep entries short. Newest at top.
 
 ---
 
+## 2026-05-17 — Phase 2 deploy-hardening series handoff (Copilot)
+
+**In-flight on `copilot/phase-2-implementation`** (Step 0 only — doc).
+
+- Added `docs/playbooks/phase2-deploy-hardening-series.md`: self-contained
+  6-PR series plan that future agents can find and follow. Modeled on
+  `docs/playbooks/ci-optimization-series.md` and the
+  `docs/playbooks/post-pr-163-followups.md` precedent.
+- Source of truth for scope: PR #184 "What's deliberately deferred (Phase 2
+  items)" + `docs/runbooks/slo.md` lines 68–70 (error-rate probe) and line
+  79 (DORA-CFR → CHANGELOG).
+- Slices, each independently revertable under the `AGENTS.md` size caps:
+  - **(a)** Error-rate probe in `post-deploy-smoke.yml` (reuses Phase 1
+    rollback path).
+  - **(b)** Sentry verification — CI check for DSN/auth-token symmetry +
+    one-shot post-deploy release-tag verifier (issue, not rollback).
+  - **(c)** DORA CFR → `docs/metrics/dora.md` via auto-opened PR, weekly
+    cron.
+  - **(d)** `apps/web/src/app/api/internal/status/route.ts` JSON endpoint
+    gated by `Authorization: Bearer ${CRON_SECRET}` (matches the existing
+    daily-summary cron pattern).
+  - **(e)** Pre-deploy checklist gate parsing the PR template's "Test
+    plan" fence.
+  - **(f)** Vercel Flags server-only scaffold under
+    `apps/web/src/lib/server/flags.ts` — nothing user-facing in this slice.
+- Recommended order: **e → a → c → b → d → f** (rationale in the doc §4).
+- Validation: same gate as the CI-opt series (`pnpm run validate` +
+  `pnpm turbo run type-check lint test` + `pnpm run security:routes`);
+  slice (f) additionally requires `pnpm run build`; slice (a) additionally
+  requires a `workflow_dispatch` dry-run with optional secrets unset to
+  prove graceful degradation.
+- Out-of-scope for the whole series, restated for emphasis: schema /
+  migrations, `packages/shared/src/types.ts`, `apps/analysis/app/models/**`,
+  any browser-facing status page, any `middleware.ts`, any weakening of
+  `harden-runner` / `concurrency` / job-scoped `permissions:`.
+- This branch (`copilot/phase-2-implementation`) is intentionally
+  doc-only. Each slice lands as its own PR off `main` on a branch named
+  `copilot/phase2-<slice>`.
+
+**Next step**
+
+- Open a fresh session per slice, paste the prompt template in §6 of the
+  new doc, swap the slice letter. Start with **(e)** (warm-up) or **(a)**
+  (highest user value).
+
+---
+
 ## 2026-05-16 — CI optimization slice (a) on series PR (Copilot)
 
 **Landed on `copilot/optimize-ci-process`** (slice (a) appended to the series-handoff PR per user direction to follow Option 1 in-place)

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -4,6 +4,41 @@ Handoff log between sessions. Keep entries short. Newest at top.
 
 ---
 
+## 2026-05-17 — Phase 2 slice (e): pre-deploy checklist gate (Copilot)
+
+**Landed on `copilot/phase-2-implementation`** alongside Step 0.
+
+- New `.github/workflows/pre-deploy-checklist.yml`: parses PR body for the
+  template's required sections; fails if any item under **Validation**,
+  **Architecture & Forbidden Changes**, or **Rollback** is unchecked. Skips
+  draft PRs and PRs labelled `guardian:approved`. SHA-pinned
+  `step-security/harden-runner`, minimum-scoped permissions
+  (`contents: read`, `pull-requests: read`), concurrency scoped per-PR.
+- New `scripts/check-pr-checklist.mjs`: pure parser + `evaluate(body)`
+  function exported for the workflow (via `actions/github-script@v9`) and
+  for unit tests.
+- New `scripts/__tests__/check-pr-checklist.test.mjs`: 7 tests, picked up
+  automatically by the existing `check:smoke-script` glob; all pass.
+- `docs/deployment.md` §CI/CD: added "Required status checks for `main`"
+  subsection with operator instructions to flip the new gate to required
+  in branch protection (cannot be configured from code).
+- Validation: `pnpm run validate` ✅ (9/9 smoke + script tests),
+  `pnpm run security:routes` ✅, `pnpm turbo run type-check lint test` ✅
+  (730 tests), CodeQL ✅ (0 alerts).
+- Branch note: the playbook's `copilot/phase2-<slice>` branch-per-slice
+  convention starts with the next slice. This slice rode the existing
+  `copilot/phase-2-implementation` branch because the playbook PR was
+  already open there and the sandbox can only push to the current branch.
+
+**Next slice**
+
+- **(a)** Error-rate probe in `post-deploy-smoke.yml`. Open a fresh
+  session, paste the prompt in §6 of
+  `docs/playbooks/phase2-deploy-hardening-series.md`, swap the slice
+  letter to `a`. Highest user value — closes the load-bearing SLO gap.
+
+---
+
 ## 2026-05-17 — Phase 2 deploy-hardening series handoff (Copilot)
 
 **In-flight on `copilot/phase-2-implementation`** (Step 0 only — doc).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -349,6 +349,29 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) runs on every push/PR:
 - **Analysis**: ruff lint, mypy type-check, pytest
 - **Shared**: type-check
 
+### Required status checks for `main`
+
+The following PR-level checks should be marked as **required** in branch
+protection so a PR cannot merge unless they pass. Branch protection cannot be
+configured from code — an operator must set this in repo Settings.
+
+- `CI / *` (existing build/lint/test matrix from `ci.yml`)
+- `CodeQL`
+- `Gitleaks / Secret scan`
+- `Pre-deploy checklist / Verify` — enforces the PR template's
+  **Validation**, **Architecture & Forbidden Changes**, and **Rollback**
+  checklists. Skipped automatically for draft PRs and for PRs labelled
+  `guardian:approved`. Source: `.github/workflows/pre-deploy-checklist.yml`
+  (parser: `scripts/check-pr-checklist.mjs`).
+
+**How to mark the checklist gate as required** (operator action):
+
+1. GitHub → repo → Settings → Branches → `main` rule.
+2. Tick **Require status checks to pass before merging**.
+3. Search for `Pre-deploy checklist` and add the **Verify** check.
+4. Save. The check now blocks merge for non-draft, non-waived PRs whose
+   bodies do not have all required checklist items ticked.
+
 ## Production deploy lifecycle
 
 Every push to `main` triggers Vercel to build and deploy production. The

--- a/docs/playbooks/phase2-deploy-hardening-series.md
+++ b/docs/playbooks/phase2-deploy-hardening-series.md
@@ -1,0 +1,445 @@
+# Phase 2 Deployment Hardening — 6-PR Series Handoff
+
+Last updated: 2026-05-17 · Owner: @stevenschling13
+
+This is a self-contained handoff for the Phase 2 deployment-hardening series.
+If you are an AI agent (Claude Code, Copilot Task Agent, Codex) picking up one
+of the PRs below, **read this top-to-bottom before doing anything else**. Each
+PR is independent and revertable. Land them in the recommended order
+(`e → a → c → b → d → f`); do not combine.
+
+> Why a series and not one PR: `.github/copilot-instructions.md` §7 and
+> `AGENTS.md` cap PRs at ≤ 30 files / ≤ 1,500 lines and "one concern per PR".
+> Each slice below fits under those caps and is independently revertable.
+
+**Authoritative scope sources:**
+
+- PR #184 description, section _"What's deliberately deferred (Phase 2 items)"_.
+- `docs/runbooks/slo.md` §"Error rate" (the error-rate auto-rollback gap) and
+  the DORA-CFR follow-up referenced under §"Deploy reliability".
+
+---
+
+## 0. Quick-start (every session)
+
+```bash
+cd /home/runner/work/PhenoSage/PhenoSage   # or wherever the repo lives
+git fetch origin main
+git checkout -b copilot/phase2-<slice>  origin/main
+
+# Healthy baseline before touching anything:
+pnpm install --frozen-lockfile
+pnpm run validate
+pnpm turbo run type-check lint test
+pnpm run security:routes
+```
+
+If any of the four commands above is red on `main`, **stop**. Fix the baseline
+first or surface it in the PR description — do not start Phase 2 work on a
+broken tree.
+
+When done, update `WORKLOG.md` with what landed (SHA), what's in-flight (branch
+
+- PR link), and any dead ends. This is required by `AGENTS.md` §Handoff.
+
+---
+
+## 1. Shared rules for every PR in this series
+
+These apply to all six slices. Violating any of them means the PR should be
+rejected in review:
+
+1. **One concern per PR.** Workflow-only slices (a, b CI half, c, e) touch
+   only `.github/workflows/**` plus the explicitly named docs. Slice (d)
+   touches `apps/web/src/app/api/internal/**` only. Slice (f) is the only
+   slice that adds a runtime dependency.
+2. **Do not weaken the security boundary.** No edits to CSP / security headers
+   in `apps/web/next.config.mjs`, no weakening of RLS, no new public Supabase
+   Storage buckets, no `middleware.ts`, no fetching the analysis service from
+   client code. (See `.github/copilot-instructions.md` §1, §6.)
+3. **Never weaken the env contract.** No secret in a `NEXT_PUBLIC_*` var. Any
+   new env var goes in both `.env.example` and the contract enforced by
+   `scripts/check-env-contract.mjs`.
+4. **Never add `--no-verify`, `--no-gpg-sign`, or `git push --force`** (per
+   `AGENTS.md` Forbidden actions). Also: never `git push --force` to a branch
+   an open PR is tracking.
+5. **Preserve `step-security/harden-runner`** on every job. Do not change
+   `egress-policy` from `audit` to anything looser in the same PR.
+6. **Preserve `concurrency:` cancel-in-progress** at the workflow level on
+   every existing workflow you touch.
+7. **Keep `permissions:` minimum-scoped.** If a slice needs a new permission,
+   add it on the specific job, not at the workflow root.
+8. **Pin third-party Actions to a full commit SHA**, with a brief note in
+   the PR description on why the action is needed. Prefer first-party or
+   already-used actions.
+9. **Degrade gracefully when secrets are absent.** Phase 1 (PR #184) set the
+   precedent: missing `VERCEL_TOKEN` / `DISCORD_WEBHOOK_URL` / `SENTRY_*`
+   silently disables the optional step instead of failing the workflow. Phase
+   2 slices must follow the same pattern.
+10. **Plant-health output discipline still applies.** If any new probe or
+    status surface can produce a misleading answer when an upstream is down,
+    it must surface an explicit inconclusive / not-ready state, not a
+    confident "ok". (See `.github/copilot-instructions.md` §9.)
+
+---
+
+## 2. The six slices
+
+### PR (a) — Error-rate probe in `post-deploy-smoke.yml`
+
+**Goal.** Close the load-bearing Phase 2 gap: today the smoke job only checks
+endpoint health, headers, and secret-leak patterns. A deploy that quietly
+spikes 5xx or Server Component throws won't trigger auto-rollback. The SLO
+doc already promises this in §"Error rate" lines 68–70.
+
+**In scope.**
+
+- Add a step to `.github/workflows/post-deploy-smoke.yml` that, after the
+  existing smoke check passes, queries error counts for the just-deployed
+  release over a short window (default 5 min):
+  - **Preferred source:** Vercel runtime logs via the existing `VERCEL_TOKEN`
+    (Vercel Logs API), filtered to the just-promoted deployment ID.
+  - **Fallback source:** Sentry `events` or `releases/.../resolved` API
+    scoped to the `release` tag pushed by `release-on-prod-deploy.yml`.
+- Threshold expressed as workflow env vars (one place to tune):
+  - `ERROR_RATE_THRESHOLD` (default `0.01` = 1% of requests in the window).
+  - `ERROR_ABSOLUTE_FLOOR` (default `5` 5xx responses) to handle low-traffic
+    windows where the ratio is statistically meaningless.
+- On breach: reuse the existing rollback path from Phase 1 (Vercel promote
+  API → previous READY deploy, open issue with the probe receipt, Discord
+  alert). **Do not add a second rollback implementation.**
+- Degrade gracefully when `SENTRY_AUTH_TOKEN` and Vercel Logs API both fail
+  or are unconfigured — write a "probe skipped: <reason>" line to the run
+  summary and let smoke pass.
+
+**Out of scope.**
+
+- New rollback machinery. The Phase 1 promote-API call is reused.
+- Editing `next.config.mjs`, CSP, or any runtime code.
+- Wiring Sentry into `apps/web` — that's slice (b).
+- Issue templates / labels (use whatever Phase 1 already opens).
+
+**Validation.**
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run validate
+pnpm turbo run type-check lint test
+pnpm run security:routes
+```
+
+Plus a `workflow_dispatch` dry-run on a non-prod branch with all optional
+secrets unset, to prove the new step degrades gracefully.
+
+**Stop condition.** The dry-run shows the probe step running, reporting
+"probe skipped: no token" (or similar) when secrets are absent, and the
+smoke job still goes green. Open the PR; do not start (b).
+
+---
+
+### PR (b) — Sentry verification
+
+**Goal.** Make sure Sentry is actually wired end-to-end and that a missing
+half of the configuration fails CI rather than failing silently in prod.
+
+**In scope.**
+
+- Add a CI check (in `ci.yml` or a small dedicated workflow) that fails if
+  the repo references `SENTRY_DSN` in client code but `SENTRY_AUTH_TOKEN`
+  isn't in the env contract — or vice versa. Implement as a small Node
+  script invoked from a workflow step; do not add a new linter.
+- Add a one-shot post-deploy step (in `release-on-prod-deploy.yml` or a
+  sibling triggered on the same event) that hits Sentry's API to confirm
+  the release tag just pushed actually shows up in Sentry. If it doesn't,
+  open an issue (label e.g. `phase2:sentry-release-missing`). **Do not
+  rollback** — Sentry being late is not a user-facing failure.
+- Update `docs/deployment.md` "Required GitHub secrets" table to include
+  `SENTRY_AUTH_TOKEN` and any new vars.
+- Extend `scripts/check-env-contract.mjs` allowlist for any new vars added
+  to `.env.example` (memory: the contract is currently out of sync with the
+  example for `SENTRY_*` / `OTEL_*`; that drift is a separate concern, do
+  not bundle the full sync into this slice — only add what this slice
+  introduces).
+
+**Out of scope.**
+
+- Wiring `@sentry/nextjs` in `apps/web` runtime code. If Sentry is not yet
+  initialised, file a separate issue and document it in the PR body; this
+  slice only verifies _configuration_, it does not introduce instrumentation.
+- Replacing or restructuring the rollback path.
+
+**Validation.** Standard gate (§3 below). Confirm the new CI check fails
+when you deliberately remove `SENTRY_DSN` from a fixture, then put it back.
+
+**Stop condition.** The check fails on a deliberately mis-configured
+fixture, passes on the real config, and the post-deploy verification step
+runs (or skips gracefully) on the PR's own deploy.
+
+---
+
+### PR (c) — DORA-metrics-to-CHANGELOG automation
+
+**Goal.** Make Change Failure Rate visible and auditable, per `slo.md` line 79.
+
+**In scope.**
+
+- Extend `.github/workflows/track-followups.yml` (or add a sibling) with a
+  weekly `schedule:` trigger to:
+  - Compute deploy count from tags pushed by `release-on-prod-deploy.yml`
+    (format `vYYYY.MM.DD-N`) over the trailing 30 days.
+  - Compute failure count from:
+    - Issues opened by the Phase 1 auto-rollback path with a known label
+      (use whatever label Phase 1 already applies; do not invent a new one
+      without checking).
+    - Commits to `main` within 6h of a deploy tag whose conventional-commit
+      type is `fix` or `revert`.
+- Write the rolling 30-day CFR to a fenced block in `docs/metrics/dora.md`
+  (new file, JSON-in-fences for easy machine read) **via a PR**, not a
+  direct push to main. Use `peter-evans/create-pull-request@<sha>` or
+  equivalent. The PR opener has minimum-scoped `permissions:`.
+- Label the auto-opened PR (e.g. `phase2:dora-update`) so it's easy to
+  auto-merge or filter.
+
+**Out of scope.**
+
+- Editing `CHANGELOG.md` if it doesn't already exist (don't create a new
+  CHANGELOG just to host one block; prefer the dedicated `docs/metrics/`
+  file).
+- Computing latency or availability SLO numbers — only CFR + deploy count
+  in this slice.
+- Publishing to anywhere other than the repo (no external dashboards).
+
+**Validation.** Standard gate. Manually invoke the workflow via
+`workflow_dispatch` and confirm a draft PR is opened with believable
+numbers.
+
+**Stop condition.** Manual dispatch opens a PR with the fenced DORA block
+populated. Do not also wire up alerting on the number — that's a future
+concern.
+
+---
+
+### PR (d) — `/api/internal/status` consolidated dashboard
+
+**Goal.** One JSON endpoint summarising deploy + smoke + cron + error-budget
+state, so on-call doesn't have to bounce between five tabs.
+
+**In scope.**
+
+- New Route Handler `apps/web/src/app/api/internal/status/route.ts`:
+  - Server-only. Gated by `Authorization: Bearer ${CRON_SECRET}` — the same
+    pattern as `apps/web/src/app/api/internal/cron/daily-summary/route.ts`
+    (see repo memory: cron-auth).
+  - Returns JSON aggregating:
+    - Last successful prod deploy tag (from GitHub Releases API).
+    - Current smoke status (last `post-deploy-smoke.yml` run conclusion).
+    - Last rollback receipt (issue opened by the Phase 1 auto-rollback
+      path) if any.
+    - Last `daily-summary` cron run timestamp.
+    - Error budget remaining for the current month (computed from the SLO
+      doc's 99.5% target, requires after slice (a) lands so the probe
+      output is available — but compute from public smoke-run history if
+      Sentry isn't wired yet).
+  - All upstream calls must time out (≤ 3s each) and individually degrade
+    to `"unknown"` / `null` per field. The overall response must always
+    distinguish `"ok" | "degraded" | "unknown"` per the plant-health output
+    discipline rule.
+- Server-only fetches go through `apps/web/src/lib/server/**`. Tests added
+  alongside under `__tests__/`.
+- Update `docs/runbooks/on-call.md` to point at the new endpoint and show a
+  one-line `curl` invocation.
+
+**Out of scope.**
+
+- A browser-facing HTML page. JSON only in this slice.
+- Schema changes / new migrations / new tables.
+- Edits to `packages/shared/src/types.ts` (the response shape lives next to
+  the route).
+- Adding new external API integrations beyond GitHub + (optionally) Vercel
+  and Sentry, all using existing secrets.
+
+**Validation.** Standard gate. Tests cover: happy path, each upstream
+timing out, missing `CRON_SECRET` (returns 401), wrong bearer (returns
+401).
+
+**Stop condition.** `curl -H "Authorization: Bearer $CRON_SECRET"
+https://.../api/internal/status` returns a 200 with the full envelope on
+preview. Don't render a UI in this slice.
+
+---
+
+### PR (e) — Pre-deploy checklist gate
+
+**Goal.** Smallest, most isolated slice. Make the existing PR-template "Test
+plan" checklist actually enforceable.
+
+**In scope.**
+
+- New workflow `.github/workflows/pre-deploy-checklist.yml`:
+  - Triggers on `pull_request` (types: `opened`, `edited`, `synchronize`,
+    `ready_for_review`) targeting `main`.
+  - Parses the PR body for the fenced "Test plan" checklist used in the
+    repo's PR template.
+  - Fails the check if any required item is unchecked.
+  - Skips for PRs labelled `guardian:approved` (same waiver pattern as
+    `scripts/pr-guardian.mjs`).
+- Document in `docs/deployment.md` how to mark this as a required status
+  check in branch protection (operator action only — branch protection
+  cannot be configured from code in this repo).
+
+**Out of scope.**
+
+- Changing the PR template itself.
+- Adding any other checklist-style gates.
+- Touching runtime code.
+
+**Validation.** Standard gate. Open a draft PR with an unchecked Test plan
+item and confirm the check fails; check it and confirm the check passes.
+
+**Stop condition.** Both scenarios above behave as expected.
+
+---
+
+### PR (f) — Vercel Flags integration scaffold
+
+**Goal.** Land the smallest possible server-only scaffold for feature flags
+so future feature work can adopt the pattern incrementally.
+
+**In scope.**
+
+- Run `gh-advisory-database` against the chosen flags package version
+  (likely `@vercel/flags`) **before** adding it to `apps/web/package.json`.
+- Add the SDK to `apps/web` dependencies only. Lockfile updated via
+  `pnpm install`.
+- New server-only module `apps/web/src/lib/server/flags.ts` with `import
+"server-only"` at the top. Defines one demo flag (e.g. `phase2Demo`) that
+  always returns `false` by default.
+- A unit test under `apps/web/src/lib/server/__tests__/flags.test.ts`.
+- Document the rollout pattern in `docs/deployment.md`:
+  - All flags are server-evaluated only.
+  - Never `NEXT_PUBLIC_*` a flag value.
+  - Flag identifiers are committed in code; flag _values_ live in Vercel.
+
+**Out of scope.**
+
+- Wiring the demo flag into any user-facing surface.
+- Adding a `/api/flags` endpoint, or any browser-readable flag value.
+- Touching `next.config.mjs`, CSP, or the env contract beyond adding
+  whatever the SDK requires (and adding it to `scripts/check-env-contract.mjs`
+  if so).
+
+**Validation.** Standard gate **plus** `pnpm run build` (this is the only
+slice that touches `apps/web` runtime code).
+
+**Stop condition.** `pnpm run build` is green, the test asserts the demo
+flag returns `false`, and no browser-imported file imports the new module
+(verified by `pnpm run security:routes` and route-boundary checker).
+
+---
+
+## 3. Validation gate for every slice
+
+```bash
+pnpm install --frozen-lockfile
+pnpm run validate
+pnpm turbo run type-check lint test
+pnpm run security:routes
+```
+
+Slice (f) additionally requires `pnpm run build`. Slice (a) additionally
+requires a `workflow_dispatch` dry-run of `post-deploy-smoke.yml` on a
+non-prod branch with optional secrets unset, to confirm graceful degradation.
+
+If `apps/analysis/**` is touched (it shouldn't be — that's out of scope for
+the whole series), also run:
+
+```bash
+cd apps/analysis && ruff check . && mypy app/ && pytest --cov=app
+```
+
+---
+
+## 4. Recommended order and dependencies
+
+Recommended order: **e → a → c → b → d → f**.
+
+- **(e) first** — smallest, no runtime risk, validates the agent loop on
+  workflow-only changes.
+- **(a) next** — closes the load-bearing SLO gap (error-rate
+  auto-rollback). Highest user value.
+- **(c) before (b)** — DORA automation is pure CI and doesn't depend on
+  Sentry being wired; Sentry verification (b) wants `SENTRY_DSN` actually
+  set in prod first.
+- **(d) after (b)** — the `/api/internal/status` endpoint benefits from
+  Sentry being verified so it can include error-budget data accurately.
+  Can still land before (b) with the error-budget field falling back to
+  `"unknown"`.
+- **(f) last** — only slice that touches `apps/web` runtime code; do it on
+  a clean tree once a–e are stable.
+
+Slices (a) and (e) are independent of each other and can swap order safely.
+Slices (b), (c), (d), (f) should not swap with anything earlier in the list.
+
+---
+
+## 5. Out of scope for the entire series
+
+- Schema changes or new migrations.
+- Any change to `packages/shared/src/types.ts` or
+  `apps/analysis/app/models/**`.
+- Editing existing migrations under `supabase/migrations/**`.
+- A browser-facing status page (slice (d) is JSON-only by design).
+- New databases, native mobile code, social / community / e-commerce
+  features (all forbidden by `.github/copilot-instructions.md` §6).
+- Adding a `middleware.ts` to `apps/web`.
+- Removing or weakening `step-security/harden-runner`, `concurrency`, or
+  job-scoped `permissions:` in any workflow this series touches.
+
+---
+
+## 6. How to prompt the next session
+
+Open a fresh Copilot Task Agent / Claude Code / Codex session **per slice**.
+Use the template below verbatim, swapping the slice letter. The agent will
+then read this file (it is committed in the repo) for full context.
+
+```
+Implement PR (<a|b|c|d|e|f>) of the Phase 2 deployment hardening series.
+
+Authoritative plan: docs/playbooks/phase2-deploy-hardening-series.md
+Read that file end-to-end before touching anything.
+
+Rules:
+- Stay strictly within "In scope" for the slice. If you would touch
+  anything in "Out of scope" — for this slice or for the whole series —
+  stop and surface it in the PR description instead.
+- Follow §1 "Shared rules for every PR in this series".
+- Run the slice's "Validation" commands locally before opening the PR.
+- Stop at the slice's "Stop condition" — do not start the next slice.
+- Degrade gracefully when secrets are absent (Phase 1 precedent).
+
+When done:
+1. Open one PR with the slice letter in the title, e.g.
+   "feat(deploy): phase2(a) error-rate probe in post-deploy smoke".
+2. In the PR body, include:
+   - What the slice does and what it deliberately does not do.
+   - Output of the validation gate.
+   - Any graceful-degradation behaviour you proved (esp. for slice a).
+3. Update WORKLOG.md per AGENTS.md §Handoff.
+```
+
+---
+
+## 7. Cross-links
+
+- `.github/copilot-instructions.md` — non-negotiable repo rules
+- `AGENTS.md` — universal agent playbook (PR caps, sensitive paths,
+  validation, handoff)
+- `CLAUDE.md` — architecture + commands + sensitive paths
+- `docs/runbooks/slo.md` — the SLO numbers this series is hardening
+- `docs/runbooks/rollback.md` — the manual rollback procedure
+- `docs/runbooks/on-call.md` — slice (d) updates this
+- `docs/deployment.md` — slices (b), (e), (f) update this
+- `docs/playbooks/ci-optimization-series.md` — the precedent this doc is
+  modeled on
+- `docs/playbooks/repo-aware-ai-coding-playbook.md` — operating model

--- a/scripts/__tests__/check-pr-checklist.test.mjs
+++ b/scripts/__tests__/check-pr-checklist.test.mjs
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { evaluate } from "../check-pr-checklist.mjs";
+
+const TEMPLATE = readFileSync(".github/PULL_REQUEST_TEMPLATE.md", "utf8");
+
+// Tick every `- [ ]` in a body so we can build "fully-checked" fixtures.
+function checkAll(body) {
+  return body.replace(/- \[ \]/g, "- [x]");
+}
+
+test("blank template body fails (everything unchecked)", () => {
+  const result = evaluate(TEMPLATE);
+  assert.equal(result.ok, false);
+  // Validation #1..#4 must all be reported.
+  const v = result.missing.filter((m) => m.section === "Validation");
+  assert.ok(v.length >= 4, `expected ≥4 Validation misses, got ${v.length}`);
+  // Conditional analysis line must NOT be reported.
+  assert.ok(
+    !v.some((m) => m.item.toLowerCase().startsWith("(if ")),
+    "conditional 'If apps/analysis changed' item should be skipped",
+  );
+  // Architecture & Forbidden block must report all 7 items.
+  const a = result.missing.filter(
+    (m) => m.section === "Architecture & Forbidden Changes",
+  );
+  assert.equal(a.length, 7);
+  // Rollback must report the "at least one" message.
+  const r = result.missing.filter((m) => m.section === "Rollback");
+  assert.equal(r.length, 1);
+  assert.match(r[0].item, /at least one/);
+});
+
+test("fully-checked template body passes", () => {
+  const result = evaluate(checkAll(TEMPLATE));
+  assert.equal(result.ok, true, result.summary);
+  assert.equal(result.missing.length, 0);
+});
+
+test("missing required section is flagged", () => {
+  const body = checkAll(TEMPLATE).replace(
+    /^##\s+Validation[\s\S]*?(?=^##\s)/im,
+    "",
+  );
+  const result = evaluate(body);
+  assert.equal(result.ok, false);
+  assert.ok(
+    result.missing.some(
+      (m) => m.section === "Validation" && /section missing/i.test(m.item),
+    ),
+  );
+});
+
+test("rollback passes when exactly one box is checked", () => {
+  let body = checkAll(TEMPLATE);
+  // Re-uncheck the two non-revert rollback rows; keep "Pure git revert" checked.
+  body = body.replace(
+    "- [x] Requires migration rollback (describe below)",
+    "- [ ] Requires migration rollback (describe below)",
+  );
+  body = body.replace(
+    "- [x] Requires env var rollback (describe below)",
+    "- [ ] Requires env var rollback (describe below)",
+  );
+  const result = evaluate(body);
+  assert.equal(result.ok, true, result.summary);
+});
+
+test("rollback fails when zero boxes are checked", () => {
+  let body = checkAll(TEMPLATE);
+  body = body.replace(
+    "- [x] Pure `git revert` is sufficient",
+    "- [ ] Pure `git revert` is sufficient",
+  );
+  body = body.replace(
+    "- [x] Requires migration rollback (describe below)",
+    "- [ ] Requires migration rollback (describe below)",
+  );
+  body = body.replace(
+    "- [x] Requires env var rollback (describe below)",
+    "- [ ] Requires env var rollback (describe below)",
+  );
+  const result = evaluate(body);
+  assert.equal(result.ok, false);
+  const r = result.missing.filter((m) => m.section === "Rollback");
+  assert.equal(r.length, 1);
+});
+
+test("summary is informative on failure", () => {
+  const result = evaluate(TEMPLATE);
+  assert.match(result.summary, /required items unchecked/i);
+  assert.match(result.summary, /guardian:approved/);
+});
+
+test("summary is concise on success", () => {
+  const result = evaluate(checkAll(TEMPLATE));
+  assert.match(result.summary, /all required items checked/i);
+});

--- a/scripts/check-pr-checklist.mjs
+++ b/scripts/check-pr-checklist.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Pure helper that parses a PR body and decides whether the required
+// pre-deploy checklists are complete.
+//
+// Required sections (matched against `.github/PULL_REQUEST_TEMPLATE.md`):
+//
+//   1. "## Validation"
+//      - All `- [ ]` items must be checked, EXCEPT the final one whose text
+//        starts with "(If " (conditional on a path change).
+//
+//   2. "## Architecture & Forbidden Changes"
+//      - All `- [ ]` items must be checked (unconditional).
+//
+//   3. "## Rollback"
+//      - At least one `- [ ]` item must be checked.
+//
+// Returns: { ok: boolean, missing: Array<{section, item}>, summary: string }
+//
+// Exported as `evaluate(body)` for use by the workflow (via github-script)
+// and by tests under scripts/__tests__/.
+
+const SECTION_RE = (heading) =>
+  new RegExp(
+    `^##\\s+${heading.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}\\s*\\n([\\s\\S]*?)(?=^##\\s|\\z)`,
+    "im",
+  );
+
+// Match list items, capturing the box state and the item text on the same
+// line. Allows leading whitespace.
+const ITEM_RE = /^\s*[-*]\s*\[( |x|X)\]\s+(.+?)\s*$/;
+
+function extractSection(body, heading) {
+  const match = body.match(SECTION_RE(heading));
+  return match ? match[1] : null;
+}
+
+function parseItems(section) {
+  if (!section) return [];
+  return section
+    .split("\n")
+    .map((line) => line.match(ITEM_RE))
+    .filter(Boolean)
+    .map((m) => ({ checked: m[1].toLowerCase() === "x", text: m[2] }));
+}
+
+export function evaluate(body) {
+  const missing = [];
+  const sectionsFound = [];
+
+  // --- Validation ---------------------------------------------------------
+  const validation = extractSection(body, "Validation");
+  if (!validation) {
+    missing.push({
+      section: "Validation",
+      item: "(section missing from PR body)",
+    });
+  } else {
+    sectionsFound.push("Validation");
+    const items = parseItems(validation);
+    for (const it of items) {
+      // The template's last validation row is conditional on apps/analysis
+      // changing. Skip it if it begins with "(If ".
+      if (/^\(If\b/i.test(it.text)) continue;
+      if (!it.checked) {
+        missing.push({ section: "Validation", item: it.text });
+      }
+    }
+  }
+
+  // --- Architecture & Forbidden Changes ----------------------------------
+  const arch = extractSection(body, "Architecture & Forbidden Changes");
+  if (!arch) {
+    missing.push({
+      section: "Architecture & Forbidden Changes",
+      item: "(section missing from PR body)",
+    });
+  } else {
+    sectionsFound.push("Architecture & Forbidden Changes");
+    for (const it of parseItems(arch)) {
+      if (!it.checked) {
+        missing.push({
+          section: "Architecture & Forbidden Changes",
+          item: it.text,
+        });
+      }
+    }
+  }
+
+  // --- Rollback (at least one checked) -----------------------------------
+  const rollback = extractSection(body, "Rollback");
+  if (!rollback) {
+    missing.push({
+      section: "Rollback",
+      item: "(section missing from PR body)",
+    });
+  } else {
+    sectionsFound.push("Rollback");
+    const items = parseItems(rollback);
+    if (items.length > 0 && !items.some((it) => it.checked)) {
+      missing.push({
+        section: "Rollback",
+        item: "at least one rollback strategy must be checked",
+      });
+    }
+  }
+
+  const ok = missing.length === 0;
+  const summary = ok
+    ? `Pre-deploy checklist: all required items checked (${sectionsFound.join(", ")}).`
+    : [
+        "Pre-deploy checklist: required items unchecked.",
+        "",
+        ...missing.map((m) => `- **${m.section}**: ${m.item}`),
+        "",
+        "Edit the PR body and check the items, or add the `guardian:approved` label to waive.",
+      ].join("\n");
+
+  return { ok, missing, summary };
+}
+
+// CLI entry: read PR body from stdin, exit 0/1 with summary on stdout.
+// Used only for local debugging; CI calls evaluate() via github-script.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  let body = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => {
+    body += chunk;
+  });
+  process.stdin.on("end", () => {
+    const result = evaluate(body);
+    process.stdout.write(`${result.summary}\n`);
+    process.exit(result.ok ? 0 : 1);
+  });
+}


### PR DESCRIPTION
## Surfacing unmerged Copilot work

This PR surfaces `copilot/phase-2-implementation` (HEAD `f5f5362`, 4 days old, no prior PR) so it enters review instead of sitting orphaned on the branch list.

## What's in this branch (849 lines, all net-new vs `main`)

| File | Lines | What |
|---|---|---|
| `.github/workflows/pre-deploy-checklist.yml` | +65 | New CI workflow that runs the checklist gate on PRs targeting `main` |
| `scripts/check-pr-checklist.mjs` | +134 | Node script that scans the PR body for required checkboxes |
| `scripts/__tests__/check-pr-checklist.test.mjs` | +100 | Tests for the gate |
| `docs/playbooks/phase2-deploy-hardening-series.md` | +445 | Multi-PR handoff doc describing the phase-2 series (a/b/c/d/e) |
| `docs/deployment.md` | +23 | Section pointing at the gate |
| `WORKLOG.md` | +82 | Session log entry |

## Why it's worth reviewing

- **It's the "e" of a planned a/b/c/d/e CI hardening series.** Phase 1 already shipped via #184 (auto-rollback, release tags, Discord, SLO) and CI work landed via #185 (turbo + caches). This is the next planned step.
- **It's tested.** 100 lines of unit tests for the checklist parser, not just a workflow snippet.
- **Self-contained.** Touches only CI workflows + scripts + docs. Zero `apps/web` or `apps/analysis` runtime code.
- **The playbook (`docs/playbooks/phase2-deploy-hardening-series.md`) is 445 lines.** It encodes design intent and rollout sequencing that's worth preserving even if you decide not to merge the gate itself.

## Review focus

- Does the checklist gate's required-item list match the actual `.github/PULL_REQUEST_TEMPLATE.md` checkbox set today?
- Is the gate strictly informational (warn-only) or does it block merge? Operator preference.
- Any overlap with auto-rollback / release-tag workflows from #184?
- Should the playbook live under `docs/playbooks/` or `docs/runbooks/` per the existing convention?

## If you decide not to merge

Close this PR + delete the branch via the GitHub UI — the playbook content can be split into a docs-only follow-up if you want to keep the design rationale.

Opened as **draft**. CI will run on the head commit (`f5f5362`) against current `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ukSvTvedX14kPuezqXRCD)_