### PR TITLE
chore(deploy): Next 16 proxy.ts ban + Railway graceful shutdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,7 +42,7 @@ Confirm none of the following were introduced (see `.github/copilot-instructions
 - [ ] No browser code calls the analysis service or Supabase service-role APIs directly
 - [ ] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
 - [ ] No client component imports from `apps/web/src/lib/server/**`
-- [ ] No `middleware.ts` added to act as a backend proxy
+- [ ] No `middleware.ts` or `proxy.ts` added to act as a backend proxy
 - [ ] No public Supabase Storage bucket for user content
 - [ ] No edits to previously-committed `supabase/migrations/**` files
 - [ ] No SQLite, second database, or new microservice introduced

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ Browser ── HTTPS ──► Vercel (apps/web)  ──► Supabase  (auth/db/p
 - **The browser MUST NEVER call the analysis service or Supabase service-role APIs directly.**
 - All browser-to-backend traffic flows through **same-origin Next.js Route Handlers** under `apps/web/src/app/api/**`.
 - Server-only modules live in `apps/web/src/lib/server/**` and **must** import `"server-only"` at the top.
-- Do **not** introduce a `middleware.ts` to act as a backend proxy. Same-origin Route Handlers are the boundary.
+- Do **not** introduce a `middleware.ts` or `proxy.ts` to act as a backend proxy. Same-origin Route Handlers are the boundary. (Next 16 renamed `middleware` → `proxy`; both are blocked.)
 
 ## 2. Secrets & Environment
 
@@ -54,7 +54,7 @@ The following are **rejected** in PR review and most are blocked by `scripts/che
 - Calling `process.env.ANALYSIS_SERVICE_URL` or `fetch("https://*.railway.app/...")` from any client-side code.
 - Adding a public Supabase Storage bucket for user content.
 - Adding SQLite, a second database, or an unrelated microservice.
-- Creating a `middleware.ts` to proxy to backend services.
+- Creating a `middleware.ts` or `proxy.ts` to proxy to backend services.
 - Adding broad social/community/ecommerce features (out of scope).
 - Adding native mobile code (out of scope; the web app is mobile-compatible).
 - Editing a previously-committed migration in `supabase/migrations/**`.

--- a/.github/instructions/apps-web.instructions.md
+++ b/.github/instructions/apps-web.instructions.md
@@ -41,4 +41,4 @@ applyTo: "apps/web/**"
 - Importing `src/lib/server/**` from a client component.
 - Calling `https://*.railway.app/...` or `https://*.supabase.co/storage/...`
   from a client component.
-- Adding a `middleware.ts` that proxies to backend services.
+- Adding a `middleware.ts` or `proxy.ts` that proxies to backend services. (Next 16 renamed `middleware` → `proxy`; both are blocked.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Any edit here requires `pnpm run validate && pnpm turbo run test`:
 
 See `.github/copilot-instructions.md` for the full list; the load-bearing ones:
 
-1. Don't add a `middleware.ts` to `apps/web`. The boundary lives in Route Handlers.
+1. Don't add a `middleware.ts` or `proxy.ts` to `apps/web`. The boundary lives in Route Handlers. (Next 16 renamed `middleware` → `proxy`; both names are blocked by `scripts/check-route-boundaries.mjs`.)
 2. Don't call the analysis service from a client component. Always go through `apps/web/src/lib/server/analysis-proxy.ts`.
 3. Don't put a secret in a `NEXT_PUBLIC_*` var.
 4. Don't edit existing migrations. Add new ones.

--- a/apps/analysis/railway.toml
+++ b/apps/analysis/railway.toml
@@ -9,3 +9,11 @@ healthcheckPath = "/health"
 healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 3
+# Graceful shutdown window: the new replica starts and serves traffic for
+# `overlapSeconds` BEFORE the old replica gets SIGTERM, and the old replica
+# then has `drainingSeconds` to finish in-flight /analyze (which can take
+# ~20s for a vision call) before SIGKILL. Without these, Railway's default
+# is 0/0 — uvicorn drops in-flight requests on every deploy. Uvicorn
+# handles SIGTERM gracefully since 0.30.x, so no app-side changes needed.
+overlapSeconds = 10
+drainingSeconds = 30

--- a/scripts/check-route-boundaries.mjs
+++ b/scripts/check-route-boundaries.mjs
@@ -6,7 +6,8 @@
 //   2. Client components ("use client") must NOT import from @/lib/server/**.
 //   3. Route Handlers (apps/web/src/app/api/**/route.ts) must NOT have "use client".
 //   4. No fetch() to *.railway.app from any client-component file.
-//   5. No middleware.ts file (boundary is owned by Route Handlers).
+//   5. No middleware.ts or proxy.ts file (boundary is owned by Route Handlers).
+//      Next 16 renamed `middleware` to `proxy`; both are blocked.
 //
 // Run via `pnpm run check:routes`.
 
@@ -62,16 +63,24 @@ for (const file of walk(WEB_SRC)) {
   }
 }
 
-// 5. No middleware.ts in apps/web
-const middlewarePaths = [
+// 5. No middleware.ts OR proxy.ts in apps/web
+//
+// Next 16 renamed the `middleware` filename to `proxy` (Node-runtime only).
+// Both are equivalent backend-proxy escape hatches that violate the
+// "boundary lives in Route Handlers" rule — block both names so the
+// guardrail keeps working on Next 16+.
+const forbiddenBoundaryFiles = [
   join(WEB_SRC, "middleware.ts"),
   join(WEB_SRC, "middleware.tsx"),
   join(ROOT, "apps", "web", "middleware.ts"),
+  join(WEB_SRC, "proxy.ts"),
+  join(WEB_SRC, "proxy.tsx"),
+  join(ROOT, "apps", "web", "proxy.ts"),
 ];
-for (const mp of middlewarePaths) {
+for (const mp of forbiddenBoundaryFiles) {
   if (existsSync(mp)) {
     errors.push(
-      `Forbidden file: ${relative(ROOT, mp).split(sep).join("/")} — backend boundary lives in Route Handlers, not middleware.`,
+      `Forbidden file: ${relative(ROOT, mp).split(sep).join("/")} — backend boundary lives in Route Handlers, not middleware/proxy.`,
     );
   }
 }

--- a/scripts/check-route-boundaries.mjs
+++ b/scripts/check-route-boundaries.mjs
@@ -63,20 +63,23 @@ for (const file of walk(WEB_SRC)) {
   }
 }
 
-// 5. No middleware.ts OR proxy.ts in apps/web
+// 5. No middleware.* OR proxy.* in apps/web
 //
 // Next 16 renamed the `middleware` filename to `proxy` (Node-runtime only).
 // Both are equivalent backend-proxy escape hatches that violate the
-// "boundary lives in Route Handlers" rule — block both names so the
-// guardrail keeps working on Next 16+.
-const forbiddenBoundaryFiles = [
-  join(WEB_SRC, "middleware.ts"),
-  join(WEB_SRC, "middleware.tsx"),
-  join(ROOT, "apps", "web", "middleware.ts"),
-  join(WEB_SRC, "proxy.ts"),
-  join(WEB_SRC, "proxy.tsx"),
-  join(ROOT, "apps", "web", "proxy.ts"),
-];
+// "boundary lives in Route Handlers" rule. Next resolves these filenames
+// against several extensions (.ts, .tsx, .js, .jsx, .mjs) and looks in
+// either `src/` or the project root — block every combination so the
+// guardrail keeps working on Next 16+ and can't be bypassed by renaming
+// the extension.
+const FORBIDDEN_BOUNDARY_NAMES = ["middleware", "proxy"];
+const FORBIDDEN_BOUNDARY_EXTS = ["ts", "tsx", "js", "jsx", "mjs"];
+const forbiddenBoundaryFiles = FORBIDDEN_BOUNDARY_NAMES.flatMap((name) =>
+  FORBIDDEN_BOUNDARY_EXTS.flatMap((ext) => [
+    join(WEB_SRC, `${name}.${ext}`),
+    join(ROOT, "apps", "web", `${name}.${ext}`),
+  ]),
+);
 for (const mp of forbiddenBoundaryFiles) {
   if (existsSync(mp)) {
     errors.push(


### PR DESCRIPTION
## Outcome

Two small wins from the 2026-05-21 deployment best-practices review: the `middleware.ts` guardrail now also catches Next.js 16's `proxy.ts`, and the analysis service no longer drops in-flight `/analyze` calls on deploy.

## Scope

- [x] Single concern; no drive-by refactors
- [x] Affected paths listed below

Affected paths:

```
CLAUDE.md
.github/copilot-instructions.md
.github/instructions/apps-web.instructions.md
.github/PULL_REQUEST_TEMPLATE.md
scripts/check-route-boundaries.mjs
apps/analysis/railway.toml
```

## Validation

- [x] `pnpm run validate`
- [x] `pnpm turbo run type-check lint test` (no app code touched; gates only)
- [x] `pnpm turbo run build` (no app code touched; gates only)
- [x] `pnpm run security:routes`
- [x] (If `apps/analysis` changed) `ruff check . && mypy app/ && pytest --cov=app` — N/A, only `railway.toml` touched in apps/analysis

Specifically verified:
- `node scripts/check-route-boundaries.mjs` — clean (267 files)
- `node scripts/check-env-contract.mjs` — clean
- `node scripts/check-route-security.mjs` — clean
- `node --test scripts/__tests__/check-pr-checklist.test.mjs` — 7/7 (template still parses after the wording tweak)

## Test evidence

No new tests. The route-boundaries change is a 3-line addition to an `existsSync` allowlist; no behavior to mock. The template wording change is covered by the existing parser test that generic-matches checkbox shape, not specific text.

## Observability impact

No SLI changes. The Railway shutdown window means `/analyze` calls that land seconds before a deploy now complete instead of erroring — should reduce 5xx slightly on deploy windows. No new log lines.

## Architecture & Forbidden Changes

- [x] No browser code calls the analysis service or Supabase service-role APIs directly
- [x] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
- [x] No client component imports from `apps/web/src/lib/server/**`
- [x] No `middleware.ts` or `proxy.ts` added to act as a backend proxy
- [x] No public Supabase Storage bucket for user content
- [x] No edits to previously-committed `supabase/migrations/**` files
- [x] No SQLite, second database, or new microservice introduced

## Affected Boundaries

- [ ] Shared types (`packages/shared`)
- [ ] Supabase migration (`supabase/migrations/**`)
- [ ] Web Route Handler (`apps/web/src/app/api/**`)
- [ ] Server-only module (`apps/web/src/lib/server/**`)
- [ ] Analysis service contract (`apps/analysis/app/models/**`)
- [ ] Env vars / `.env.example`

No contract symmetry concerns — guardrail strings + Railway deploy config only.

## Rollback

- [x] Pure `git revert` is sufficient
- [ ] Requires migration rollback (describe below)
- [ ] Requires env var rollback (describe below)

```
git revert <merge-sha>
```

Reverting restores the pre-Next-16 guardrail (still works on Next 15.x) and Railway's default 0s shutdown window. Both regressions are silent and only matter on the next deploy + on any contributor who tries to add `proxy.ts`.

## Follow-ups

- Operator action (separate from this PR): enable Vercel Rolling Releases + Skew Protection in Project Settings → Advanced (already documented in `docs/deployment.md`, just hasn't been flipped).
- Operator action: convert the seven server-only secrets + four webhook secrets to Vercel **Sensitive** env vars.
- P1-5 follow-up PR: orphan-signup reconciliation cron to close the `pg_net` silent-drop gap.
- P2-7 follow-up PR: `apps/web/instrumentation.ts` for Vercel ↔ Railway OTel trace propagation.

---
_Generated by [Claude Code](https://claude.ai/code/session_018ukSvTvedX14kPuezqXRCD)_