### PR TITLE
feat(web): orphan-signup reconciliation cron

### DIFF
--- a/apps/web/src/app/api/internal/cron/reconcile-onboarding/__tests__/route.test.ts
+++ b/apps/web/src/app/api/internal/cron/reconcile-onboarding/__tests__/route.test.ts
@@ -1,0 +1,88 @@
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { NextRequest } from "next/server";
+
+const reconcileOnboarding = vi.fn();
+
+vi.mock("@/lib/server/onboarding", () => ({
+  reconcileOnboarding: (...args: unknown[]) => reconcileOnboarding(...args),
+}));
+
+import { GET } from "../route";
+
+const SECRET = "test-cron-secret";
+
+function buildRequest(opts: { bearer?: string | null } = {}) {
+  const bearer = opts.bearer === undefined ? SECRET : opts.bearer;
+  const headers: Record<string, string> = {};
+  if (bearer) headers["authorization"] = `Bearer ${bearer}`;
+  return new NextRequest(
+    "http://localhost/api/internal/cron/reconcile-onboarding",
+    { method: "GET", headers },
+  );
+}
+
+describe("GET /api/internal/cron/reconcile-onboarding", () => {
+  const originalSecret = process.env["CRON_SECRET"];
+
+  beforeEach(() => {
+    (reconcileOnboarding as Mock).mockReset();
+    process.env["CRON_SECRET"] = SECRET;
+  });
+
+  afterAll(() => {
+    if (originalSecret === undefined) {
+      delete process.env["CRON_SECRET"];
+    } else {
+      process.env["CRON_SECRET"] = originalSecret;
+    }
+  });
+
+  it("returns 503 when CRON_SECRET is not configured", async () => {
+    delete process.env["CRON_SECRET"];
+    const res = await GET(buildRequest({ bearer: null }));
+    expect(res.status).toBe(503);
+    expect(reconcileOnboarding).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when the bearer header is missing", async () => {
+    const res = await GET(buildRequest({ bearer: null }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when the bearer is wrong", async () => {
+    const res = await GET(buildRequest({ bearer: "nope" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with the reconcile report on success", async () => {
+    reconcileOnboarding.mockResolvedValue({
+      scanned: 3,
+      seeded: 2,
+      errored: 1,
+    });
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      status: "ok",
+      scanned: 3,
+      seeded: 2,
+      errored: 1,
+    });
+    expect(typeof body.durationMs).toBe("number");
+  });
+
+  it("returns 500 when reconciliation throws", async () => {
+    reconcileOnboarding.mockRejectedValue(new Error("db unavailable"));
+    const res = await GET(buildRequest());
+    expect(res.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/internal/cron/reconcile-onboarding/route.ts
+++ b/apps/web/src/app/api/internal/cron/reconcile-onboarding/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { reconcileOnboarding } from "@/lib/server/onboarding";
+import { getOrCreateRequestId, logServerEvent } from "@/lib/server/request-id";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+// 60s is the same budget the daily-summary cron uses. The migration's
+// bounded `p_limit` keeps a worst-case sweep well under that.
+export const maxDuration = 60;
+
+// GET /api/internal/cron/reconcile-onboarding
+//
+// Vercel Cron daily job. Defends against the `pg_net`-backed
+// /api/internal/webhooks/auth/user-created Database Webhook silently
+// dropping an `auth.users` INSERT — finds users with zero `grows` rows
+// and seeds a default grow for each via the existing onboarding helper.
+//
+// Auth: `Authorization: Bearer ${CRON_SECRET}`, matching the
+// daily-summary cron pattern. Vercel Cron signs every invocation with
+// this header; manual `curl` against prod requires the same.
+export async function GET(request: NextRequest) {
+  const requestId = getOrCreateRequestId(request);
+
+  const cronSecret = process.env["CRON_SECRET"];
+  if (!cronSecret) {
+    logServerEvent("error", "reconcile-onboarding: CRON_SECRET not set", {
+      requestId,
+    });
+    return NextResponse.json(
+      { error: "Cron secret not configured", requestId },
+      { status: 503 },
+    );
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { error: "Unauthorized", requestId },
+      { status: 401 },
+    );
+  }
+
+  const startedAt = new Date();
+  try {
+    const report = await reconcileOnboarding();
+    const durationMs = Date.now() - startedAt.getTime();
+    logServerEvent("info", "reconcile-onboarding: complete", {
+      requestId,
+      ...report,
+      durationMs,
+    });
+    return NextResponse.json({
+      status: "ok",
+      ran: startedAt.toISOString(),
+      ...report,
+      durationMs,
+    });
+  } catch (err) {
+    logServerEvent("error", "reconcile-onboarding: failed", {
+      requestId,
+      error: err instanceof Error ? err.message : "unknown_error",
+    });
+    return NextResponse.json(
+      {
+        error: "Reconciliation failed",
+        requestId,
+        message: err instanceof Error ? err.message : "unknown_error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/lib/server/__tests__/onboarding.test.ts
+++ b/apps/web/src/lib/server/__tests__/onboarding.test.ts
@@ -138,7 +138,7 @@ describe("reconcileOnboarding", () => {
     const report = await reconcileOnboarding();
     expect(report).toEqual({ scanned: 0, seeded: 0, errored: 0 });
     expect(db.rpc).toHaveBeenCalledWith("find_users_without_default_grow", {
-      p_limit: 1000,
+      p_limit: 200,
     });
   });
 

--- a/apps/web/src/lib/server/__tests__/onboarding.test.ts
+++ b/apps/web/src/lib/server/__tests__/onboarding.test.ts
@@ -6,7 +6,7 @@ vi.mock("../db", () => ({
   getDbClient: (...args: unknown[]) => getDbClient(...args),
 }));
 
-import { seedDefaultGrowForUser } from "../onboarding";
+import { reconcileOnboarding, seedDefaultGrowForUser } from "../onboarding";
 
 const USER_ID = "11111111-1111-4111-8111-111111111111";
 
@@ -87,5 +87,116 @@ describe("seedDefaultGrowForUser", () => {
     await expect(seedDefaultGrowForUser({ userId: USER_ID })).rejects.toThrow(
       /Failed to seed default grow: insert boom/,
     );
+  });
+});
+
+describe("reconcileOnboarding", () => {
+  function makeReconcileClient(opts: {
+    rpcResult: { data: unknown; error: { message: string } | null };
+    perUserCounts?: Array<{
+      count: number | null;
+      error: { message: string } | null;
+    }>;
+    perUserInserts?: Array<{
+      data: { id: string } | null;
+      error: { message: string } | null;
+    }>;
+  }) {
+    const rpc = vi.fn().mockResolvedValue(opts.rpcResult);
+
+    let countCall = 0;
+    let insertCall = 0;
+
+    const growsCountEq = vi.fn().mockImplementation(() => {
+      const result = opts.perUserCounts?.[countCall] ?? {
+        count: 0,
+        error: null,
+      };
+      countCall++;
+      return Promise.resolve(result);
+    });
+    const growsSelect = vi.fn(() => ({ eq: growsCountEq }));
+
+    const insertSingle = vi.fn().mockImplementation(() => {
+      const result = opts.perUserInserts?.[insertCall] ?? {
+        data: { id: `grow-${insertCall}` },
+        error: null,
+      };
+      insertCall++;
+      return Promise.resolve(result);
+    });
+    const insertSelect = vi.fn(() => ({ single: insertSingle }));
+    const insert = vi.fn(() => ({ select: insertSelect }));
+
+    const from = vi.fn(() => ({ select: growsSelect, insert }));
+    return { from, rpc };
+  }
+
+  it("returns zeros when the RPC reports no orphans", async () => {
+    const db = makeReconcileClient({ rpcResult: { data: [], error: null } });
+    getDbClient.mockReturnValue(db);
+    const report = await reconcileOnboarding();
+    expect(report).toEqual({ scanned: 0, seeded: 0, errored: 0 });
+    expect(db.rpc).toHaveBeenCalledWith("find_users_without_default_grow", {
+      p_limit: 1000,
+    });
+  });
+
+  it("throws when the RPC returns an error", async () => {
+    const db = makeReconcileClient({
+      rpcResult: { data: null, error: { message: "rpc boom" } },
+    });
+    getDbClient.mockReturnValue(db);
+    await expect(reconcileOnboarding()).rejects.toThrow(
+      /Failed to enumerate orphan users: rpc boom/,
+    );
+  });
+
+  it("seeds each orphan and reports counts", async () => {
+    const orphans = ["u1", "u2", "u3"];
+    const db = makeReconcileClient({
+      rpcResult: { data: orphans, error: null },
+    });
+    getDbClient.mockReturnValue(db);
+    const report = await reconcileOnboarding();
+    expect(report).toEqual({ scanned: 3, seeded: 3, errored: 0 });
+  });
+
+  it("counts a per-user insert failure as errored, not abort", async () => {
+    const orphans = ["u1", "u2"];
+    const db = makeReconcileClient({
+      rpcResult: { data: orphans, error: null },
+      perUserCounts: [
+        { count: 0, error: null },
+        { count: 0, error: null },
+      ],
+      perUserInserts: [
+        { data: null, error: { message: "insert boom" } },
+        { data: { id: "g2" }, error: null },
+      ],
+    });
+    getDbClient.mockReturnValue(db);
+    const report = await reconcileOnboarding();
+    expect(report).toEqual({ scanned: 2, seeded: 1, errored: 1 });
+  });
+
+  it("treats a webhook race (user gained a grow between enumerate and seed) as no-op", async () => {
+    const orphans = ["u1"];
+    const db = makeReconcileClient({
+      rpcResult: { data: orphans, error: null },
+      perUserCounts: [{ count: 1, error: null }],
+    });
+    getDbClient.mockReturnValue(db);
+    const report = await reconcileOnboarding();
+    expect(report).toEqual({ scanned: 1, seeded: 0, errored: 0 });
+  });
+
+  it("accepts row-object shape from the RPC ({ id })", async () => {
+    const db = makeReconcileClient({
+      rpcResult: { data: [{ id: "u1" }, { id: "u2" }], error: null },
+    });
+    getDbClient.mockReturnValue(db);
+    const report = await reconcileOnboarding();
+    expect(report.scanned).toBe(2);
   });
 });

--- a/apps/web/src/lib/server/onboarding.ts
+++ b/apps/web/src/lib/server/onboarding.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { getDbClient } from "./db";
+import { logServerEvent } from "./request-id";
 
 export type SeedDefaultGrowOutcome =
   | { kind: "already_has_grow"; growCount: number }
@@ -10,6 +11,11 @@ interface SeedDefaultGrowInput {
 }
 
 const DEFAULT_GROW_NAME = "My First Grow";
+
+// Cap on how many orphan users a single reconciliation cron tick processes.
+// Sized so a worst-case full sweep still fits inside the 60s Vercel cron
+// function budget at ~1 insert per ms (Supabase is well under that).
+const RECONCILE_BATCH_LIMIT = 1000;
 
 /**
  * Create a starter `grows` row for a freshly signed-up user so the dashboard
@@ -53,4 +59,64 @@ export async function seedDefaultGrowForUser(
   }
 
   return { kind: "seeded", growId: inserted.id };
+}
+
+export interface ReconcileOnboardingReport {
+  scanned: number;
+  seeded: number;
+  errored: number;
+}
+
+/**
+ * Find all `auth.users` rows that have zero `grows` rows and seed a
+ * default grow for each. Defends against the `pg_net`-backed Database
+ * Webhook silently dropping an `auth.users` INSERT — see migration
+ * 20260521190000 for the SECURITY DEFINER function this calls.
+ *
+ * Bounded to `RECONCILE_BATCH_LIMIT` users per tick so a single cron
+ * run can't run past Vercel's function timeout. A persistent backlog
+ * will drain on subsequent daily ticks.
+ */
+export async function reconcileOnboarding(): Promise<ReconcileOnboardingReport> {
+  const db = getDbClient();
+  const { data: rows, error } = await db.rpc(
+    "find_users_without_default_grow",
+    {
+      p_limit: RECONCILE_BATCH_LIMIT,
+    },
+  );
+  if (error) {
+    throw new Error(`Failed to enumerate orphan users: ${error.message}`);
+  }
+
+  const userIds: string[] = Array.isArray(rows)
+    ? rows
+        .map((r) =>
+          typeof r === "string"
+            ? r
+            : r && typeof r === "object" && "id" in r
+              ? String((r as { id: unknown }).id)
+              : null,
+        )
+        .filter((v): v is string => v !== null)
+    : [];
+
+  let seeded = 0;
+  let errored = 0;
+  for (const userId of userIds) {
+    try {
+      const outcome = await seedDefaultGrowForUser({ userId });
+      if (outcome.kind === "seeded") seeded++;
+      // already_has_grow is possible if a webhook delivered between the
+      // enumerate and the seed — counted as a no-op, not an error.
+    } catch (err) {
+      errored++;
+      logServerEvent("error", "reconcile-onboarding: per-user seed failed", {
+        userId,
+        error: err instanceof Error ? err.message : "unknown_error",
+      });
+    }
+  }
+
+  return { scanned: userIds.length, seeded, errored };
 }

--- a/apps/web/src/lib/server/onboarding.ts
+++ b/apps/web/src/lib/server/onboarding.ts
@@ -2,20 +2,31 @@ import "server-only";
 import { getDbClient } from "./db";
 import { logServerEvent } from "./request-id";
 
+type SupabaseDbClient = ReturnType<typeof getDbClient>;
+
 export type SeedDefaultGrowOutcome =
   | { kind: "already_has_grow"; growCount: number }
   | { kind: "seeded"; growId: string };
 
 interface SeedDefaultGrowInput {
   userId: string;
+  /**
+   * Optional caller-supplied service-role client. Defaults to a fresh
+   * `getDbClient()` per call. Pass an explicit client when looping over
+   * many users (e.g. the reconcile cron) so we don't instantiate a new
+   * Supabase JS client per iteration.
+   */
+  db?: SupabaseDbClient;
 }
 
 const DEFAULT_GROW_NAME = "My First Grow";
 
 // Cap on how many orphan users a single reconciliation cron tick processes.
-// Sized so a worst-case full sweep still fits inside the 60s Vercel cron
-// function budget at ~1 insert per ms (Supabase is well under that).
-const RECONCILE_BATCH_LIMIT = 1000;
+// Each user costs a count + insert round-trip. At ~50ms per pair over the
+// public internet (Vercel → Supabase), 200 users ≈ 10s — comfortably under
+// the 60s Vercel cron budget with plenty of headroom for retries and
+// network jitter. A persistent backlog will drain on subsequent ticks.
+const RECONCILE_BATCH_LIMIT = 200;
 
 /**
  * Create a starter `grows` row for a freshly signed-up user so the dashboard
@@ -33,7 +44,7 @@ const RECONCILE_BATCH_LIMIT = 1000;
 export async function seedDefaultGrowForUser(
   input: SeedDefaultGrowInput,
 ): Promise<SeedDefaultGrowOutcome> {
-  const db = getDbClient();
+  const db = input.db ?? getDbClient();
 
   const { count: existing, error: countErr } = await db
     .from("grows")
@@ -105,7 +116,10 @@ export async function reconcileOnboarding(): Promise<ReconcileOnboardingReport> 
   let errored = 0;
   for (const userId of userIds) {
     try {
-      const outcome = await seedDefaultGrowForUser({ userId });
+      // Reuse the single service-role client across the loop instead of
+      // instantiating a fresh Supabase JS client per user — avoids the
+      // memory + socket overhead of N clients per cron tick.
+      const outcome = await seedDefaultGrowForUser({ userId, db });
       if (outcome.kind === "seeded") seeded++;
       // already_has_grow is possible if a webhook delivered between the
       // enumerate and the seed — counted as a no-op, not an error.

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -8,6 +8,10 @@
     {
       "path": "/api/internal/cron/daily-summary",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/internal/cron/reconcile-onboarding",
+      "schedule": "30 7 * * *"
     }
   ]
 }

--- a/supabase/migrations/20260521190000_find_users_without_default_grow.sql
+++ b/supabase/migrations/20260521190000_find_users_without_default_grow.sql
@@ -1,0 +1,46 @@
+-- Migration: find_users_without_default_grow
+--
+-- Adds a SECURITY DEFINER function that lets the application server
+-- (service_role) enumerate `auth.users` rows with zero `grows` rows.
+-- Used by the new `/api/internal/cron/reconcile-onboarding` daily cron
+-- to defend against the `pg_net`-backed Database Webhook silently
+-- dropping an `auth.users` INSERT event (pg_net is in beta, response
+-- retention is 6h, the unlogged queue table is not crash-safe).
+--
+-- Why a SECURITY DEFINER function instead of querying `auth.users`
+-- directly via PostgREST: Supabase's PostgREST default exposes only
+-- `public`, `storage`, and `graphql_public`. The `auth` schema is
+-- unreachable from the REST layer even with the service-role key.
+-- The hotfix in #240 removed an attempt to query `auth.users` from
+-- the auth webhook handler for the same reason; this function is the
+-- correct shape for that read pattern.
+--
+-- Access model:
+--   * `revoke execute ... from public/authenticated` — end users
+--     cannot call this RPC.
+--   * `grant execute ... to service_role` — the daily cron's
+--     route handler (using SUPABASE_SERVICE_ROLE_KEY) is the only
+--     caller.
+--
+-- Rollback: drop the function. No app code depends on it until the
+-- reconciliation cron PR lands.
+
+create or replace function find_users_without_default_grow(
+  p_limit integer default 1000
+)
+returns setof uuid
+language sql
+security definer
+set search_path = public
+as $$
+  select u.id
+  from auth.users u
+  left join grows g on g.owner_id = u.id
+  where g.id is null
+  order by u.created_at asc
+  limit greatest(coalesce(p_limit, 1000), 1);
+$$;
+
+revoke execute on function find_users_without_default_grow(integer) from public;
+revoke execute on function find_users_without_default_grow(integer) from authenticated;
+grant execute on function find_users_without_default_grow(integer) to service_role;


### PR DESCRIPTION
## Outcome

Daily cron now backfills the default `grows` row for any `auth.users` rows the Database Webhook missed. No user can sit in production with an empty dashboard because a `pg_net` delivery dropped — the worst case is now a 24h delay before reconciliation.

## Scope

- [x] Single concern; no drive-by refactors
- [x] Affected paths listed below

Affected paths:

```
supabase/migrations/20260521190000_find_users_without_default_grow.sql
apps/web/src/lib/server/onboarding.ts
apps/web/src/lib/server/__tests__/onboarding.test.ts
apps/web/src/app/api/internal/cron/reconcile-onboarding/route.ts
apps/web/src/app/api/internal/cron/reconcile-onboarding/__tests__/route.test.ts
apps/web/vercel.json
```

## Validation

- [x] `pnpm run validate`
- [x] `pnpm turbo run type-check lint test`
- [x] `pnpm turbo run build`
- [x] `pnpm run security:routes`
- [x] (If `apps/analysis` changed) `ruff check . && mypy app/ && pytest --cov=app` — N/A

Specifically verified:
- `tsc --noEmit` — clean
- New + updated tests: 15 pass (6 reconcile + existing 4 seed + 5 route)
- `pnpm turbo run test type-check lint --filter=web` — 3/3 tasks green
- Guardrails: env-contract, route-security, route-boundaries — all clean

## Test evidence

```
 Test Files  2 passed (2)
      Tests  15 passed (15)
```

Per-test coverage:
- RPC returns `[]` → `{scanned:0, seeded:0, errored:0}`
- RPC error → helper throws
- 3 orphans → all seeded
- Per-user insert failure → counted as errored, sweep continues
- Webhook race (user gained grow between enumerate + seed) → counted as no-op
- RPC returns row-object shape `{id}` (PostgREST quirk) → handled
- Route auth: missing CRON_SECRET → 503
- Route auth: missing/wrong bearer → 401
- Route happy path → 200 with `{scanned, seeded, errored, durationMs}`
- Route exception → 500

## Observability impact

New log lines (all JSON, same envelope as existing crons):

- `info — reconcile-onboarding: complete` with `{scanned, seeded, errored, durationMs}` on every successful run
- `error — reconcile-onboarding: per-user seed failed` per orphan that errors (does not abort sweep)
- `error — reconcile-onboarding: failed` if the RPC itself errors

No SLI changes. The cron runs at 07:30 UTC daily (30 min before daily-summary at 08:00 UTC) so any newly-seeded grow is included in its owner's first digest.

## Architecture & Forbidden Changes

- [x] No browser code calls the analysis service or Supabase service-role APIs directly
- [x] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
- [x] No client component imports from `apps/web/src/lib/server/**`
- [x] No `middleware.ts` or `proxy.ts` added to act as a backend proxy
- [x] No public Supabase Storage bucket for user content
- [x] No edits to previously-committed `supabase/migrations/**` files — adds a new append-only migration
- [x] No SQLite, second database, or new microservice introduced

## Affected Boundaries

- [ ] Shared types (`packages/shared`)
- [x] Supabase migration (`supabase/migrations/**`) — adds `20260521190000_find_users_without_default_grow.sql`
- [x] Web Route Handler (`apps/web/src/app/api/**`)
- [x] Server-only module (`apps/web/src/lib/server/**`)
- [ ] Analysis service contract (`apps/analysis/app/models/**`)
- [ ] Env vars / `.env.example`

No new env vars (re-uses `CRON_SECRET`). Migration is service-role-only via explicit `revoke ... from public/authenticated` + `grant ... to service_role`.

## Rollback

- [x] Pure `git revert` is sufficient
- [ ] Requires migration rollback (describe below)
- [ ] Requires env var rollback (describe below)

```
git revert <merge-sha>
# Optional cleanup (migration is otherwise harmless):
psql "$SUPABASE_DB_URL" -c "drop function if exists find_users_without_default_grow(integer);"
```

The migration is forward-compatible — dropping the function only matters if you want to forensically clean. The cron is gated by `CRON_SECRET` and will 401 if rolled back without the function present.

## Follow-ups

- Operator: confirm the new cron is registered in Vercel → `pheno-sage-web` → Settings → Cron Jobs after the next prod deploy.
- Operator: monitor `/api/internal/cron/reconcile-onboarding` first run logs for any per-user `errored` count > 0 — should be 0 in steady state.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ukSvTvedX14kPuezqXRCD)_