### PR TITLE
fix(web): drop unreachable auth.users lookup in onboarding seed

### DIFF
--- a/apps/web/src/app/api/internal/webhooks/auth/user-created/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/webhooks/auth/user-created/__tests__/route.test.ts
@@ -127,14 +127,6 @@ describe("POST /api/internal/webhooks/auth/user-created", () => {
     expect(body.data.reason).toBe("already_onboarded");
   });
 
-  it("returns 200 with seeded=false when the user no longer exists (stale event)", async () => {
-    seedDefaultGrowForUser.mockResolvedValue({ kind: "user_not_found" });
-    const res = await POST(buildRequest(envelope()));
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.data.reason).toBe("user_not_found");
-  });
-
   it("returns 500 when onboarding throws", async () => {
     seedDefaultGrowForUser.mockRejectedValue(new Error("db unavailable"));
     const res = await POST(buildRequest(envelope()));

--- a/apps/web/src/app/api/internal/webhooks/auth/user-created/route.ts
+++ b/apps/web/src/app/api/internal/webhooks/auth/user-created/route.ts
@@ -91,19 +91,6 @@ export async function POST(request: NextRequest) {
 
   try {
     const outcome = await seedDefaultGrowForUser({ userId });
-    if (outcome.kind === "user_not_found") {
-      // Treat as success — a delete-then-replay race or a stale event
-      // shouldn't trigger the sender's retry loop. Just log and ack.
-      logServerEvent("info", "auth webhook: user not found, skipping", {
-        requestId,
-        userId,
-      });
-      return apiSuccess(
-        200,
-        { user_id: userId, seeded: false, reason: "user_not_found" },
-        requestId,
-      );
-    }
     if (outcome.kind === "already_has_grow") {
       logServerEvent("info", "auth webhook: user already onboarded", {
         requestId,

--- a/apps/web/src/lib/server/__tests__/onboarding.test.ts
+++ b/apps/web/src/lib/server/__tests__/onboarding.test.ts
@@ -11,10 +11,6 @@ import { seedDefaultGrowForUser } from "../onboarding";
 const USER_ID = "11111111-1111-4111-8111-111111111111";
 
 interface MakeClientOpts {
-  userLookup: {
-    data: { id: string } | null;
-    error: { message: string } | null;
-  };
   growCount?: {
     count: number | null;
     error: { message: string } | null;
@@ -25,15 +21,8 @@ interface MakeClientOpts {
   };
 }
 
-function makeClient(opts: MakeClientOpts) {
-  // auth.users lookup: db.schema("auth").from("users").select("id").eq("id", ...).maybeSingle()
-  const userMaybeSingle = vi.fn().mockResolvedValue(opts.userLookup);
-  const userEq = vi.fn(() => ({ maybeSingle: userMaybeSingle }));
-  const userSelect = vi.fn(() => ({ eq: userEq }));
-  const authFrom = vi.fn(() => ({ select: userSelect }));
-  const schema = vi.fn(() => ({ from: authFrom }));
-
-  // grows count: db.from("grows").select(..., { count, head }).eq(...)
+function makeClient(opts: MakeClientOpts = {}) {
+  // grows count: db.from("grows").select("id", { count, head }).eq(...)
   const countResult = opts.growCount ?? { count: 0, error: null };
   const growsCountEq = vi.fn().mockResolvedValue(countResult);
 
@@ -46,24 +35,10 @@ function makeClient(opts: MakeClientOpts) {
   const insertSelect = vi.fn(() => ({ single: insertSingle }));
   const insert = vi.fn(() => ({ select: insertSelect }));
 
-  // Branch on whether the call is a count select or an insert
   const growsSelect = vi.fn(() => ({ eq: growsCountEq }));
-  const publicFrom = vi.fn(() => ({ select: growsSelect, insert }));
+  const from = vi.fn(() => ({ select: growsSelect, insert }));
 
-  const from = vi.fn((table: string) => {
-    if (table === "grows") return publicFrom();
-    return { select: vi.fn() };
-  });
-
-  return {
-    schema,
-    from,
-    publicFrom,
-    growsCountEq,
-    insert,
-    insertSingle,
-    userMaybeSingle,
-  };
+  return { from, growsCountEq, insert, insertSingle };
 }
 
 beforeEach(() => {
@@ -71,29 +46,8 @@ beforeEach(() => {
 });
 
 describe("seedDefaultGrowForUser", () => {
-  it("returns user_not_found when the auth.users row is missing", async () => {
-    const db = makeClient({ userLookup: { data: null, error: null } });
-    getDbClient.mockReturnValue(db);
-    const result = await seedDefaultGrowForUser({ userId: USER_ID });
-    expect(result).toEqual({ kind: "user_not_found" });
-    expect(db.insert).not.toHaveBeenCalled();
-  });
-
-  it("throws when the auth lookup errors", async () => {
-    const db = makeClient({
-      userLookup: { data: null, error: { message: "auth boom" } },
-    });
-    getDbClient.mockReturnValue(db);
-    await expect(seedDefaultGrowForUser({ userId: USER_ID })).rejects.toThrow(
-      /Failed to look up auth user: auth boom/,
-    );
-  });
-
   it("skips insert when the user already owns at least one grow", async () => {
-    const db = makeClient({
-      userLookup: { data: { id: USER_ID }, error: null },
-      growCount: { count: 2, error: null },
-    });
+    const db = makeClient({ growCount: { count: 2, error: null } });
     getDbClient.mockReturnValue(db);
     const result = await seedDefaultGrowForUser({ userId: USER_ID });
     expect(result).toEqual({ kind: "already_has_grow", growCount: 2 });
@@ -102,7 +56,6 @@ describe("seedDefaultGrowForUser", () => {
 
   it("throws when the grow count errors", async () => {
     const db = makeClient({
-      userLookup: { data: { id: USER_ID }, error: null },
       growCount: { count: null, error: { message: "count boom" } },
     });
     getDbClient.mockReturnValue(db);
@@ -113,7 +66,6 @@ describe("seedDefaultGrowForUser", () => {
 
   it("inserts a default grow when the user has none", async () => {
     const db = makeClient({
-      userLookup: { data: { id: USER_ID }, error: null },
       growCount: { count: 0, error: null },
       insertResult: { data: { id: "grow-new" }, error: null },
     });
@@ -128,7 +80,6 @@ describe("seedDefaultGrowForUser", () => {
 
   it("throws when the insert errors", async () => {
     const db = makeClient({
-      userLookup: { data: { id: USER_ID }, error: null },
       growCount: { count: 0, error: null },
       insertResult: { data: null, error: { message: "insert boom" } },
     });

--- a/apps/web/src/lib/server/onboarding.ts
+++ b/apps/web/src/lib/server/onboarding.ts
@@ -3,8 +3,7 @@ import { getDbClient } from "./db";
 
 export type SeedDefaultGrowOutcome =
   | { kind: "already_has_grow"; growCount: number }
-  | { kind: "seeded"; growId: string }
-  | { kind: "user_not_found" };
+  | { kind: "seeded"; growId: string };
 
 interface SeedDefaultGrowInput {
   userId: string;
@@ -15,25 +14,20 @@ const DEFAULT_GROW_NAME = "My First Grow";
 /**
  * Create a starter `grows` row for a freshly signed-up user so the dashboard
  * doesn't land them in an empty state. Idempotent: skipped if the user
- * already owns any grow row. Uses the service-role client to bypass RLS
- * — this runs from a server-only webhook handler with no authenticated
- * session to map auth.uid() to.
+ * already owns any grow row.
+ *
+ * Uses the service-role client to bypass RLS. We deliberately do NOT verify
+ * the user exists in `auth.users` first — Supabase's `auth` schema isn't
+ * exposed through PostgREST by default, and the trigger that calls us
+ * already fired AFTER an INSERT into `auth.users`, so the row provably
+ * existed at trigger time. If the user was deleted between insert and
+ * processing (a vanishingly rare race), the `grows.owner_id` FK to
+ * `auth.users(id)` will reject the insert and the caller surfaces a 500.
  */
 export async function seedDefaultGrowForUser(
   input: SeedDefaultGrowInput,
 ): Promise<SeedDefaultGrowOutcome> {
   const db = getDbClient();
-
-  const { data: userRow, error: userErr } = await db
-    .schema("auth")
-    .from("users")
-    .select("id")
-    .eq("id", input.userId)
-    .maybeSingle();
-  if (userErr) {
-    throw new Error(`Failed to look up auth user: ${userErr.message}`);
-  }
-  if (!userRow) return { kind: "user_not_found" };
 
   const { count: existing, error: countErr } = await db
     .from("grows")


### PR DESCRIPTION
## Outcome

Auth webhook receiver stops 500'ing on every Supabase Database Webhook delivery; new signups now actually get their default `grows` row seeded.

## Scope

- [x] Single concern; no drive-by refactors
- [x] Affected paths listed below

Affected paths:

```
apps/web/src/lib/server/onboarding.ts
apps/web/src/app/api/internal/webhooks/auth/user-created/route.ts
apps/web/src/lib/server/__tests__/onboarding.test.ts
apps/web/src/app/api/internal/webhooks/auth/user-created/__tests__/route.test.ts
```

## Validation

- [x] `pnpm run validate`
- [x] `pnpm turbo run type-check lint test` (3/3 tasks green; 13 targeted tests pass)
- [x] `pnpm turbo run build`
- [x] `pnpm run security:routes`
- [x] (If `apps/analysis` changed) `ruff check . && mypy app/ && pytest --cov=app` — N/A, analysis service untouched

## Test evidence

```
Test Files  2 passed (2)
     Tests  13 passed (13)
```

Production smoke before fix:
```
POST /api/internal/webhooks/auth/user-created
  → HTTP 500 {"code":"INTERNAL_ERROR"}
```

Root cause confirmed by reading `seedDefaultGrowForUser` — the `db.schema("auth").from("users")` call hits PostgREST's schema allowlist, which by default only exposes `public`, `storage`, `graphql_public`. The service-role key doesn't override the allowlist.

## Observability impact

Removes the `auth webhook: user not found, skipping` log line (the branch is unreachable). All other log lines unchanged. No SLI changes; no new Sentry categories.

## Architecture & Forbidden Changes

- [x] No browser code calls the analysis service or Supabase service-role APIs directly
- [x] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
- [x] No client component imports from `apps/web/src/lib/server/**`
- [x] No `middleware.ts` added to act as a backend proxy
- [x] No public Supabase Storage bucket for user content
- [x] No edits to previously-committed `supabase/migrations/**` files
- [x] No SQLite, second database, or new microservice introduced

## Affected Boundaries

- [ ] Shared types (`packages/shared`)
- [ ] Supabase migration (`supabase/migrations/**`)
- [x] Web Route Handler (`apps/web/src/app/api/**`)
- [x] Server-only module (`apps/web/src/lib/server/**`)
- [ ] Analysis service contract (`apps/analysis/app/models/**`)
- [ ] Env vars / `.env.example`

No contract symmetry concerns — purely a server-internal change. The Supabase Database Webhook payload shape it accepts is unchanged.

## Rollback

How do we revert this safely?

- [x] Pure `git revert` is sufficient
- [ ] Requires migration rollback (describe below)
- [ ] Requires env var rollback (describe below)

```
git revert <merge-sha>
```

Reverting restores the broken pre-fix behavior — auth webhook returns 500 again — so revert only if a worse regression is discovered.

## Follow-ups

- Confirm `grows.owner_id` FK to `auth.users(id)` is present and `ON DELETE CASCADE` in the production schema (it is in 001 but verifying after this lands closes the loop on the "what if user gets deleted mid-process" race story).
