### PR TITLE
feat(web): @vercel/otel for Vercel ↔ Railway trace propagation

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -78,3 +78,12 @@ NEXT_PUBLIC_APP_ENV=development
 # Leave empty to disable error reporting and tracing.
 SENTRY_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.1
+
+# OpenTelemetry trace propagation (apps/web/instrumentation.ts).
+# When ANALYSIS_SERVICE_URL is set, @vercel/otel automatically registers
+# fetch instrumentation and adds the W3C `traceparent` header on outgoing
+# calls to that URL — letting traces span Vercel → Railway end-to-end.
+# Set OTEL_ENABLED=true to force-register OTel even without ANALYSIS_SERVICE_URL
+# (e.g. for local OTLP testing). OTEL_SERVICE_NAME defaults to "phenosage-web".
+OTEL_ENABLED=false
+OTEL_SERVICE_NAME=phenosage-web

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,4 +1,46 @@
+import { registerOTel } from "@vercel/otel";
+
 export async function register() {
+  // 1. OpenTelemetry trace propagation.
+  //
+  // Wires Next.js's underlying OTel runtime so outgoing `fetch()` calls to
+  // the analysis service carry a W3C `traceparent` header. The analysis
+  // service already reads `traceparent` (see apps/analysis/app/telemetry.py)
+  // so spans on both sides correlate end-to-end without anyone having to
+  // copy trace IDs by hand.
+  //
+  // Graceful skip when `ANALYSIS_SERVICE_URL` is unset — local dev runs
+  // without the analysis service and we shouldn't fail boot for that.
+  const analysisUrl = process.env["ANALYSIS_SERVICE_URL"]?.trim();
+  const otelEnabled =
+    (process.env["OTEL_ENABLED"] ?? "").toLowerCase() === "true";
+  if (analysisUrl || otelEnabled) {
+    try {
+      registerOTel({
+        serviceName: process.env["OTEL_SERVICE_NAME"] ?? "phenosage-web",
+        ...(analysisUrl
+          ? {
+              instrumentationConfig: {
+                fetch: { propagateContextUrls: [analysisUrl] },
+              },
+            }
+          : {}),
+      });
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          message: "web OTel register skipped",
+          service: "phenosage-web",
+          reason: error instanceof Error ? error.message : "unknown_error",
+        }),
+      );
+    }
+  }
+
+  // 2. Sentry. Optional — only initializes when SENTRY_DSN is set and the
+  // @sentry/nextjs package is installed. Dynamic import keeps this file
+  // friendly to deployments that haven't adopted Sentry yet.
   const dsn = process.env["SENTRY_DSN"]?.trim();
   if (!dsn) {
     return;

--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -1,4 +1,4 @@
-import { registerOTel } from "@vercel/otel";
+const SERVICE_NAME = process.env["OTEL_SERVICE_NAME"] ?? "phenosage-web";
 
 export async function register() {
   // 1. OpenTelemetry trace propagation.
@@ -9,15 +9,25 @@ export async function register() {
   // so spans on both sides correlate end-to-end without anyone having to
   // copy trace IDs by hand.
   //
-  // Graceful skip when `ANALYSIS_SERVICE_URL` is unset — local dev runs
-  // without the analysis service and we shouldn't fail boot for that.
+  // Dynamic import so the file boots even if `@vercel/otel` is absent
+  // (e.g. removed by a security audit) — matches the Sentry pattern
+  // below. Graceful skip when `ANALYSIS_SERVICE_URL` is unset AND
+  // `OTEL_ENABLED` is not "true" so local dev doesn't try to register a
+  // tracer it has no use for.
   const analysisUrl = process.env["ANALYSIS_SERVICE_URL"]?.trim();
   const otelEnabled =
     (process.env["OTEL_ENABLED"] ?? "").toLowerCase() === "true";
   if (analysisUrl || otelEnabled) {
     try {
-      registerOTel({
-        serviceName: process.env["OTEL_SERVICE_NAME"] ?? "phenosage-web",
+      const dynamicImport = new Function(
+        "specifier",
+        "return import(specifier)",
+      ) as (_specifier: string) => Promise<{
+        registerOTel?: (_options: Record<string, unknown>) => void;
+      }>;
+      const otel = await dynamicImport("@vercel/otel");
+      otel.registerOTel?.({
+        serviceName: SERVICE_NAME,
         ...(analysisUrl
           ? {
               instrumentationConfig: {
@@ -31,7 +41,7 @@ export async function register() {
         JSON.stringify({
           level: "warn",
           message: "web OTel register skipped",
-          service: "phenosage-web",
+          service: SERVICE_NAME,
           reason: error instanceof Error ? error.message : "unknown_error",
         }),
       );
@@ -68,7 +78,7 @@ export async function register() {
       JSON.stringify({
         level: "warn",
         message: "web instrumentation init skipped",
-        service: "phenosage-web",
+        service: SERVICE_NAME,
         reason: error instanceof Error ? error.message : "unknown_error",
       }),
     );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "^1.38.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/otel": "^2.1.2",
     "@vercel/speed-insights": "^2.0.0",
     "next": "16.2.6",
     "openai": "^6.38.0",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,6 +226,42 @@ handler in `apps/analysis/app/main.py`:
 
 ---
 
+## Observability — Distributed traces
+
+`apps/web/instrumentation.ts` registers `@vercel/otel` at boot. When
+`ANALYSIS_SERVICE_URL` is set, the registration wires Next.js's underlying
+OpenTelemetry runtime so any outgoing `fetch()` call to the analysis service
+carries a W3C `traceparent` header. The analysis service already reads
+`traceparent` (`apps/analysis/app/telemetry.py`) and continues the same trace,
+so a single user request shows as one trace tree across both platforms in any
+OTLP-compatible backend (Honeycomb, Tempo, Vercel's own runtime trace viewer,
+etc).
+
+Configuration:
+
+- **Production**: nothing to do — registration auto-fires because
+  `ANALYSIS_SERVICE_URL` is required. To export traces somewhere other than
+  Vercel's default sink, set `OTEL_EXPORTER_OTLP_ENDPOINT` on the project.
+- **Local dev**: `OTEL_ENABLED=true` force-registers OTel even without
+  `ANALYSIS_SERVICE_URL` so an operator can validate spans against a local
+  OTLP collector.
+- **Sentry coexistence**: the file initializes OTel first, then Sentry if
+  `SENTRY_DSN` is set. `@sentry/nextjs` v8+ composes with `@vercel/otel`
+  cleanly — Sentry attaches as a span processor instead of replacing the
+  TracerProvider.
+
+If `@vercel/otel` is absent (e.g. the package was removed by an audit), the
+instrumentation hook logs a `warn — web OTel register skipped` line and the
+app continues to boot. Traces just stop crossing the Vercel ↔ Railway
+boundary in that case.
+
+Docs (as of 2026-05-21):
+
+- [Vercel OTel instrumentation](https://vercel.com/docs/tracing/instrumentation)
+- [Next.js instrumentation hook](https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation)
+
+---
+
 ## Smoke Checks
 
 After every preview / production deploy, run:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,13 +55,16 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@vercel/otel':
+        specifier: ^2.1.2
+        version: 2.1.2(@opentelemetry/api-logs@0.218.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       openai:
         specifier: ^6.38.0
         version: 6.38.0(ws@8.20.0)(zod@3.25.76)
@@ -131,7 +134,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
 
   packages/shared:
     devDependencies:
@@ -143,7 +146,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.6
-        version: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
+        version: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
 
 packages:
 
@@ -806,6 +809,54 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@opentelemetry/api-logs@0.218.0':
+    resolution: {integrity: sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.7.1':
+    resolution: {integrity: sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.218.0':
+    resolution: {integrity: sha512-mIZil8Es+sYDK5m+DQiwAwF57F14TF2YlEqvIjZ/RQWcxDBwRGsKfdK2Tv65OU9meQKCMzSIFS9mxAcnAb6Bkg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.7.1':
+    resolution: {integrity: sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.218.0':
+    resolution: {integrity: sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.7.1':
+    resolution: {integrity: sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.7.1':
+    resolution: {integrity: sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1372,6 +1423,18 @@ packages:
       vue-router:
         optional: true
 
+  '@vercel/otel@2.1.2':
+    resolution: {integrity: sha512-PbGyq1lLwWbnftylNcQ6KFxc7DLc8LJdnaU3snM43bgXiWkWsHrgaU/LdUD8sHaSgG8UKuydX/aymNt3J+hzuA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <2.0.0'
+      '@opentelemetry/api-logs': '>=0.200.0 <0.300.0'
+      '@opentelemetry/instrumentation': '>=0.200.0 <0.300.0'
+      '@opentelemetry/resources': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-logs': '>=0.200.0 <0.300.0'
+      '@opentelemetry/sdk-metrics': '>=2.0.0 <3.0.0'
+      '@opentelemetry/sdk-trace-base': '>=2.0.0 <3.0.0'
+
   '@vercel/speed-insights@2.0.0':
     resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
     peerDependencies:
@@ -1441,6 +1504,11 @@ packages:
 
   '@vitest/utils@4.1.6':
     resolution: {integrity: sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1621,6 +1689,9 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -2198,6 +2269,10 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2578,6 +2653,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2803,6 +2881,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resend@6.12.3:
     resolution: {integrity: sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==}
@@ -3934,6 +4016,55 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@opentelemetry/api-logs@0.218.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.4':
@@ -4401,14 +4532,24 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
-  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/otel@2.1.2(@opentelemetry/api-logs@0.218.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/resources@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.218.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-metrics@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.218.0
+      '@opentelemetry/instrumentation': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.218.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.7.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
+
+  '@vercel/speed-insights@2.0.0(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
-      next: 16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))':
@@ -4435,7 +4576,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -4477,6 +4618,10 @@ snapshots:
       '@vitest/pretty-format': 4.1.6
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -4678,6 +4823,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  cjs-module-lexer@2.2.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -5402,6 +5549,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
@@ -5774,6 +5928,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  module-details-from-path@1.0.4: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
@@ -5782,7 +5938,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -5801,6 +5957,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.6
       '@next/swc-win32-arm64-msvc': 16.2.6
       '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.9.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -5999,6 +6156,13 @@ snapshots:
       set-function-name: 2.0.2
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resend@6.12.3:
     dependencies:
@@ -6480,7 +6644,7 @@ snapshots:
       lightningcss: 1.32.0
       yaml: 2.9.0
 
-  vitest@4.1.6(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0)):
+  vitest@4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-v8@4.1.6)(jsdom@26.1.0)(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.6
       '@vitest/mocker': 4.1.6(vite@6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0))
@@ -6503,6 +6667,7 @@ snapshots:
       vite: 6.4.2(@types/node@25.9.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.0
       '@vitest/coverage-v8': 4.1.6(vitest@4.1.6)
       jsdom: 26.1.0


### PR DESCRIPTION
## Outcome

Outgoing `fetch()` from `apps/web` to the analysis service now carries a W3C `traceparent` header, so a single user request shows as one trace tree across both platforms in any OTLP backend instead of two disconnected traces.

## Scope

- [x] Single concern; no drive-by refactors
- [x] Affected paths listed below

Affected paths:

```
apps/web/package.json
pnpm-lock.yaml
apps/web/instrumentation.ts
apps/web/.env.example
docs/deployment.md
```

## Validation

- [x] `pnpm run validate`
- [x] `pnpm turbo run type-check lint test`
- [x] `pnpm turbo run build` — clean Next 16 build with the new `@vercel/otel` registration
- [x] `pnpm run security:routes`
- [x] (If `apps/analysis` changed) `ruff check . && mypy app/ && pytest --cov=app` — N/A

Specifically verified:
- `pnpm add @vercel/otel` → resolved to 2.1.2
- `tsc --noEmit` — clean
- `eslint .` — clean
- Next 16 build — finished without warnings about the instrumentation hook
- `node scripts/check-env-contract.mjs` — clean

## Test evidence

No new tests. The instrumentation hook is hard to unit-test (boot-time side-effect, dynamic imports) and the existing Sentry-init branch has no test either. The functional check is the smoke after deploy: a real `traceparent` header should appear on outgoing analysis requests, viewable in Vercel runtime logs / OTLP backend.

## Observability impact

- Adds OTel spans to `apps/web` for the standard Next.js fetch / route-handler instrumentation. With `OTEL_EXPORTER_OTLP_ENDPOINT` unset, spans go to Vercel's default sink (visible in Vercel's runtime trace viewer for projects on Pro+).
- Adds `traceparent` to outgoing requests to `ANALYSIS_SERVICE_URL`. The analysis service was already reading this header (`apps/analysis/app/telemetry.py`).
- One new log line on boot if registration fails: `warn — web OTel register skipped` (degrades gracefully, app continues).

## Architecture & Forbidden Changes

- [x] No browser code calls the analysis service or Supabase service-role APIs directly
- [x] No server-only secrets (`SUPABASE_SERVICE_ROLE_KEY`, `OPENAI_API_KEY`, `ANALYSIS_SERVICE_*`) leaked to client modules or `NEXT_PUBLIC_*`
- [x] No client component imports from `apps/web/src/lib/server/**`
- [x] No `middleware.ts` or `proxy.ts` added to act as a backend proxy
- [x] No public Supabase Storage bucket for user content
- [x] No edits to previously-committed `supabase/migrations/**` files
- [x] No SQLite, second database, or new microservice introduced

## Affected Boundaries

- [ ] Shared types (`packages/shared`)
- [ ] Supabase migration (`supabase/migrations/**`)
- [ ] Web Route Handler (`apps/web/src/app/api/**`)
- [ ] Server-only module (`apps/web/src/lib/server/**`)
- [ ] Analysis service contract (`apps/analysis/app/models/**`)
- [x] Env vars / `.env.example` — adds `OTEL_ENABLED` + `OTEL_SERVICE_NAME` to `apps/web/.env.example` (already in root `.env.example` and in `apps/analysis/.env.example`)

No contract symmetry concerns — the analysis service was already consuming `traceparent`, this PR just guarantees the web side actually emits it.

## Rollback

- [x] Pure `git revert` is sufficient
- [ ] Requires migration rollback (describe below)
- [ ] Requires env var rollback (describe below)

```
git revert <merge-sha>
```

Reverting just removes the trace-propagation header from outgoing fetches; the analysis service still works fine, traces just stop crossing the boundary. No data loss. The `@vercel/otel` dep removal happens via the revert touching `pnpm-lock.yaml`.

## Follow-ups

- Operator: pick an OTLP backend and set `OTEL_EXPORTER_OTLP_ENDPOINT` if you want traces somewhere other than Vercel's default runtime trace viewer.
- Phase-2 slice (b): once Sentry is verified-wired, Sentry will compose with this OTel registration as a span processor — no code change required, just the operator wiring `SENTRY_DSN`.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ukSvTvedX14kPuezqXRCD)_